### PR TITLE
Rename ApiKey#id; change LogController return type

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
@@ -79,7 +79,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
         return user != null &&
             user.apiKeys
                 .stream()
-                .anyMatch(apiKey -> apiKeyId.equals(apiKey.id));
+                .anyMatch(apiKey -> apiKeyId.equals(apiKey.keyId));
     }
 
     /**
@@ -100,7 +100,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
         }
         // FIXME Should an Api user be limited to one api key per usage plan (and perhaps stage)?
         ApiKey apiKey = ApiGatewayUtils.createApiKey(targetUser.id, usagePlanId);
-        if (apiKey == null || apiKey.id == null) {
+        if (apiKey == null || apiKey.keyId == null) {
             logMessageAndHalt(req,
                 HttpStatus.INTERNAL_SERVER_ERROR_500,
                 String.format("Unable to get AWS API key for user id (%s) and usage plan id (%s)", targetUser.id, usagePlanId),
@@ -137,7 +137,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
         boolean success = deleteApiKey(new ApiKey(apiKeyId));
         if (success) {
             // Delete api key from user and persist
-            targetUser.apiKeys.removeIf(apiKey -> apiKeyId.equals(apiKey.id));
+            targetUser.apiKeys.removeIf(apiKey -> apiKeyId.equals(apiKey.keyId));
             Persistence.apiUsers.replace(targetUser.id, targetUser);
             return Persistence.apiUsers.getById(targetUser.id);
         } else {

--- a/src/main/java/org/opentripplanner/middleware/models/ApiKey.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ApiKey.java
@@ -2,17 +2,18 @@ package org.opentripplanner.middleware.models;
 
 import com.amazonaws.services.apigateway.model.CreateApiKeyResult;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * Represents a subset of an AWS API Gateway API key.
  */
