### PR TITLE
Api key management unit testing

### DIFF
--- a/configurations/test/env.yml
+++ b/configurations/test/env.yml
@@ -26,4 +26,3 @@ MONGO_DB_NAME: otp_middleware_test
 OTP_API_ROOT: http://otp-server.example.com/otp
 OTP_PLAN_ENDPOINT: /routers/default/plan
 MAXIMUM_PERMITTED_MONITORED_TRIPS: 5
-DEFAULT_USAGE_PLAN_ID: ajjp1j

--- a/configurations/test/env.yml
+++ b/configurations/test/env.yml
@@ -1,6 +1,7 @@
 AUTH0_API_CLIENT: test-auth0-client-id
 AUTH0_API_SECRET: test-auth0-secret
 AUTH0_DOMAIN: test.auth0.com
+DISABLE_AUTH: true
 
 BUGSNAG_API_KEY: bugsnag-api-key
 BUGSNAG_EVENT_JOB_DELAY_IN_MINUTES: 1

--- a/configurations/test/env.yml
+++ b/configurations/test/env.yml
@@ -1,7 +1,6 @@
 AUTH0_API_CLIENT: test-auth0-client-id
 AUTH0_API_SECRET: test-auth0-secret
 AUTH0_DOMAIN: test.auth0.com
-DISABLE_AUTH: true
 
 BUGSNAG_API_KEY: bugsnag-api-key
 BUGSNAG_EVENT_JOB_DELAY_IN_MINUTES: 1

--- a/configurations/test/env.yml
+++ b/configurations/test/env.yml
@@ -26,3 +26,4 @@ MONGO_DB_NAME: otp_middleware_test
 OTP_API_ROOT: http://otp-server.example.com/otp
 OTP_PLAN_ENDPOINT: /routers/default/plan
 MAXIMUM_PERMITTED_MONITORED_TRIPS: 5
+DEFAULT_USAGE_PLAN_ID: ajjp1j

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@
         </resources>
         <plugins>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.0.2</version>

