### PR TITLE
Create key w better name; restrict key deletion

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/utils/CreateApiKeyException.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/CreateApiKeyException.java
@@ -1,0 +1,19 @@
+package org.opentripplanner.middleware.utils;
+
+import org.opentripplanner.middleware.models.ApiUser;
+
+/**
+ * This is the exception for issues when creating an API key for an {@link ApiUser}.
+ */
+public class CreateApiKeyException extends Exception {
+    public CreateApiKeyException(String userId, String usagePlanId, Exception cause) {
+        super(
+            String.format(
+                "Unable to create API key for user id (%s) and usage plan id (%s)",
+                userId,
+                usagePlanId
+            ),
+            cause
+        );
+    }
+}

--- a/src/main/java/org/opentripplanner/middleware/utils/CreateApiKeyException.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/CreateApiKeyException.java
@@ -9,9 +9,10 @@ public class CreateApiKeyException extends Exception {
     public CreateApiKeyException(String userId, String usagePlanId, Exception cause) {
         super(
             String.format(
-                "Unable to create API key for user id (%s) and usage plan id (%s)",
+                "Unable to create API key for user id (%s) and usage plan id (%s) (cause: %s)",
                 userId,
-                usagePlanId
+                usagePlanId,
+                cause.toString()
             ),
             cause
         );

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -144,7 +144,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         apiUser = Persistence.apiUsers.getById(apiUser.id);
 
         if (apiUser.apiKeys.isEmpty()) {
-            ApiKey apiKey = ApiGatewayUtils.createApiKey(apiUser.id, DEFAULT_USAGE_PLAN_ID);
+            ApiKey apiKey = ApiGatewayUtils.createApiKey(apiUser, DEFAULT_USAGE_PLAN_ID);
             apiUser.apiKeys.add(apiKey);
             // Save update so the API key delete endpoint is aware of the new API key.
             Persistence.apiUsers.replace(apiUser.id, apiUser);

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.middleware;
 
+import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -76,7 +77,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
     public void canCreateApiKeyForSelf() {
         assumeTrue(getBooleanEnvVar("RUN_E2E"));
         HttpResponse<String> response = createApiKeyRequest(apiUser.id, apiUser.auth0UserId);
-        assertEquals(200, response.statusCode());
+        assertEquals(HttpStatus.OK_200, response.statusCode());
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
         // refresh API key
         ApiUser userFromDb = Persistence.apiUsers.getById(apiUser.id);
@@ -91,7 +92,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
     public void adminCanCreateApiKeyForApiUser() {
         assumeTrue(getBooleanEnvVar("RUN_E2E"));
         HttpResponse<String> response = createApiKeyRequest(apiUser.id, adminUser.auth0UserId);
-        assertEquals(200, response.statusCode());
+        assertEquals(HttpStatus.OK_200, response.statusCode());
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
         // refresh API key
         ApiUser userFromDb = Persistence.apiUsers.getById(apiUser.id);
@@ -100,22 +101,23 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
     }
 
     /**
-     * Ensure that an {@link ApiUser} can delete an API key for self.
+     * Ensure that an {@link ApiUser} is unable to delete an API key for self (to prevent delete/create abuse of request
+     * limits).
      */
     @Test
-    public void canDeleteApiKeyForSelf() {
+    public void cannotDeleteApiKeyForSelf() {
         assumeTrue(getBooleanEnvVar("RUN_E2E"));
-        ensureAtLeastOneApiKeyIsAvailable();
+        ensureApiKeyExists();
+        int initialKeyCount = apiUser.apiKeys.size();
         // delete key
         String keyId = apiUser.apiKeys.get(0).keyId;
         HttpResponse<String> response = deleteApiKeyRequest(apiUser.id, keyId, apiUser.auth0UserId);
-        assertEquals(200, response.statusCode());
-        ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
-        assertTrue(userFromResponse.apiKeys.isEmpty());
-        LOG.info("API user successfully deleted API key id {}", keyId);
-        // refresh API key
+        int status = response.statusCode();
+        assertEquals(HttpStatus.FORBIDDEN_403, status);
+        LOG.info("Delete key request status: {}", status);
+        // Ensure key count is the same after delete request.
         ApiUser userFromDb = Persistence.apiUsers.getById(apiUser.id);
-        assertTrue(userFromDb.apiKeys.isEmpty());
+        assertEquals(initialKeyCount, userFromDb.apiKeys.size());
     }
 
     /**
@@ -124,11 +126,11 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
     @Test
     public void adminCanDeleteApiKeyForApiUser() {
         assumeTrue(getBooleanEnvVar("RUN_E2E"));
-        ensureAtLeastOneApiKeyIsAvailable();
+        ensureApiKeyExists();
         // delete key
         String keyId = apiUser.apiKeys.get(0).keyId;
         HttpResponse<String> response = deleteApiKeyRequest(apiUser.id, keyId, adminUser.auth0UserId);
-        assertEquals(200, response.statusCode());
+        assertEquals(HttpStatus.OK_200, response.statusCode());
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.body(), ApiUser.class);
         assertTrue(userFromResponse.apiKeys.isEmpty());
         // refresh API key
@@ -140,21 +142,24 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
     /**
      * Make sure that at least one API key exists.
      */
-    private void ensureAtLeastOneApiKeyIsAvailable() {
+    private boolean ensureApiKeyExists() {
         // Refresh API keys.
         apiUser = Persistence.apiUsers.getById(apiUser.id);
-
         if (apiUser.apiKeys.isEmpty()) {
-            ApiKey apiKey;
+            // Create key if there are none.
             try {
-                apiKey = ApiGatewayUtils.createApiKey(apiUser, DEFAULT_USAGE_PLAN_ID);
+                ApiKey apiKey = ApiGatewayUtils.createApiKey(apiUser, DEFAULT_USAGE_PLAN_ID);
                 apiUser.apiKeys.add(apiKey);
                 // Save update so the API key delete endpoint is aware of the new API key.
                 Persistence.apiUsers.replace(apiUser.id, apiUser);
+                LOG.info("Successfully created API key");
+                return true;
             } catch (CreateApiKeyException e) {
                 LOG.error("Could not create API key", e);
+                return false;
             }
         }
+        return true;
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -9,6 +9,7 @@ import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.persistence.PersistenceUtil;
 import org.opentripplanner.middleware.utils.ApiGatewayUtils;
+import org.opentripplanner.middleware.utils.CreateApiKeyException;
 import org.opentripplanner.middleware.utils.HttpUtils;
 import org.opentripplanner.middleware.utils.JsonUtils;
 import org.slf4j.Logger;
@@ -144,10 +145,15 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         apiUser = Persistence.apiUsers.getById(apiUser.id);
 
         if (apiUser.apiKeys.isEmpty()) {
-            ApiKey apiKey = ApiGatewayUtils.createApiKey(apiUser, DEFAULT_USAGE_PLAN_ID);
-            apiUser.apiKeys.add(apiKey);
-            // Save update so the API key delete endpoint is aware of the new API key.
-            Persistence.apiUsers.replace(apiUser.id, apiUser);
+            ApiKey apiKey;
+            try {
+                apiKey = ApiGatewayUtils.createApiKey(apiUser, DEFAULT_USAGE_PLAN_ID);
+                apiUser.apiKeys.add(apiKey);
+                // Save update so the API key delete endpoint is aware of the new API key.
+                Persistence.apiUsers.replace(apiUser.id, apiUser);
+            } catch (CreateApiKeyException e) {
+                LOG.error("Could not create API key", e);
+            }
         }
     }
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds a couple of more changes to API Key management:
- restricts key deletion to admin users -- the thinking here is that we may not want people to constantly churn through API keys. That could cause us/admins to lose track of API usage as they're deleted.
- creates keys with more descriptive names (this way it's easier to track back the key in the AWS console)