-public class ApiKey {
+public class ApiKey implements Serializable {
 
     /**
      * The api key id as provided by AWS API Gateway.
      */
-    public String id;
+    public String keyId;
 
     /**
      * The name given to the api key.
@@ -34,14 +35,14 @@ public class ApiKey {
      * Construct ApiKey from a single api key id.
      */
     public ApiKey(String apiKeyId) {
-        id = apiKeyId;
+        keyId = apiKeyId;
     }
 
     /**
      * Construct ApiKey from AWS api gateway create api key result.
      */
     public ApiKey(CreateApiKeyResult apiKeyResult) {
-        id = apiKeyResult.getId();
+        keyId = apiKeyResult.getId();
         name = apiKeyResult.getName();
         value = apiKeyResult.getValue();
     }
@@ -51,13 +52,13 @@ public class ApiKey {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ApiKey apiKey = (ApiKey) o;
-        return id.equals(apiKey.id) &&
+        return keyId.equals(apiKey.keyId) &&
             name.equals(apiKey.name) &&
             value.equals(apiKey.value);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, value);
+        return Objects.hash(keyId, name, value);
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/models/ApiUsageResult.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ApiUsageResult.java
@@ -7,10 +7,20 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Provides a wrapper around the AWS {@link GetUsageResult} class so that API usage per API key can be returned by
+ * {@link org.opentripplanner.middleware.controllers.api.LogController} along with a mapping of API key ID to the
+ * particular user it belongs to (if any). Note: this is not persisted to MongoDB (it's intended only for transient
+ * results refreshed from the AWS SDK on each request).
+ */
 public class ApiUsageResult implements Serializable {
     public final GetUsageResult result;
     public final Map<String, ApiUser> apiUsers;
 
+    /**
+     * Construct an instance from {@link GetUsageResult}. This iterates over the API key IDs found in the result and
+     * assigns the first {@link ApiUser} found for each keyId (there should only be one user for each key ID).
+     */
     public ApiUsageResult(GetUsageResult result) {
         this.result = result;
         // Map keyIds to their respective API users. This contains a null check for ApiUser because it's possible that

--- a/src/main/java/org/opentripplanner/middleware/models/ApiUsageResult.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ApiUsageResult.java
@@ -1,0 +1,25 @@
+package org.opentripplanner.middleware.models;
+
+import com.amazonaws.services.apigateway.model.GetUsageResult;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ApiUsageResult implements Serializable {
+    public final GetUsageResult result;
+    public final Map<String, ApiUser> apiUsers;
+
+    public ApiUsageResult(GetUsageResult result) {
+        this.result = result;
+        // Map keyIds to their respective API users. This contains a null check for ApiUser because it's possible that
+        // an API key exists, but is not assigned to a user, and we don't want to throw a NPE in this case.
+        this.apiUsers = result.getItems().keySet().stream()
+            .flatMap(keyId -> {
+                ApiUser userForKey = ApiUser.userForApiKey(keyId);
+                return userForKey != null ? Stream.of(Map.entry(keyId, userForKey)) : null;
+            })
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/src/main/java/org/opentripplanner/middleware/models/ApiUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ApiUser.java
@@ -34,6 +34,10 @@ public class ApiUser extends AbstractUser {
     /** The name of this user */
     public String name;
 
+    /**
+     * @return the first {@link ApiUser} found with an {@link ApiKey#keyId} in {@link #apiKeys} that matches the
+     * provided apiKeyId.
+     */
     public static ApiUser userForApiKey(String apiKeyId) {
         return Persistence.apiUsers.getOneFiltered(Filters.elemMatch("apiKeys", Filters.eq("keyId", apiKeyId)));
     }

--- a/src/main/java/org/opentripplanner/middleware/models/ApiUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ApiUser.java
@@ -1,5 +1,8 @@
 package org.opentripplanner.middleware.models;
 
+import com.mongodb.client.model.Filters;
+import org.opentripplanner.middleware.persistence.Persistence;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,4 +33,8 @@ public class ApiUser extends AbstractUser {
     // FIXME: Move this member to AbstractUser?
     /** The name of this user */
     public String name;
+
+    public static ApiUser userForApiKey(String apiKeyId) {
+        return Persistence.apiUsers.getOneFiltered(Filters.elemMatch("apiKeys", Filters.eq("keyId", apiKeyId)));
+    }
 }

--- a/src/main/java/org/opentripplanner/middleware/utils/ApiGatewayUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/ApiGatewayUtils.java
@@ -107,13 +107,13 @@ public class ApiGatewayUtils {
         try {
             DeleteApiKeyRequest deleteApiKeyRequest = new DeleteApiKeyRequest();
             deleteApiKeyRequest.setSdkRequestTimeout(SDK_REQUEST_TIMEOUT);
-            deleteApiKeyRequest.setApiKey(apiKey.id);
+            deleteApiKeyRequest.setApiKey(apiKey.keyId);
             gateway.deleteApiKey(deleteApiKeyRequest);
             LOG.debug("Deleting Api keys took {} msec", System.currentTimeMillis() - startTime);
         } catch (NotFoundException e) {
-            LOG.warn("Api key ({}) not found, unable to delete", apiKey.id, e);
+            LOG.warn("Api key ({}) not found, unable to delete", apiKey.keyId, e);
         } catch (Exception e) {
-            String message = String.format("Unable to delete api key (%s)", apiKey.id);
+            String message = String.format("Unable to delete api key (%s)", apiKey.keyId);
             BugsnagReporter.reportErrorToBugsnag(message, e);
             success = false;
         }
@@ -121,7 +121,8 @@ public class ApiGatewayUtils {
     }
 
     /**
-     * Get usage logs from AWS api gateway for a given key id, start and end date
+     * Get usage logs from AWS api gateway for a given key id, start and end date. Note: a null key id will return usage
+     * for all usage plans and API keys.
      */
     public static List<GetUsageResult> getUsageLogsForKey(String keyId, String startDate, String endDate) {
         long startTime = System.currentTimeMillis();
@@ -133,7 +134,6 @@ public class ApiGatewayUtils {
         List<GetUsageResult> usageResults = new ArrayList<>();
         for (UsagePlan usagePlan : usagePlansResult.getItems()) {
             GetUsageRequest getUsageRequest = new GetUsageRequest()
-                // TODO: Once third party dev accounts are fleshed out, this query param might go away?
                 .withKeyId(keyId)
                 .withStartDate(startDate)
                 .withEndDate(endDate)
@@ -162,7 +162,7 @@ public class ApiGatewayUtils {
 
         List<GetUsageResult> usageResults = new ArrayList<>();
         for (ApiKey apiKey : apiKeys) {
-            usageResults.addAll(getUsageLogsForKey(apiKey.id, startDate, endDate));
+            usageResults.addAll(getUsageLogsForKey(apiKey.keyId, startDate, endDate));
         }
 
         LOG.debug("Retrieving usage logs for a list of api keys took {} msec", System.currentTimeMillis() - startTime);

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -79,7 +79,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
         // refresh API key
         ApiUser userFromDb = Persistence.apiUsers.getById(apiUser.id);
-        LOG.info("API user successfully created API key id {}", userFromResponse.apiKeys.get(0).id);
+        LOG.info("API user successfully created API key id {}", userFromResponse.apiKeys.get(0).keyId);
         assertEquals(userFromDb.apiKeys, userFromResponse.apiKeys);
     }
 
@@ -94,7 +94,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
         // refresh API key
         ApiUser userFromDb = Persistence.apiUsers.getById(apiUser.id);
-        LOG.info("Admin user successfully created API key id {}", userFromResponse.apiKeys.get(0).id);
+        LOG.info("Admin user successfully created API key id {}", userFromResponse.apiKeys.get(0).keyId);
         assertEquals(userFromDb.apiKeys, userFromResponse.apiKeys);
     }
 
@@ -106,7 +106,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         assumeTrue(getBooleanEnvVar("RUN_E2E"));
         ensureAtLeastOneApiKeyIsAvailable();
         // delete key
-        String keyId = apiUser.apiKeys.get(0).id;
+        String keyId = apiUser.apiKeys.get(0).keyId;
         HttpResponse<String> response = deleteApiKeyRequest(apiUser.id, keyId, apiUser.auth0UserId);
         assertEquals(200, response.statusCode());
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
@@ -125,7 +125,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         assumeTrue(getBooleanEnvVar("RUN_E2E"));
         ensureAtLeastOneApiKeyIsAvailable();
         // delete key
-        String keyId = apiUser.apiKeys.get(0).id;
+        String keyId = apiUser.apiKeys.get(0).keyId;
         HttpResponse<String> response = deleteApiKeyRequest(apiUser.id, keyId, adminUser.auth0UserId);
         assertEquals(200, response.statusCode());
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);


### PR DESCRIPTION
### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

This PR 
- changes `ApiKey#id` to `ApiKey#keyId` (Mongo doesn't seem to like queries that try to reference `id`) and
- modifies the return type of LogController so that ApiUsers can be more easily associated with the usage for different key ids.