--- a/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
+++ b/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
@@ -112,7 +112,11 @@ public class OtpMiddlewareMain {
         // Return 404 for any API path that is not configured.
         // IMPORTANT: Any API paths must be registered before this halt.
         spark.get(API_PREFIX + "*", (request, response) -> {
-            logMessageAndHalt(request, 404, "No API route configured for this path.");
+            logMessageAndHalt(
+                request,
+                404,
+                String.format("No API route configured for path %s.", request.uri())
+            );
             return null;
         });
     }

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -41,7 +41,7 @@ public class Auth0Connection {
         if (authDisabled()) {
             // If in a development or testing environment, assign a mock profile of an admin user to the request
             // attribute and skip authentication.
-            addUserToRequest(req, Auth0UserProfile.createTestAdminUser());
+            addUserToRequest(req, Auth0UserProfile.createTestUser(req));
             return;
         }
         String token = getTokenFromRequest(req);

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0UserProfile.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0UserProfile.java
@@ -23,7 +23,8 @@ public class Auth0UserProfile {
     public final String auth0UserId;
 
     /**
-     * Constructor is only used for creating a test user
+     * Constructor is only used for creating a test user. If an Auth0 user id is provided check persistence for matching
+     * user else create default user.
      */
     private Auth0UserProfile(String auth0UserId) {
         if (auth0UserId == null) {
@@ -52,12 +53,14 @@ public class Auth0UserProfile {
     }
 
     /**
-     * Utility method for creating a test user. If auth0 user Id is defined check persistence for matching user else
-     * create default user.
+     * Utility method for creating a test user. If a Auth0 user Id is defined within the Authorization header param
+     * define test user based on this.
      */
     static Auth0UserProfile createTestUser(Request req) {
         String auth0UserId = null;
         if (isAuthHeaderPresent(req)) {
+            // If the auth header has been provided get the Auth0 user id from it. This is different from normal
+            // operation as the parameter will only contain the Auth0 user id and not "Bearer token".
             auth0UserId = req.headers("Authorization");
         }
         return new Auth0UserProfile(auth0UserId);

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0UserProfile.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0UserProfile.java
@@ -7,6 +7,8 @@ import org.opentripplanner.middleware.models.AdminUser;
 import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.persistence.Persistence;
+import org.opentripplanner.middleware.utils.HttpUtils;
+import spark.Request;
 
 import static com.mongodb.client.model.Filters.eq;
 
@@ -22,10 +24,18 @@ public class Auth0UserProfile {
 
     /** Constructor is only used for creating a test user */
     private Auth0UserProfile(String auth0UserId) {
-        this.auth0UserId = auth0UserId;
-        otpUser = new OtpUser();
-        apiUser = new ApiUser();
-        adminUser = new AdminUser();
+        if (auth0UserId == null) {
+            this.auth0UserId = "user_id:string";
+            otpUser = new OtpUser();
+            apiUser = new ApiUser();
+            adminUser = new AdminUser();
+        } else {
+            this.auth0UserId = auth0UserId;
+            Bson withAuth0UserId = eq("auth0UserId", auth0UserId);
+            otpUser = Persistence.otpUsers.getOneFiltered(withAuth0UserId);
+            adminUser = Persistence.adminUsers.getOneFiltered(withAuth0UserId);
+            apiUser = Persistence.apiUsers.getOneFiltered(withAuth0UserId);
+        }
     }
 
     /** Create a user profile from the request's JSON web token. Check persistence for stored user */
@@ -38,9 +48,11 @@ public class Auth0UserProfile {
     }
 
     /**
-     * Utility method for creating a test admin (with application-admin permissions) user.
+     * Utility method for creating a test user. If auth0 user Id is defined check persistence for matching user else
+     * create default user.
      */
-    public static Auth0UserProfile createTestAdminUser() {
-        return new Auth0UserProfile("user_id:string");
+    static Auth0UserProfile createTestUser(Request req) {
+        String auth0UserId = req.queryParamOrDefault("auth0UserId", null);
+        return new Auth0UserProfile(auth0UserId);
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0UserProfile.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0UserProfile.java
@@ -7,10 +7,10 @@ import org.opentripplanner.middleware.models.AdminUser;
 import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.persistence.Persistence;
-import org.opentripplanner.middleware.utils.HttpUtils;
 import spark.Request;
 
 import static com.mongodb.client.model.Filters.eq;
+import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthHeaderPresent;
 
 /**
  * User profile that is attached to an HTTP request.
@@ -22,7 +22,9 @@ public class Auth0UserProfile {
     public final AdminUser adminUser;
     public final String auth0UserId;
 
-    /** Constructor is only used for creating a test user */
+    /**
+     * Constructor is only used for creating a test user
+     */
     private Auth0UserProfile(String auth0UserId) {
         if (auth0UserId == null) {
             this.auth0UserId = "user_id:string";
@@ -38,7 +40,9 @@ public class Auth0UserProfile {
         }
     }
 
-    /** Create a user profile from the request's JSON web token. Check persistence for stored user */
+    /**
+     * Create a user profile from the request's JSON web token. Check persistence for stored user
+     */
     public Auth0UserProfile(DecodedJWT jwt) {
         this.auth0UserId = jwt.getClaim("sub").asString();
         Bson withAuth0UserId = eq("auth0UserId", auth0UserId);
@@ -52,7 +56,10 @@ public class Auth0UserProfile {
      * create default user.
      */
     static Auth0UserProfile createTestUser(Request req) {
-        String auth0UserId = req.queryParamOrDefault("auth0UserId", null);
+        String auth0UserId = null;
+        if (isAuthHeaderPresent(req)) {
+            auth0UserId = req.headers("Authorization");
+        }
         return new Auth0UserProfile(auth0UserId);
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -11,6 +11,8 @@ import org.opentripplanner.middleware.auth.Auth0Users;
 import org.opentripplanner.middleware.models.AbstractUser;
 import org.opentripplanner.middleware.persistence.TypedPersistence;
 import org.opentripplanner.middleware.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
@@ -27,6 +29,7 @@ import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
  * services using the hooks provided by {@link ApiController}.
  */
 public abstract class AbstractUserController<U extends AbstractUser> extends ApiController<U> {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractUserController.class);
     static final String NO_USER_WITH_AUTH0_ID_MESSAGE = "No user with auth0UserID=%s found.";
     private static final String TOKEN_PATH = "/fromtoken";
     private static final String VERIFICATION_EMAIL_PATH = "/verification-email";

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiController.java
@@ -45,7 +45,7 @@ public abstract class ApiController<T extends Model> implements Endpoint {
     protected static final String ID_PATH = "/:" + ID_PARAM;
     protected final String ROOT_ROUTE;
     private static final String SECURE = "secure/";
-    protected static final Logger LOG = LoggerFactory.getLogger(ApiController.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ApiController.class);
     private final String classToLowercase;
     final TypedPersistence<T> persistence;
     private final Class<T> clazz;

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
@@ -40,9 +40,9 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
 
     @Override
     protected void buildEndpoint(ApiEndpoint baseEndpoint) {
-        LOG.info("Registering path {}.", ROOT_ROUTE + API_KEY_PATH);
-
         // Add the api key route BEFORE the regular CRUD methods
+        // (to avoid interference with "get API user by ID" route)
+        LOG.info("Registering path {}.", ROOT_ROUTE + ID_PATH + API_KEY_PATH);
         ApiEndpoint modifiedEndpoint = baseEndpoint
             // Create API key
             .post(path(ID_PATH + API_KEY_PATH)

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.middleware.controllers.api;
 
-import com.amazonaws.services.apigateway.model.CreateApiKeyResult;
 import com.beerboy.ss.ApiEndpoint;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
@@ -11,6 +10,8 @@ import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.utils.ApiGatewayUtils;
 import org.opentripplanner.middleware.utils.HttpUtils;
 import org.opentripplanner.middleware.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import spark.HaltException;
 import spark.Request;
 import spark.Response;
@@ -27,6 +28,7 @@ import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
  * managing an {@link ApiUser}'s API keys.
  */
 public class ApiUserController extends AbstractUserController<ApiUser> {
+    private static final Logger LOG = LoggerFactory.getLogger(ApiUserController.class);
     private static final String DEFAULT_USAGE_PLAN_ID = getConfigPropertyAsText("DEFAULT_USAGE_PLAN_ID");
     private static final String API_KEY_PATH = "/apikey";
     private static final int API_KEY_LIMIT_PER_USER = 2;
@@ -97,8 +99,8 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
             }
         }
         // FIXME Should an Api user be limited to one api key per usage plan (and perhaps stage)?
-        CreateApiKeyResult apiKeyResult = ApiGatewayUtils.createApiKey(targetUser.id, usagePlanId);
-        if (apiKeyResult == null || apiKeyResult.getId() == null) {
+        ApiKey apiKey = ApiGatewayUtils.createApiKey(targetUser.id, usagePlanId);
+        if (apiKey == null || apiKey.id == null) {
             logMessageAndHalt(req,
                 HttpStatus.INTERNAL_SERVER_ERROR_500,
                 String.format("Unable to get AWS API key for user id (%s) and usage plan id (%s)", targetUser.id, usagePlanId),
@@ -107,7 +109,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
             return null;
         }
         // Add new API key to user and persist
-        targetUser.apiKeys.add(new ApiKey(apiKeyResult));
+        targetUser.apiKeys.add(apiKey);
         Persistence.apiUsers.replace(targetUser.id, targetUser);
         return Persistence.apiUsers.getById(targetUser.id);
     }
@@ -156,19 +158,16 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
      */
     @Override
     ApiUser preCreateHook(ApiUser user, Request req) {
-        CreateApiKeyResult apiKeyResult = ApiGatewayUtils.createApiKey(user.id, DEFAULT_USAGE_PLAN_ID);
-        if (apiKeyResult == null) {
+        ApiKey apiKey = ApiGatewayUtils.createApiKey(user.id, DEFAULT_USAGE_PLAN_ID);
+        if (apiKey == null) {
             logMessageAndHalt(req,
                 HttpStatus.INTERNAL_SERVER_ERROR_500,
                 String.format("Unable to get AWS api key for user %s", user),
                 null);
         }
-
-        ApiKey apiKey = new ApiKey(apiKeyResult);
-
         // store api key id including the actual api key (value)
         user.apiKeys.add(apiKey);
-
+        // Call AbstractUserController#preCreateHook and delete api key in case something goes wrong.
         try {
             return super.preCreateHook(user, req);
         } catch (HaltException e) {
@@ -183,6 +182,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
      */
     @Override
     boolean preDeleteHook(ApiUser user, Request req) {
+        // TODO: Create method for deleting user's API keys?
         for (ApiKey apiKey : user.apiKeys) {
             deleteApiKey(apiKey);
         }

--- a/src/main/java/org/opentripplanner/middleware/models/ApiKey.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ApiKey.java
@@ -2,6 +2,8 @@ package org.opentripplanner.middleware.models;
 
 import com.amazonaws.services.apigateway.model.CreateApiKeyResult;
 
+import java.util.Objects;
+
 /**
  * Represents a subset of an AWS API Gateway API key.
  */
@@ -42,5 +44,20 @@ public class ApiKey {
         id = apiKeyResult.getId();
         name = apiKeyResult.getName();
         value = apiKeyResult.getValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ApiKey apiKey = (ApiKey) o;
+        return id.equals(apiKey.id) &&
+            name.equals(apiKey.name) &&
+            value.equals(apiKey.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, value);
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/utils/ApiGatewayUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/ApiGatewayUtils.java
@@ -54,12 +54,14 @@ public class ApiGatewayUtils {
     /**
      * Request an API key from AWS api gateway and assign it to an existing usage plan.
      */
-    public static CreateApiKeyResult createApiKey(String userId, String usagePlanId) {
+    public static ApiKey createApiKey(String userId, String usagePlanId) {
+        if (userId == null || usagePlanId == null) {
+            LOG.error("All required input parameters must be provided.");
+            return null;
+        }
         long startTime = System.currentTimeMillis();
-
         try {
             AmazonApiGateway gateway = getAmazonApiGateway();
-
             // create API key
             CreateApiKeyRequest apiKeyRequest = new CreateApiKeyRequest();
             apiKeyRequest.setSdkRequestTimeout(SDK_REQUEST_TIMEOUT);
@@ -83,8 +85,7 @@ public class ApiGatewayUtils {
                 .withKeyId(apiKeyResult.getId())
                 .withKeyType("API_KEY");
             gateway.createUsagePlanKey(usagePlanKeyRequest);
-
-            return apiKeyResult;
+            return new ApiKey(apiKeyResult);
         } catch (Exception e) {
             String message = String.format("Unable to get api key from AWS for user id (%s) and usage plan id (%s)",
                 userId,

--- a/src/main/java/org/opentripplanner/middleware/utils/JsonUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/JsonUtils.java
@@ -100,7 +100,7 @@ public class JsonUtils {
     ) throws HaltException {
         // Note that halting occurred, also print error stacktrace if applicable
         if (e != null) e.printStackTrace();
-        LOG.info("Halting with status code {}.  Error message: {}", statusCode, message);
+        LOG.error("Halting with status code {}.  Error message: {}", statusCode, message);
 
         if (statusCode >= 500) {
             BugsnagReporter.reportErrorToBugsnag(message, e);

--- a/src/main/java/org/opentripplanner/middleware/utils/JsonUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/JsonUtils.java
@@ -100,7 +100,7 @@ public class JsonUtils {
     ) throws HaltException {
         // Note that halting occurred, also print error stacktrace if applicable
         if (e != null) e.printStackTrace();
-        LOG.error("Halting with status code {}.  Error message: {}", statusCode, message);
+        LOG.error("Halting {} with status code {}.  Error message: {}", request.uri(), statusCode, message);
 
         if (statusCode >= 500) {
             BugsnagReporter.reportErrorToBugsnag(message, e);

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -7,24 +7,30 @@ import org.junit.jupiter.api.Test;
 import org.opentripplanner.middleware.models.AdminUser;
 import org.opentripplanner.middleware.models.ApiKey;
 import org.opentripplanner.middleware.models.ApiUser;
+import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.persistence.PersistenceUtil;
+import org.opentripplanner.middleware.utils.ApiGatewayUtils;
 import org.opentripplanner.middleware.utils.HttpUtils;
+import org.opentripplanner.middleware.utils.JsonUtils;
 
 import java.io.IOException;
+import java.net.http.HttpResponse;
 
-import static org.opentripplanner.middleware.persistence.PersistenceUtil.getApiUser;
-import static org.opentripplanner.middleware.persistence.PersistenceUtil.getStatusCodeFromResponse;
-import static org.opentripplanner.middleware.persistence.PersistenceUtil.removeAdminUser;
-import static org.opentripplanner.middleware.persistence.PersistenceUtil.removeApiUser;
+import static org.opentripplanner.middleware.OtpMiddlewareMain.getConfigPropertyAsText;
+import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedRequest;
 
 /**
  * Tests for creating and deleting api keys. The following config parameters are required for these tests to run:
  *
- * DISABLE_AUTH set to true to bypass auth checks and use users defined here.
- * DEFAULT_USAGE_PLAN_ID set to a valid usage plan id. AWS requires this to create an api key.
+ * An AWS_PROFILE is required, or AWS access has been configured for your operating environment e.g.
+ * C:\Users\<username>\.aws\credentials in Windows or Mac OS equivalent.
+ *
+ * DISABLE_AUTH set to true to bypass auth checks and use users defined here. DEFAULT_USAGE_PLAN_ID set to a valid usage
+ * plan id. AWS requires this to create an api key.
  */
 public class ApiKeyManagementTest extends OtpMiddlewareTest {
 
+    private static String DEFAULT_USAGE_PLAN_ID;
     private static ApiUser apiUser;
     private static AdminUser adminUser;
 
@@ -34,6 +40,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
     @BeforeAll
     public static void setUp() throws IOException {
         OtpMiddlewareTest.setUp();
+        DEFAULT_USAGE_PLAN_ID = getConfigPropertyAsText("DEFAULT_USAGE_PLAN_ID");
         apiUser = PersistenceUtil.createApiUser("test@example.com");
         adminUser = PersistenceUtil.createAdminUser("test@example.com");
     }
@@ -43,19 +50,15 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     @AfterAll
     public static void tearDown() {
-        removeAdminUser(adminUser.id);
+        Persistence.adminUsers.removeById(adminUser.id);
 
         // refresh api keys
-        apiUser = getApiUser(apiUser.id);
+        apiUser = Persistence.apiUsers.getById(apiUser.id);
         for (ApiKey apiKey : apiUser.apiKeys) {
-            // delete api keys if present
-            String url = String.format("http://localhost:4567/api/secure/application/%s/apikey/%s",
-                apiUser.id,
-                apiKey.id);
-            getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.DELETE, apiUser.auth0UserId);
+            ApiGatewayUtils.deleteApiKey(apiKey);
         }
 
-        removeApiUser(apiUser.id);
+        Persistence.apiUsers.removeById(apiUser.id);
     }
 
     /**
@@ -63,8 +66,13 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     @Test
     public void canCreateApiKeyForSelf() {
-        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey", apiUser.id);
-        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.POST, apiUser.auth0UserId), 200);
+        HttpResponse<String> response = createApiKey(apiUser.id, apiUser.auth0UserId);
+        Assertions.assertEquals(response.statusCode(), 200);
+        ApiUser testUser = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
+        // refresh API key
+        apiUser = Persistence.apiUsers.getById(apiUser.id);
+        //TODO: Convert to Lambda?
+        Assertions.assertTrue(apiUser.apiKeys.equals(testUser.apiKeys));
     }
 
     /**
@@ -72,8 +80,13 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     @Test
     public void adminCanCreateApiKeyForApiUser() {
-        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey", apiUser.id);
-        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.POST, adminUser.auth0UserId), 200);
+        HttpResponse<String> response = createApiKey(apiUser.id, adminUser.auth0UserId);
+        Assertions.assertEquals(response.statusCode(), 200);
+        ApiUser testUser = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
+        // refresh API key
+        apiUser = Persistence.apiUsers.getById(apiUser.id);
+        //TODO: Convert to Lambda?
+        Assertions.assertTrue(apiUser.apiKeys.equals(testUser.apiKeys));
     }
 
     /**
@@ -81,14 +94,15 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     @Test
     public void canDeleteApiKeyForSelf() {
-
         ensureAtLeastOneApiKeyIsAvailable();
-
         // delete key
-        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey/%s",
-            apiUser.id,
-            apiUser.apiKeys.get(0).id);
-        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.DELETE, apiUser.auth0UserId), 200);
+        HttpResponse<String> response = deleteApiKey(apiUser.id, apiUser.apiKeys.get(0).id, apiUser.auth0UserId);
+        Assertions.assertEquals(response.statusCode(), 200);
+        ApiUser testUser = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
+        Assertions.assertTrue(testUser.apiKeys.isEmpty());
+        // refresh API key
+        apiUser = Persistence.apiUsers.getById(apiUser.id);
+        Assertions.assertTrue(apiUser.apiKeys.isEmpty());
     }
 
     /**
@@ -96,31 +110,45 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     @Test
     public void adminCanDeleteApiKeyForApiUser() {
-
         ensureAtLeastOneApiKeyIsAvailable();
-
         // delete key
-        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey/%s",
-            apiUser.id,
-            apiUser.apiKeys.get(0).id);
-        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.DELETE, adminUser.auth0UserId), 200);
+        HttpResponse<String> response = deleteApiKey(apiUser.id, apiUser.apiKeys.get(0).id, adminUser.auth0UserId);
+        Assertions.assertEquals(response.statusCode(), 200);
+        ApiUser testUser = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
+        Assertions.assertTrue(testUser.apiKeys.isEmpty());
+        // refresh API key
+        apiUser = Persistence.apiUsers.getById(apiUser.id);
+        Assertions.assertTrue(apiUser.apiKeys.isEmpty());
     }
 
     /**
      * Make sure that at least one API key exists.
      */
     private void ensureAtLeastOneApiKeyIsAvailable() {
-        // refresh api keys
-        apiUser = getApiUser(apiUser.id);
+        // Refresh API keys.
+        apiUser = Persistence.apiUsers.getById(apiUser.id);
 
         if (apiUser.apiKeys.isEmpty()) {
-            // create key
-            String url = String.format("http://localhost:4567/api/secure/application/%s/apikey", apiUser.id);
-            getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.POST, adminUser.auth0UserId);
-
-            // refresh api keys
-            apiUser = getApiUser(apiUser.id);
+            ApiKey apiKey = new ApiKey(ApiGatewayUtils.createApiKey(apiUser.id, DEFAULT_USAGE_PLAN_ID));
+            apiUser.apiKeys.add(apiKey);
+            // Save update so the API key delete endpoint is aware of the new API key.
+            Persistence.apiUsers.replace(apiUser.id, apiUser);
         }
+    }
 
+    /**
+     * Create API key for target user based on authorization of requesting user
+     */
+    private HttpResponse<String> createApiKey(String targetUserId, String requestingAuth0UserId) {
+        String url = String.format("api/secure/application/%s/apikey", targetUserId);
+        return mockAuthenticatedRequest(url, HttpUtils.REQUEST_METHOD.POST, requestingAuth0UserId);
+    }
+
+    /**
+     * Delete API key for target user based on authorization of requesting user
+     */
+    private HttpResponse<String> deleteApiKey(String targetUserId, String apiKeyId, String requestingAuth0UserId) {
+        String url = String.format("api/secure/application/%s/apikey/%s", targetUserId, apiKeyId);
+        return mockAuthenticatedRequest(url, HttpUtils.REQUEST_METHOD.DELETE, requestingAuth0UserId);
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -1,7 +1,21 @@
 package org.opentripplanner.middleware;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.middleware.models.AdminUser;
+import org.opentripplanner.middleware.models.ApiUser;
+import org.opentripplanner.middleware.persistence.PersistenceUtil;
+import org.opentripplanner.middleware.utils.HttpUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.opentripplanner.middleware.TestUtils.getBooleanEnvVar;
 
 /**
  * Tests for creating and deleting api keys. The following config parameters are required for these tests to run:
@@ -13,15 +27,45 @@ import org.junit.jupiter.api.Test;
 // FIXME: User is derived from token so difficult to test. To be addressed at a later date.
 public class ApiKeyManagementTest extends OtpMiddlewareTest {
 
-    @Test @Disabled
-    public void createApiKeyForUser() {
+    private static ApiUser apiUser;
+
+    @BeforeAll
+    public static void setUp() throws IOException {
+        OtpMiddlewareTest.setUp();
+        apiUser = PersistenceUtil.createApiUser("test@example.com");
     }
 
-    @Test @Disabled
-    public void getApiKeyForUser() {
+    /**
+     * Ensure that an {@link ApiUser} can create an API key for self.
+     */
+    @Test
+    public void canCreateApiKeyForSelf() {
+        // TODO: Call endpoint to create API key
+        HttpResponse<String> stringHttpResponse = HttpUtils.httpRequestRawResponse(
+            URI.create("http://localhost:4567/api/secure/application/apikey"),
+            1000,
+            HttpUtils.REQUEST_METHOD.POST,
+            new HashMap<>(),
+            null
+        );
+        Assertions.assertEquals(stringHttpResponse.statusCode(), 200);
     }
 
-    @Test @Disabled
-    public void deleteApiKeyForUser() {
+    /**
+     * Ensure that an {@link AdminUser} can create an API key for an {@link ApiUser}.
+     */
+    @Test
+    public void adminCanCreateApiKeyForApiUser() {
+        // TODO: Call endpoint to create API key
+    }
+
+    @Test
+    public void canGetApiKeyForUser() {
+        // TODO: Call endpoint to get API key with value
+    }
+
+    @Test
+    public void canDeleteApiKeyForUser() {
+        // TODO: Call endpoint to delete API key by ID.
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -19,7 +19,7 @@ import static org.opentripplanner.middleware.persistence.PersistenceUtil.removeA
 
 /**
  * Tests for creating and deleting api keys. The following config parameters are required for these tests to run:
- * <p>
+ *
  * DISABLE_AUTH set to true to bypass auth checks and use users defined here.
  * DEFAULT_USAGE_PLAN_ID set to a valid usage plan id. AWS requires this to create an api key.
  */

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -1,7 +1,6 @@
 package org.opentripplanner.middleware;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.middleware.models.AdminUser;
@@ -18,13 +17,16 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.http.HttpResponse;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.OtpMiddlewareMain.getConfigPropertyAsText;
 import static org.opentripplanner.middleware.TestUtils.getBooleanEnvVar;
 import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedRequest;
 
 /**
- * Tests for creating and deleting api keys. The following config parameters are required for these tests to run:
+ * Tests for creating and deleting api keys. The following config parameters are must be set in
+ * configurations/default/env.yml for these end-to-end tests to run:
  *  - RUN_E2E=true the end-to-end environment variable must be set (NOTE: this is not a config value)
  *  - An AWS_PROFILE is required, or AWS access has been configured for your operating environment e.g.
  *    C:\Users\<username>\.aws\credentials in Windows or Mac OS equivalent.
@@ -73,12 +75,12 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
     public void canCreateApiKeyForSelf() {
         assumeTrue(getBooleanEnvVar("RUN_E2E"));
         HttpResponse<String> response = createApiKeyRequest(apiUser.id, apiUser.auth0UserId);
-        Assertions.assertEquals(200, response.statusCode());
+        assertEquals(200, response.statusCode());
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
         // refresh API key
         ApiUser userFromDb = Persistence.apiUsers.getById(apiUser.id);
         LOG.info("API user successfully created API key id {}", userFromResponse.apiKeys.get(0).id);
-        Assertions.assertEquals(userFromDb.apiKeys, userFromResponse.apiKeys);
+        assertEquals(userFromDb.apiKeys, userFromResponse.apiKeys);
     }
 
     /**
@@ -88,12 +90,12 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
     public void adminCanCreateApiKeyForApiUser() {
         assumeTrue(getBooleanEnvVar("RUN_E2E"));
         HttpResponse<String> response = createApiKeyRequest(apiUser.id, adminUser.auth0UserId);
-        Assertions.assertEquals(200, response.statusCode());
+        assertEquals(200, response.statusCode());
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
         // refresh API key
         ApiUser userFromDb = Persistence.apiUsers.getById(apiUser.id);
         LOG.info("Admin user successfully created API key id {}", userFromResponse.apiKeys.get(0).id);
-        Assertions.assertEquals(userFromDb.apiKeys, userFromResponse.apiKeys);
+        assertEquals(userFromDb.apiKeys, userFromResponse.apiKeys);
     }
 
     /**
@@ -106,13 +108,13 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         // delete key
         String keyId = apiUser.apiKeys.get(0).id;
         HttpResponse<String> response = deleteApiKeyRequest(apiUser.id, keyId, apiUser.auth0UserId);
-        Assertions.assertEquals(200, response.statusCode());
+        assertEquals(200, response.statusCode());
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
-        Assertions.assertTrue(userFromResponse.apiKeys.isEmpty());
+        assertTrue(userFromResponse.apiKeys.isEmpty());
         LOG.info("API user successfully deleted API key id {}", keyId);
         // refresh API key
         ApiUser userFromDb = Persistence.apiUsers.getById(apiUser.id);
-        Assertions.assertTrue(userFromDb.apiKeys.isEmpty());
+        assertTrue(userFromDb.apiKeys.isEmpty());
     }
 
     /**
@@ -125,13 +127,13 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         // delete key
         String keyId = apiUser.apiKeys.get(0).id;
         HttpResponse<String> response = deleteApiKeyRequest(apiUser.id, keyId, adminUser.auth0UserId);
-        Assertions.assertEquals(response.statusCode(), 200);
+        assertEquals(200, response.statusCode());
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
-        Assertions.assertTrue(userFromResponse.apiKeys.isEmpty());
+        assertTrue(userFromResponse.apiKeys.isEmpty());
         // refresh API key
         ApiUser userFromDb = Persistence.apiUsers.getById(apiUser.id);
         LOG.info("Admin user successfully deleted API key id {}", keyId);
-        Assertions.assertTrue(userFromDb.apiKeys.isEmpty());
+        assertTrue(userFromDb.apiKeys.isEmpty());
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -19,7 +19,7 @@ import static org.opentripplanner.middleware.persistence.PersistenceUtil.removeA
 
 /**
  * Tests for creating and deleting api keys. The following config parameters are required for these tests to run:
- *
+ * <p>
  * DISABLE_AUTH set to true to bypass auth checks and use users defined here.
  * DEFAULT_USAGE_PLAN_ID set to a valid usage plan id. AWS requires this to create an api key.
  */
@@ -49,11 +49,10 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         apiUser = getApiUser(apiUser.id);
         for (ApiKey apiKey : apiUser.apiKeys) {
             // delete api keys if present
-            String url = String.format("http://localhost:4567/api/secure/application/%s/apikey/%s?auth0UserId=%s",
+            String url = String.format("http://localhost:4567/api/secure/application/%s/apikey/%s",
                 apiUser.id,
-                apiKey.id,
-                apiUser.auth0UserId);
-            getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.DELETE);
+                apiKey.id);
+            getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.DELETE, apiUser.auth0UserId);
         }
 
         removeApiUser(apiUser.id);
@@ -64,10 +63,8 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     @Test
     public void canCreateApiKeyForSelf() {
-        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey?auth0UserId=%s",
-            apiUser.id,
-            apiUser.auth0UserId);
-        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.POST), 200);
+        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey", apiUser.id);
+        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.POST, apiUser.auth0UserId), 200);
     }
 
     /**
@@ -75,10 +72,8 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     @Test
     public void adminCanCreateApiKeyForApiUser() {
-        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey?auth0UserId=%s",
-            apiUser.id,
-            adminUser.auth0UserId);
-        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.POST), 200);
+        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey", apiUser.id);
+        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.POST, adminUser.auth0UserId), 200);
     }
 
     /**
@@ -90,11 +85,10 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         ensureAtLeastOneApiKeyIsAvailable();
 
         // delete key
-        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey/%s?auth0UserId=%s",
+        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey/%s",
             apiUser.id,
-            apiUser.apiKeys.get(0).id,
-            apiUser.auth0UserId);
-        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.DELETE), 200);
+            apiUser.apiKeys.get(0).id);
+        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.DELETE, apiUser.auth0UserId), 200);
     }
 
     /**
@@ -106,11 +100,10 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         ensureAtLeastOneApiKeyIsAvailable();
 
         // delete key
-        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey/%s?auth0UserId=%s",
+        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey/%s",
             apiUser.id,
-            apiUser.apiKeys.get(0).id,
-            adminUser.auth0UserId);
-        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.DELETE), 200);
+            apiUser.apiKeys.get(0).id);
+        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.DELETE, adminUser.auth0UserId), 200);
     }
 
     /**
@@ -122,10 +115,8 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
 
         if (apiUser.apiKeys.isEmpty()) {
             // create key
-            String url = String.format("http://localhost:4567/api/secure/application/%s/apikey?auth0UserId=%s",
-                apiUser.id,
-                adminUser.auth0UserId);
-            getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.POST);
+            String url = String.format("http://localhost:4567/api/secure/application/%s/apikey", apiUser.id);
+            getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.POST, adminUser.auth0UserId);
 
             // refresh api keys
             apiUser = getApiUser(apiUser.id);

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -1,38 +1,62 @@
 package org.opentripplanner.middleware;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.middleware.models.AdminUser;
+import org.opentripplanner.middleware.models.ApiKey;
 import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.persistence.PersistenceUtil;
 import org.opentripplanner.middleware.utils.HttpUtils;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpResponse;
-import java.util.HashMap;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.opentripplanner.middleware.TestUtils.getBooleanEnvVar;
+import static org.opentripplanner.middleware.persistence.PersistenceUtil.getApiUser;
+import static org.opentripplanner.middleware.persistence.PersistenceUtil.getStatusCodeFromResponse;
+import static org.opentripplanner.middleware.persistence.PersistenceUtil.removeAdminUser;
+import static org.opentripplanner.middleware.persistence.PersistenceUtil.removeApiUser;
 
 /**
  * Tests for creating and deleting api keys. The following config parameters are required for these tests to run:
  *
- * DISABLE_AUTH set to true to bypass auth checks.
+ * DISABLE_AUTH set to true to bypass auth checks and use users defined here.
  * DEFAULT_USAGE_PLAN_ID set to a valid usage plan id. AWS requires this to create an api key.
- * OTP_MIDDLEWARE_URI_ROOT, e.g. http://localhost:4567.
  */
-// FIXME: User is derived from token so difficult to test. To be addressed at a later date.
 public class ApiKeyManagementTest extends OtpMiddlewareTest {
 
     private static ApiUser apiUser;
+    private static AdminUser adminUser;
 
+    /**
+     * Create an {@link ApiUser} and an {@link AdminUser} prior to unit tests
+     */
     @BeforeAll
     public static void setUp() throws IOException {
         OtpMiddlewareTest.setUp();
         apiUser = PersistenceUtil.createApiUser("test@example.com");
+        adminUser = PersistenceUtil.createAdminUser("test@example.com");
+    }
+
+    /**
+     * Remove the users {@link AdminUser} and {@link ApiUser} and any remaining API keys.
+     */
+    @AfterAll
+    public static void tearDown() {
+        removeAdminUser(adminUser.id);
+
+        // refresh api keys
+        apiUser = getApiUser(apiUser.id);
+        for (ApiKey apiKey : apiUser.apiKeys) {
+            // delete api keys if present
+            String url = String.format("http://localhost:4567/api/secure/application/%s/apikey/%s?auth0UserId=%s",
+                apiUser.id,
+                apiKey.id,
+                apiUser.auth0UserId);
+            getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.DELETE);
+        }
+
+        removeApiUser(apiUser.id);
     }
 
     /**
@@ -40,15 +64,10 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     @Test
     public void canCreateApiKeyForSelf() {
-        // TODO: Call endpoint to create API key
-        HttpResponse<String> stringHttpResponse = HttpUtils.httpRequestRawResponse(
-            URI.create("http://localhost:4567/api/secure/application/apikey"),
-            1000,
-            HttpUtils.REQUEST_METHOD.POST,
-            new HashMap<>(),
-            null
-        );
-        Assertions.assertEquals(stringHttpResponse.statusCode(), 200);
+        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey?auth0UserId=%s",
+            apiUser.id,
+            apiUser.auth0UserId);
+        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.POST), 200);
     }
 
     /**
@@ -56,16 +75,61 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     @Test
     public void adminCanCreateApiKeyForApiUser() {
-        // TODO: Call endpoint to create API key
+        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey?auth0UserId=%s",
+            apiUser.id,
+            adminUser.auth0UserId);
+        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.POST), 200);
     }
 
+    /**
+     * Ensure that an {@link ApiUser} can delete an API key for self.
+     */
     @Test
-    public void canGetApiKeyForUser() {
-        // TODO: Call endpoint to get API key with value
+    public void canDeleteApiKeyForSelf() {
+
+        ensureAtLeastOneApiKeyIsAvailable();
+
+        // delete key
+        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey/%s?auth0UserId=%s",
+            apiUser.id,
+            apiUser.apiKeys.get(0).id,
+            apiUser.auth0UserId);
+        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.DELETE), 200);
     }
 
+    /**
+     * Ensure that an {@link AdminUser} can delete an API key for an {@link ApiUser}.
+     */
     @Test
-    public void canDeleteApiKeyForUser() {
-        // TODO: Call endpoint to delete API key by ID.
+    public void adminCanDeleteApiKeyForApiUser() {
+
+        ensureAtLeastOneApiKeyIsAvailable();
+
+        // delete key
+        String url = String.format("http://localhost:4567/api/secure/application/%s/apikey/%s?auth0UserId=%s",
+            apiUser.id,
+            apiUser.apiKeys.get(0).id,
+            adminUser.auth0UserId);
+        Assertions.assertEquals(getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.DELETE), 200);
+    }
+
+    /**
+     * Make sure that at least one API key exists.
+     */
+    private void ensureAtLeastOneApiKeyIsAvailable() {
+        // refresh api keys
+        apiUser = getApiUser(apiUser.id);
+
+        if (apiUser.apiKeys.isEmpty()) {
+            // create key
+            String url = String.format("http://localhost:4567/api/secure/application/%s/apikey?auth0UserId=%s",
+                apiUser.id,
+                adminUser.auth0UserId);
+            getStatusCodeFromResponse(url, HttpUtils.REQUEST_METHOD.POST);
+
+            // refresh api keys
+            apiUser = getApiUser(apiUser.id);
+        }
+
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/OtpMiddlewareTest.java
+++ b/src/test/java/org/opentripplanner/middleware/OtpMiddlewareTest.java
@@ -4,7 +4,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
+
+import static org.opentripplanner.middleware.TestUtils.getBooleanEnvVar;
 
 /**
  * This abstract class is used to start a test instance of otp-middleware that other tests can use to perform
@@ -29,7 +32,19 @@ public abstract class OtpMiddlewareTest {
 
         LOG.info("Starting server");
         OtpMiddlewareMain.inTestEnvironment = true;
-        OtpMiddlewareMain.main(new String[]{"configurations/test/env.yml"});
+        // If in the e2e environment, use the secret env.yml file to start the server.
+        // TODO: When ran on Travis CI, this file will automatically be setup.
+        String[] args = getBooleanEnvVar("RUN_E2E")
+            ? new String[] { "configurations/default/env.yml" }
+            : new String[] { "configurations/test/env.yml"};
+        // Fail this test and others if the above files do not exist.
+        for (String arg : args) {
+            File f = new File(arg);
+            if (!f.exists() || f.isDirectory()) {
+                throw new IOException(String.format("Required config file %s does not exist!", f.getName()));
+            }
+        }
+        OtpMiddlewareMain.main(args);
         setUpIsDone = true;
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -1,0 +1,12 @@
+package org.opentripplanner.middleware;
+
+public class TestUtils {
+
+    /**
+     * Returns true only if an environment variable exists and is set to "true".
+     */
+    public static boolean getBooleanEnvVar (String var) {
+        String variable = System.getenv(var);
+        return variable != null && variable.equals("true");
+    }
+}

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -1,12 +1,37 @@
 package org.opentripplanner.middleware;
 
+import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.utils.HttpUtils;
+
+import java.net.URI;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+
 public class TestUtils {
 
     /**
      * Returns true only if an environment variable exists and is set to "true".
      */
-    public static boolean getBooleanEnvVar (String var) {
+    public static boolean getBooleanEnvVar(String var) {
         String variable = System.getenv(var);
         return variable != null && variable.equals("true");
     }
+
+    /**
+     * Send request to provided URL placing the Auth0 user id in the headers so that {@link Auth0UserProfile} can check
+     * the database for a matching user. Returns the response.
+     */
+    public static HttpResponse<String> mockAuthenticatedRequest(String path, HttpUtils.REQUEST_METHOD requestMethod, String auth0UserId) {
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put("Authorization", auth0UserId);
+
+        return HttpUtils.httpRequestRawResponse(
+            URI.create("http://localhost:4567/" + path),
+            1000,
+            requestMethod,
+            headers,
+            ""
+        );
+    }
+
 }

--- a/src/test/java/org/opentripplanner/middleware/persistence/PersistenceUtil.java
+++ b/src/test/java/org/opentripplanner/middleware/persistence/PersistenceUtil.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.middleware.persistence;
 
+import org.opentripplanner.middleware.models.AdminUser;
 import org.opentripplanner.middleware.models.ApiUser;
-import org.opentripplanner.middleware.utils.FileUtils;
 import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.models.TripRequest;
@@ -10,8 +10,15 @@ import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.Place;
 import org.opentripplanner.middleware.otp.response.Response;
+import org.opentripplanner.middleware.utils.FileUtils;
+import org.opentripplanner.middleware.utils.HttpUtils;
 
-import java.util.*;
+import java.net.URI;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * Utility class to aid with creating and storing objects in Mongo.
@@ -45,6 +52,36 @@ public class PersistenceUtil {
         return user;
     }
 
+    /**
+     * Create Admin user and store in database.
+     */
+    public static AdminUser createAdminUser(String email) {
+        AdminUser user = new AdminUser();
+        user.email = email;
+        Persistence.adminUsers.create(user);
+        return user;
+    }
+
+    /**
+     * Get Api user from database
+     */
+    public static ApiUser getApiUser(String id) {
+        return Persistence.apiUsers.getById(id);
+    }
+
+    /**
+     * Remove Api user from database
+     */
+    public static void removeApiUser(String id) {
+        Persistence.apiUsers.removeById(id);
+    }
+
+    /**
+     * Remove Admin user from database
+     */
+    public static void removeAdminUser(String id) {
+        Persistence.adminUsers.removeById(id);
+    }
 
     /**
      * Create trip request and store in database.
@@ -159,5 +196,17 @@ public class PersistenceUtil {
         final String filePath = "src/test/resources/org/opentripplanner/middleware/";
         PLAN_RESPONSE = FileUtils.getFileContentsAsJSON(filePath + "planResponse.json", Response.class);
         PLAN_ERROR_RESPONSE = FileUtils.getFileContentsAsJSON(filePath + "planErrorResponse.json", Response.class);
+    }
+
+    public static int getStatusCodeFromResponse(String url, HttpUtils.REQUEST_METHOD requestMethod) {
+        HttpResponse<String> stringHttpResponse = HttpUtils.httpRequestRawResponse(
+            URI.create(url),
+            1000,
+            requestMethod,
+            new HashMap<>(),
+            ""
+        );
+
+        return stringHttpResponse.statusCode();
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/persistence/PersistenceUtil.java
+++ b/src/test/java/org/opentripplanner/middleware/persistence/PersistenceUtil.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import spark.Request;
 
 /**
  * Utility class to aid with creating and storing objects in Mongo.
@@ -130,7 +132,7 @@ public class PersistenceUtil {
      * Delete multiple trip requests from database.
      */
     public static void deleteTripRequests(List<TripRequest> tripRequests) {
-        for (TripRequest tripRequest: tripRequests) {
+        for (TripRequest tripRequest : tripRequests) {
             Persistence.tripRequests.removeById(tripRequest.id);
         }
     }
@@ -198,12 +200,19 @@ public class PersistenceUtil {
         PLAN_ERROR_RESPONSE = FileUtils.getFileContentsAsJSON(filePath + "planErrorResponse.json", Response.class);
     }
 
-    public static int getStatusCodeFromResponse(String url, HttpUtils.REQUEST_METHOD requestMethod) {
+    /**
+     * Send request to provided URL placing the Auth0 user id in the headers so that {@link Auth0UserProfile} can check
+     * the database for a matching user. Returns the response status code.
+      */
+    public static int getStatusCodeFromResponse(String url, HttpUtils.REQUEST_METHOD requestMethod, String auth0UserId) {
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put("Authorization", auth0UserId);
+
         HttpResponse<String> stringHttpResponse = HttpUtils.httpRequestRawResponse(
             URI.create(url),
             1000,
             requestMethod,
-            new HashMap<>(),
+            headers,
             ""
         );
 

--- a/src/test/java/org/opentripplanner/middleware/persistence/PersistenceUtil.java
+++ b/src/test/java/org/opentripplanner/middleware/persistence/PersistenceUtil.java
@@ -11,16 +11,10 @@ import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.Place;
 import org.opentripplanner.middleware.otp.response.Response;
 import org.opentripplanner.middleware.utils.FileUtils;
-import org.opentripplanner.middleware.utils.HttpUtils;
 
-import java.net.URI;
-import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
-import spark.Request;
 
 /**
  * Utility class to aid with creating and storing objects in Mongo.
@@ -62,27 +56,6 @@ public class PersistenceUtil {
         user.email = email;
         Persistence.adminUsers.create(user);
         return user;
-    }
-
-    /**
-     * Get Api user from database
-     */
-    public static ApiUser getApiUser(String id) {
-        return Persistence.apiUsers.getById(id);
-    }
-
-    /**
-     * Remove Api user from database
-     */
-    public static void removeApiUser(String id) {
-        Persistence.apiUsers.removeById(id);
-    }
-
-    /**
-     * Remove Admin user from database
-     */
-    public static void removeAdminUser(String id) {
-        Persistence.adminUsers.removeById(id);
     }
 
     /**
@@ -198,24 +171,5 @@ public class PersistenceUtil {
         final String filePath = "src/test/resources/org/opentripplanner/middleware/";
         PLAN_RESPONSE = FileUtils.getFileContentsAsJSON(filePath + "planResponse.json", Response.class);
         PLAN_ERROR_RESPONSE = FileUtils.getFileContentsAsJSON(filePath + "planErrorResponse.json", Response.class);
-    }
-
-    /**
-     * Send request to provided URL placing the Auth0 user id in the headers so that {@link Auth0UserProfile} can check
-     * the database for a matching user. Returns the response status code.
-      */
-    public static int getStatusCodeFromResponse(String url, HttpUtils.REQUEST_METHOD requestMethod, String auth0UserId) {
-        HashMap<String, String> headers = new HashMap<>();
-        headers.put("Authorization", auth0UserId);
-
-        HttpResponse<String> stringHttpResponse = HttpUtils.httpRequestRawResponse(
-            URI.create(url),
-            1000,
-            requestMethod,
-            headers,
-            ""
-        );
-
-        return stringHttpResponse.statusCode();
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR allows developers to unit test the API key management functionality via the Swagger/Spark endpoints.  A key enhancement to authentication allows test user objects to be used instead of a temporary admin account. User objects are matched with actual database objects providing more accurate testing. 

This is achieved by placing the Auth0 user id (of the newly created object) into the Authorization header parameter for each request. If authorization is NOT disabled a bearer token is expected (normal operation), if authorization is disabled, the Auth0 user id is extracted from the Authorization header and used to load the appropriate user from the database. If the Authorization header is not defined or the user is not available in the DB, a temporary admin account is created matching the previous functionality.

The following config parameters are required for these tests to run:
 
An AWS_PROFILE is required, or AWS access has been configured for your operating environment e.g. C:\Users\<username>\\.aws\credentials in Windows or Mac OS equivalent.

DISABLE_AUTH set to true to bypass auth checks and use users defined here.
DEFAULT_USAGE_PLAN_ID set to a valid usage plan id. AWS requires this to create an api key.
