### PR TITLE
Get apikey fromaws

### DIFF
--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -14,6 +14,7 @@ AUTH0_DOMAIN: your_domain.auth0.com
 AUTH0_API_CLIENT: your-api-client-id
 AUTH0_API_SECRET: your-api-secret-id
 AWS_PROFILE: default
+AWS_API_GATEWAY_USAGE_PLAN_ID: usage-plan-id
 
 # To configure a remote MongoDB service (such as MongoDB Atlas), provide all
 # Mongo properties below. Otherwise, only a database name is needed (server

--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -14,7 +14,7 @@ AUTH0_DOMAIN: your_domain.auth0.com
 AUTH0_API_CLIENT: your-api-client-id
 AUTH0_API_SECRET: your-api-secret-id
 AWS_PROFILE: default
-AWS_API_GATEWAY_USAGE_PLAN_ID: usage-plan-id
+DEFAULT_USAGE_PLAN_ID: usage-plan-id
 
 # To configure a remote MongoDB service (such as MongoDB Atlas), provide all
 # Mongo properties below. Otherwise, only a database name is needed (server

--- a/src/main/java/org/opentripplanner/middleware/aws/AwsApiGateway.java
+++ b/src/main/java/org/opentripplanner/middleware/aws/AwsApiGateway.java
@@ -1,0 +1,104 @@
+package org.opentripplanner.middleware.aws;
+
+import com.amazonaws.services.apigateway.AmazonApiGateway;
+import com.amazonaws.services.apigateway.AmazonApiGatewayClient;
+import com.amazonaws.services.apigateway.AmazonApiGatewayClientBuilder;
+import com.amazonaws.services.apigateway.model.CreateApiKeyRequest;
+import com.amazonaws.services.apigateway.model.CreateApiKeyResult;
+import com.amazonaws.services.apigateway.model.CreateUsagePlanKeyRequest;
+import com.amazonaws.services.apigateway.model.DeleteApiKeyRequest;
+import com.amazonaws.services.apigateway.model.GetUsagePlanRequest;
+import com.amazonaws.services.apigateway.model.GetUsagePlanResult;
+import com.amazonaws.services.apigateway.model.NotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.opentripplanner.middleware.spark.Main.getConfigPropertyAsText;
+
+/**
+ * Manages all interactions with AWS api gateway.
+ */
+public class AwsApiGateway {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AwsApiGateway.class);
+    private static final int SDK_REQUEST_TIMEOUT = 10 * 1000;
+    private static final String AWS_API_GATEWAY_USAGE_PLAN_ID
+        = getConfigPropertyAsText("AWS_API_GATEWAY_USAGE_PLAN_ID");
+
+    /**
+     * Create connection to AWS api gateway.
+     */
+    private static AmazonApiGateway getAmazonApiGateway() {
+        AmazonApiGatewayClientBuilder gatewayBuilder = AmazonApiGatewayClient.builder();
+        AmazonApiGateway gateway = gatewayBuilder.build();
+        return gateway;
+    }
+
+    /**
+     * Request an API key from AWS api gateway and assign it to an existing usage plan.
+     */
+    public static String getApiKeyId(String userId) {
+        long startTime = System.currentTimeMillis();
+
+        try {
+
+            AmazonApiGateway gateway = getAmazonApiGateway();
+
+            // create API key
+            CreateApiKeyRequest apiKeyRequest = new CreateApiKeyRequest();
+            apiKeyRequest.setSdkRequestTimeout(SDK_REQUEST_TIMEOUT);
+            apiKeyRequest
+                .withName(userId)
+                .withCustomerId(userId)
+                .withEnabled(true);
+            CreateApiKeyResult apiKeyResult = gateway.createApiKey(apiKeyRequest);
+
+            // get existing usage plan
+            GetUsagePlanRequest usagePlanRequest = new GetUsagePlanRequest();
+            usagePlanRequest.withUsagePlanId(AWS_API_GATEWAY_USAGE_PLAN_ID);
+            GetUsagePlanResult usagePlanResult = gateway.getUsagePlan(usagePlanRequest);
+
+            // add API key to usage plan
+            CreateUsagePlanKeyRequest usagePlanKeyRequest = new CreateUsagePlanKeyRequest();
+            usagePlanKeyRequest
+                .withUsagePlanId(usagePlanResult.getId())
+                .withKeyId(apiKeyResult.getId())
+                .withKeyType("API_KEY");
+            gateway.createUsagePlanKey(usagePlanKeyRequest);
+
+            return apiKeyResult.getId();
+        } catch (Exception e) {
+            LOG.error("Unable to get api key from AWS", e);
+            //FIXME add bugsnag
+        } finally {
+            LOG.debug("Get api key and assign to usage plan took {} msec", System.currentTimeMillis() - startTime);
+        }
+        return null;
+    }
+
+    /**
+     * Delete api keys from AWS api gateway.
+     */
+    public static void deleteApiKeys(List<String> apiKeyIds) {
+        long startTime = System.currentTimeMillis();
+
+        AmazonApiGateway gateway = getAmazonApiGateway();
+
+        for (String apiKeyId : apiKeyIds) {
+            try {
+                DeleteApiKeyRequest deleteApiKeyRequest = new DeleteApiKeyRequest();
+                deleteApiKeyRequest.setSdkRequestTimeout(SDK_REQUEST_TIMEOUT);
+                deleteApiKeyRequest.setApiKey(apiKeyId);
+                gateway.deleteApiKey(deleteApiKeyRequest);
+            } catch (NotFoundException e) {
+                LOG.warn("Api key ({}) not found, unable to delete", apiKeyId, e);
+            } catch (Exception e) {
+                LOG.error("Unable to delete api key ({})", apiKeyId, e);
+                //FIXME add bugsnag
+            }
+        }
+        LOG.debug("Deleting Api keys took {} msec", System.currentTimeMillis() - startTime);
+    }
+}

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
@@ -1,9 +1,13 @@
 package org.opentripplanner.middleware.controllers.api;
 
+import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.aws.AwsApiGateway;
 import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.persistence.Persistence;
 import spark.Request;
+
+import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
  * Implementation of the {@link AbstractUserController} for {@link ApiUser}.
@@ -24,8 +28,28 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
      */
     @Override
     ApiUser preCreateHook(ApiUser user, Request req) {
-        // TODO: Add the API keys for this user.
+        String apiKeyId = AwsApiGateway.getApiKeyId(user.id);
+        if (apiKeyId == null) {
+            logMessageAndHalt(req, HttpStatus.INTERNAL_SERVER_ERROR_500,
+                String.format("Unable to get AWS api key for user %s", user)
+                , null);
+        }
 
+        //FIXME This suggests many, where only one is returned?
+        user.apiKeyIds.add(apiKeyId);
+
+        //FIXME If there are any issues creating the user, the api key in AWS will be orphaned
         return super.preCreateHook(user, req);
     }
+
+    /**
+     * Before deleting an API user in MongoDB,
+     * remove the API keys for this user.
+     */
+    @Override
+    boolean preDeleteHook(ApiUser user, Request req) {
+        AwsApiGateway.deleteApiKeys(user.apiKeyIds);
+        return true;
+    }
+
 }

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
@@ -42,6 +42,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
                 null);
         }
 
+        // store api key id (not the actual api key)
         user.apiKeyIds.add(apiKey.getId());
 
         try {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/LogController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/LogController.java
@@ -1,53 +1,28 @@
 package org.opentripplanner.middleware.controllers.api;
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider;
-import com.amazonaws.services.apigateway.AmazonApiGateway;
-import com.amazonaws.services.apigateway.AmazonApiGatewayClient;
-import com.amazonaws.services.apigateway.AmazonApiGatewayClientBuilder;
-import com.amazonaws.services.apigateway.model.GetUsagePlansRequest;
-import com.amazonaws.services.apigateway.model.GetUsagePlansResult;
-import com.amazonaws.services.apigateway.model.GetUsageRequest;
 import com.amazonaws.services.apigateway.model.GetUsageResult;
-import com.amazonaws.services.apigateway.model.UsagePlan;
 import org.eclipse.jetty.http.HttpStatus;
+import org.opentripplanner.middleware.utils.ApiGatewayUtils;
 import org.opentripplanner.middleware.utils.JsonUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 import spark.Service;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 
-import static org.opentripplanner.middleware.spark.Main.getConfigPropertyAsText;
-import static org.opentripplanner.middleware.spark.Main.hasConfigProperty;
-import static org.opentripplanner.middleware.spark.Main.inTestEnvironment;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
  * Sets up HTTP endpoints for getting logging and request summary information from AWS Cloudwatch and API Gateway.
  */
 public class LogController {
-    private static final Logger LOG = LoggerFactory.getLogger(LogController.class);
-    private static AmazonApiGateway gateway;
 
     /**
      * Register http endpoints with {@link spark.Spark} instance at the provided API prefix.
      */
-    public static void register (Service spark, String apiPrefix) {
-        AmazonApiGatewayClientBuilder gatewayBuilder = AmazonApiGatewayClient.builder();
-        if (hasConfigProperty("AWS_PROFILE")) {
-            gatewayBuilder.withCredentials(new ProfileCredentialsProvider(getConfigPropertyAsText("AWS_PROFILE")));
-        }
-        if (!inTestEnvironment) {
-            // FIXME Only build API Gateway client if not testing to avoid Travis issues with AWS credentials.
-            gateway = gatewayBuilder.build();
-        } else {
-            LOG.warn("Not building API Gateway client.");
-        }
+    public static void register(Service spark, String apiPrefix) {
         spark.get(apiPrefix + "/secure/logs", LogController::getUsageLogs, JsonUtils::toJson);
     }
 
@@ -55,7 +30,7 @@ public class LogController {
      * HTTP endpoint to return the usage (number of requests made/requests remaining) for the AWS API Gateway usage
      * plans. Defaults to the last 30 days for all API keys in the AWS account.
      */
-    public static List<GetUsageResult> getUsageLogs(Request req, Response res) {
+    private static List<GetUsageResult> getUsageLogs(Request req, Response res) {
         // keyId param is optional (if not provided, all API keys will be included in response).
         String keyId = req.queryParamOrDefault("keyId", null);
         LocalDateTime now = LocalDateTime.now();
@@ -64,23 +39,13 @@ public class LogController {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         String startDate = req.queryParamOrDefault("startDate", formatter.format(now.minusDays(30)));
         String endDate = req.queryParamOrDefault("endDate", formatter.format(now));
-        GetUsagePlansRequest getUsagePlansRequest = new GetUsagePlansRequest();
-        GetUsagePlansResult usagePlansResult = gateway.getUsagePlans(getUsagePlansRequest);
-        List<GetUsageResult> usageResults = new ArrayList<>();
-        for (UsagePlan usagePlan : usagePlansResult.getItems()) {
-            GetUsageRequest getUsageRequest = new GetUsageRequest()
-                // TODO: Once third party dev accounts are fleshed out, this query param might go away?
-                .withKeyId(keyId)
-                .withStartDate(startDate)
-                .withEndDate(endDate)
-                .withUsagePlanId(usagePlan.getId());
-            try {
-                usageResults.add(gateway.getUsage(getUsageRequest));
-            } catch (Exception e) {
-                // Catch any issues with bad request parameters (e.g., invalid API keyId or bad date format).
-                logMessageAndHalt(req, HttpStatus.BAD_REQUEST_400, "Error requesting usage results", e);
-            }
+        try {
+            return ApiGatewayUtils.getUsageLogs(keyId, startDate, endDate);
+        } catch (Exception e) {
+            // Catch any issues with bad request parameters (e.g., invalid API keyId or bad date format).
+            logMessageAndHalt(req, HttpStatus.BAD_REQUEST_400, "Error requesting usage results", e);
         }
-        return usageResults;
+
+        return null;
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/spark/Main.java
+++ b/src/main/java/org/opentripplanner/middleware/spark/Main.java
@@ -35,7 +35,6 @@ public class Main {
     // ObjectMapper that loads in YAML config files
     private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
     private static final String API_PREFIX = "/api/";
-    public static boolean inTestEnvironment = false;
 
     public static void main(String[] args) throws IOException {
         // Load configuration.

--- a/src/main/java/org/opentripplanner/middleware/utils/ApiGatewayUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/ApiGatewayUtils.java
@@ -56,7 +56,6 @@ public class ApiGatewayUtils {
         long startTime = System.currentTimeMillis();
 
         try {
-
             AmazonApiGateway gateway = getAmazonApiGateway();
 
             // create API key

--- a/src/main/java/org/opentripplanner/middleware/utils/ApiGatewayUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/ApiGatewayUtils.java
@@ -1,5 +1,6 @@
-package org.opentripplanner.middleware.aws;
+package org.opentripplanner.middleware.utils;
 
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.services.apigateway.AmazonApiGateway;
 import com.amazonaws.services.apigateway.AmazonApiGatewayClient;
 import com.amazonaws.services.apigateway.AmazonApiGatewayClientBuilder;
@@ -9,37 +10,49 @@ import com.amazonaws.services.apigateway.model.CreateUsagePlanKeyRequest;
 import com.amazonaws.services.apigateway.model.DeleteApiKeyRequest;
 import com.amazonaws.services.apigateway.model.GetUsagePlanRequest;
 import com.amazonaws.services.apigateway.model.GetUsagePlanResult;
+import com.amazonaws.services.apigateway.model.GetUsagePlansRequest;
+import com.amazonaws.services.apigateway.model.GetUsagePlansResult;
+import com.amazonaws.services.apigateway.model.GetUsageRequest;
+import com.amazonaws.services.apigateway.model.GetUsageResult;
 import com.amazonaws.services.apigateway.model.NotFoundException;
+import com.amazonaws.services.apigateway.model.UsagePlan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.opentripplanner.middleware.spark.Main.getConfigPropertyAsText;
+import static org.opentripplanner.middleware.spark.Main.hasConfigProperty;
 
 /**
  * Manages all interactions with AWS api gateway.
  */
-public class AwsApiGateway {
+public class ApiGatewayUtils {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AwsApiGateway.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ApiGatewayUtils.class);
     private static final int SDK_REQUEST_TIMEOUT = 10 * 1000;
-    private static final String AWS_API_GATEWAY_USAGE_PLAN_ID
-        = getConfigPropertyAsText("AWS_API_GATEWAY_USAGE_PLAN_ID");
 
     /**
      * Create connection to AWS api gateway.
      */
     private static AmazonApiGateway getAmazonApiGateway() {
+        long startTime = System.currentTimeMillis();
+
         AmazonApiGatewayClientBuilder gatewayBuilder = AmazonApiGatewayClient.builder();
+        if (hasConfigProperty("AWS_PROFILE")) {
+            gatewayBuilder.withCredentials(new ProfileCredentialsProvider(getConfigPropertyAsText("AWS_PROFILE")));
+        }
         AmazonApiGateway gateway = gatewayBuilder.build();
+
+        LOG.debug("Connection to AWS api gateway took {} msec", System.currentTimeMillis() - startTime);
         return gateway;
     }
 
     /**
      * Request an API key from AWS api gateway and assign it to an existing usage plan.
      */
-    public static String getApiKeyId(String userId) {
+    public static CreateApiKeyResult createApiKey(String userId, String usagePlanId) {
         long startTime = System.currentTimeMillis();
 
         try {
@@ -55,9 +68,9 @@ public class AwsApiGateway {
                 .withEnabled(true);
             CreateApiKeyResult apiKeyResult = gateway.createApiKey(apiKeyRequest);
 
-            // get existing usage plan
+            // get usage plan
             GetUsagePlanRequest usagePlanRequest = new GetUsagePlanRequest();
-            usagePlanRequest.withUsagePlanId(AWS_API_GATEWAY_USAGE_PLAN_ID);
+            usagePlanRequest.withUsagePlanId(usagePlanId);
             GetUsagePlanResult usagePlanResult = gateway.getUsagePlan(usagePlanRequest);
 
             // add API key to usage plan
@@ -68,7 +81,7 @@ public class AwsApiGateway {
                 .withKeyType("API_KEY");
             gateway.createUsagePlanKey(usagePlanKeyRequest);
 
-            return apiKeyResult.getId();
+            return apiKeyResult;
         } catch (Exception e) {
             LOG.error("Unable to get api key from AWS", e);
             //FIXME add bugsnag
@@ -100,5 +113,40 @@ public class AwsApiGateway {
             }
         }
         LOG.debug("Deleting Api keys took {} msec", System.currentTimeMillis() - startTime);
+    }
+
+    /**
+     * Get usage logs from AWS api gateway for a given key id, start and end date
+     */
+    public static List<GetUsageResult> getUsageLogs(String keyId, String startDate, String endDate) {
+        long startTime = System.currentTimeMillis();
+
+        AmazonApiGateway gateway = getAmazonApiGateway();
+
+        GetUsagePlansRequest getUsagePlansRequest = new GetUsagePlansRequest();
+        GetUsagePlansResult usagePlansResult = gateway.getUsagePlans(getUsagePlansRequest);
+        List<GetUsageResult> usageResults = new ArrayList<>();
+        for (UsagePlan usagePlan : usagePlansResult.getItems()) {
+            GetUsageRequest getUsageRequest = new GetUsageRequest()
+                // TODO: Once third party dev accounts are fleshed out, this query param might go away?
+                .withKeyId(keyId)
+                .withStartDate(startDate)
+                .withEndDate(endDate)
+                .withUsagePlanId(usagePlan.getId());
+            try {
+                usageResults.add(gateway.getUsage(getUsageRequest));
+            } catch (Exception e) {
+                // Catch any issues with bad request parameters (e.g., invalid API keyId or bad date format).
+                LOG.error("Unable to get usage results for key id ({}) with start date ({}) and end date ({})",
+                    keyId,
+                    startDate,
+                    endDate,
+                    e);
+                //FIXME add bugsnag
+                throw e;
+            }
+        }
+        LOG.debug("Retrieving usage logs took {} msec", System.currentTimeMillis() - startTime);
+        return usageResults;
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/OtpMiddlewareTest.java
+++ b/src/test/java/org/opentripplanner/middleware/OtpMiddlewareTest.java
@@ -30,7 +30,6 @@ public abstract class OtpMiddlewareTest {
         LOG.info("OtpMiddlewareTest setup");
 
         LOG.info("Starting server");
-        otpMiddleware.inTestEnvironment = true;
         otpMiddleware.main(new String[]{"configurations/test/env.yml"});
         setUpIsDone = true;
     }


### PR DESCRIPTION
### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] Code coverage improves or is at 100% _(remove this if not merging to master)_

### Description

PR to create AWS API key and assign it to a usage plan. The API key id is then saved along with an API user. If the API user is deleted, the associated API key is deleted from AWS.

### To run

An AWS_PROFILE is required, or AWS access has been configured for your operating environment e.g. C:\Users\<username\.aws\credentials in Windows or iOS equivalent.

A DEFAULT_USAGE_PLAN_ID is required. This is needed so the newly created api key can be assigned to a usage plan. This can be obtained by logging into the AWS console and navagating to API gateway, usage plans. From here the desired usage plan can be selected and the id extracted.

### TODO
Add Bugsnag error reporting

### For consideration (see FIXME)

It appears many api key ids are expected, when only one is returned. I'm concerned that I might be creating a generic api key which allows access to all APIs... perhaps this is by design:

https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html

"You can use API keys together with usage plans or Lambda authorizers to control access to your APIs"

"API key values must be unique. If you try to create two API keys with different names and the same value, API Gateway considers them to be the same API key. "