### PR TITLE
Refactor api user check

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -279,7 +279,8 @@ public class Auth0Connection {
     }
 
     /**
-     * Confirm that the user's actions are on their items if not admin.
+     * Confirm that the user's actions are on their items if not admin. In the case of an Api user confirm that the
+     * user's actions, on Otp users, are Otp users they created initially.
      */
     public static void isAuthorized(String userId, Request request) {
         RequestingUser requestingUser = getUserFromRequest(request);
@@ -287,7 +288,7 @@ public class Auth0Connection {
         if (requestingUser.adminUser != null) {
             return;
         }
-        // If userId is defined, it must be set to a value associated with the a user.
+        // If userId is defined, it must be set to a value associated with a user.
         if (userId != null) {
             if (requestingUser.otpUser != null && requestingUser.otpUser.id.equals(userId)) {
                 // Otp user requesting their item.
@@ -298,7 +299,7 @@ public class Auth0Connection {
                 return;
             }
             if (requestingUser.apiUser != null) {
-                // Api user potentially requesting an item on behave of an Otp user they created.
+                // Api user potentially requesting an item on behalf of an Otp user they created.
                 OtpUser otpUser = Persistence.otpUsers.getById(userId);
                 if (otpUser != null && requestingUser.apiUser.id.equals(otpUser.applicationId)) {
                     return;

--- a/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
@@ -16,17 +16,17 @@ import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthHeaderPr
  * User profile that is attached to an HTTP request.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Auth0UserProfile {
-    public final OtpUser otpUser;
-    public final ApiUser apiUser;
-    public final AdminUser adminUser;
-    public final String auth0UserId;
+public class RequestingUser {
+    public OtpUser otpUser;
+    public ApiUser apiUser;
+    public AdminUser adminUser;
+    public String auth0UserId;
 
     /**
      * Constructor is only used for creating a test user. If an Auth0 user id is provided check persistence for matching
      * user else create default user.
      */
-    private Auth0UserProfile(String auth0UserId) {
+    private RequestingUser(String auth0UserId) {
         if (auth0UserId == null) {
             this.auth0UserId = "user_id:string";
             otpUser = new OtpUser();
@@ -44,7 +44,7 @@ public class Auth0UserProfile {
     /**
      * Create a user profile from the request's JSON web token. Check persistence for stored user
      */
-    public Auth0UserProfile(DecodedJWT jwt) {
+    public RequestingUser(DecodedJWT jwt) {
         this.auth0UserId = jwt.getClaim("sub").asString();
         Bson withAuth0UserId = eq("auth0UserId", auth0UserId);
         otpUser = Persistence.otpUsers.getOneFiltered(withAuth0UserId);
@@ -52,17 +52,25 @@ public class Auth0UserProfile {
         apiUser = Persistence.apiUsers.getOneFiltered(withAuth0UserId);
     }
 
+    public RequestingUser(String apiKey, boolean isApiUser) {
+        apiUser = getApiUserForApiKey(apiKey);
+    }
+
+    private ApiUser getApiUserForApiKey(String apiKey) {
+        return Persistence.apiUsers.getOneFiltered();
+    }
+
     /**
      * Utility method for creating a test user. If a Auth0 user Id is defined within the Authorization header param
      * define test user based on this.
      */
-    static Auth0UserProfile createTestUser(Request req) {
+    static RequestingUser createTestUser(Request req) {
         String auth0UserId = null;
         if (isAuthHeaderPresent(req)) {
             // If the auth header has been provided get the Auth0 user id from it. This is different from normal
             // operation as the parameter will only contain the Auth0 user id and not "Bearer token".
             auth0UserId = req.headers("Authorization");
         }
-        return new Auth0UserProfile(auth0UserId);
+        return new RequestingUser(auth0UserId);
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -8,6 +8,7 @@ import org.opentripplanner.middleware.auth.Auth0Connection;
 import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.auth.Auth0Users;
 import org.opentripplanner.middleware.models.AbstractUser;
+import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.persistence.TypedPersistence;
 import org.opentripplanner.middleware.utils.JsonUtils;
@@ -105,7 +106,7 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
         RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         // TODO: If MOD UI is to be an ApiUser, we may want to do an additional check here to determine if this is a
         //  first-party API user (MOD UI) or third party.
-        if (requestingUser.apiUser != null && user instanceof OtpUser) {
+        if (requestingUser.apiUser != null && user instanceof OtpUser || user instanceof ApiUser) {
             // Do not create Auth0 account for OtpUsers created on behalf of third party API users.
             return user;
         } else {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AdminUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AdminUserController.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.middleware.controllers.api;
 
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.models.AdminUser;
 import org.opentripplanner.middleware.persistence.Persistence;
 
@@ -18,7 +18,7 @@ public class AdminUserController extends AbstractUserController<AdminUser> {
     }
 
     @Override
-    protected AdminUser getUserProfile(Auth0UserProfile profile) {
+    protected AdminUser getUserProfile(RequestingUser profile) {
         return profile.adminUser;
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
@@ -3,7 +3,7 @@ package org.opentripplanner.middleware.controllers.api;
 import com.beerboy.ss.ApiEndpoint;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.models.ApiKey;
 import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.persistence.Persistence;
@@ -90,7 +90,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
      */
     private ApiUser createApiKeyForApiUser(Request req, Response res) {
         ApiUser targetUser = getApiUser(req);
-        Auth0UserProfile requestingUser = Auth0Connection.getUserFromRequest(req);
+        RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         String usagePlanId = req.queryParamOrDefault("usagePlanId", DEFAULT_USAGE_PLAN_ID);
         // If requester is not an admin user, force the usage plan ID to the default and enforce key limit. A non-admin
         // user should not be able to create an API key for any usage plan.
@@ -120,7 +120,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
      * Delete an api key from a given user's list of api keys (if present) and from AWS api gateway.
      */
     private ApiUser deleteApiKeyForApiUser(Request req, Response res) {
-        Auth0UserProfile requestingUser = Auth0Connection.getUserFromRequest(req);
+        RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         // Do not permit key deletion unless user is an admin.
         if (!isUserAdmin(requestingUser)) {
             logMessageAndHalt(req, HttpStatus.FORBIDDEN_403, "Must be an admin to delete an API key.");
@@ -155,7 +155,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
     }
 
     @Override
-    protected ApiUser getUserProfile(Auth0UserProfile profile) {
+    protected ApiUser getUserProfile(RequestingUser profile) {
         return profile.apiUser;
     }
 
@@ -199,7 +199,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
      * Get an Api user from Mongo DB based on the provided user id. Make sure user is admin or managing self.
      */
     private static ApiUser getApiUser(Request req) {
-        Auth0UserProfile requestingUser = Auth0Connection.getUserFromRequest(req);
+        RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         String userId = HttpUtils.getRequiredParamFromRequest(req, ID_PARAM);
         ApiUser apiUser = Persistence.apiUsers.getById(userId);
         if (apiUser == null) {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/LogController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/LogController.java
@@ -5,7 +5,7 @@ import com.beerboy.ss.SparkSwagger;
 import com.beerboy.ss.rest.Endpoint;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.models.ApiKey;
 import org.opentripplanner.middleware.models.ApiUsageResult;
 import org.opentripplanner.middleware.utils.ApiGatewayUtils;
@@ -80,7 +80,7 @@ public class LogController implements Endpoint {
     private static List<ApiUsageResult> getUsageLogs(Request req, Response res) {
         // Get list of API keys (if present) from request.
         List<ApiKey> apiKeys = getApiKeyIdsFromRequest(req);
-        Auth0UserProfile requestingUser = Auth0Connection.getUserFromRequest(req);
+        RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         // If the user is not an admin, the list of API keys is defaulted to their keys.
         if (!isUserAdmin(requestingUser)) {
             if (requestingUser.apiUser == null) {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -4,7 +4,7 @@ import com.beerboy.ss.SparkSwagger;
 import com.beerboy.ss.rest.Endpoint;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.models.TripRequest;
 import org.opentripplanner.middleware.models.TripSummary;
 import org.opentripplanner.middleware.otp.OtpDispatcher;
@@ -25,7 +25,6 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthHeaderPresent;
 import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
-import static org.opentripplanner.middleware.otp.OtpDispatcher.OTP_API_ROOT;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
@@ -132,7 +131,7 @@ public class OtpRequestProcessor implements Endpoint {
         long tripStorageStartTime = DateTimeUtils.currentTimeMillis();
 
         Auth0Connection.checkUser(request);
-        Auth0UserProfile profile = Auth0Connection.getUserFromRequest(request);
+        RequestingUser profile = Auth0Connection.getUserFromRequest(request);
 
         final boolean storeTripHistory = profile != null && profile.otpUser != null && profile.otpUser.storeTripHistory;
         // only save trip details if the user has given consent and a response from OTP is provided

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
@@ -5,7 +5,7 @@ import com.twilio.rest.verify.v2.service.Verification;
 import com.twilio.rest.verify.v2.service.VerificationCheck;
 import org.eclipse.jetty.http.HttpStatus;
 import com.mongodb.client.model.Filters;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.bugsnag.BugsnagReporter;
 import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.models.OtpUser;
@@ -80,7 +80,7 @@ public class OtpUserController extends AbstractUserController<OtpUser> {
     }
 
     @Override
-    protected OtpUser getUserProfile(Auth0UserProfile profile) {
+    protected OtpUser getUserProfile(RequestingUser profile) {
         return profile.otpUser;
     }
 

--- a/src/main/java/org/opentripplanner/middleware/models/AbstractUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/AbstractUser.java
@@ -2,7 +2,7 @@ package org.opentripplanner.middleware.models;
 
 import com.auth0.exception.Auth0Exception;
 import org.opentripplanner.middleware.auth.Auth0Connection;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.auth.Permission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +44,7 @@ public abstract class AbstractUser extends Model {
      * permissions) or if the requesting user has permission to manage the entity type.
      */
     @Override
-    public boolean canBeManagedBy(Auth0UserProfile user) {
+    public boolean canBeManagedBy(RequestingUser user) {
         // If the user is attempting to update someone else's profile, they must be an admin.
         boolean isManagingSelf = this.auth0UserId.equals(user.auth0UserId);
         if (isManagingSelf) {

--- a/src/main/java/org/opentripplanner/middleware/models/AbstractUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/AbstractUser.java
@@ -30,6 +30,13 @@ public abstract class AbstractUser extends Model {
      * value, so the stored user will contain the value from Auth0 (e.g., "auth0|abcd1234").
      */
     public String auth0UserId = UUID.randomUUID().toString();
+
+    /**
+     * Random api key for testing.
+     */
+    public String apiKey = UUID.randomUUID().toString();
+
+
     /** Whether a user is also a Data Tools user */
     public boolean isDataToolsUser;
     /**

--- a/src/main/java/org/opentripplanner/middleware/models/AdminUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/AdminUser.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.middleware.models;
 
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.auth.Permission;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.slf4j.Logger;
@@ -31,7 +31,7 @@ public class AdminUser extends AbstractUser {
      * TODO: Change to application admin?
      */
     @Override
-    public boolean canBeCreatedBy(Auth0UserProfile user) {
+    public boolean canBeCreatedBy(RequestingUser user) {
         return isUserAdmin(user);
     }
 

--- a/src/main/java/org/opentripplanner/middleware/models/Model.java
+++ b/src/main/java/org/opentripplanner/middleware/models/Model.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.middleware.models;
 
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 
 import java.io.Serializable;
 import java.util.Date;
@@ -27,7 +27,7 @@ public class Model implements Serializable {
      * This is a basic authorization check for any entity to determine if a user can create the entity. By default any
      * user can create any entity. This method should be overridden if there are more restrictions needed.
      */
-    public boolean canBeCreatedBy(Auth0UserProfile user) {
+    public boolean canBeCreatedBy(RequestingUser user) {
         return true;
     }
 
@@ -35,7 +35,7 @@ public class Model implements Serializable {
      * This is a basic authorization check for any entity to determine if a user can manage it. This method
      * should be overridden in subclasses in order to provide more fine-grained checks.
      */
-    public boolean canBeManagedBy(Auth0UserProfile user) {
+    public boolean canBeManagedBy(RequestingUser user) {
         // TODO: Check if user has application administrator permission?
         return isUserAdmin(user);
     }

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.middleware.models;
 
 import org.bson.conversions.Bson;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.auth.Permission;
 import org.opentripplanner.middleware.otp.OtpDispatcherResponse;
 import org.opentripplanner.middleware.otp.response.Itinerary;
@@ -179,7 +179,7 @@ public class MonitoredTrip extends Model {
     }
 
     @Override
-    public boolean canBeCreatedBy(Auth0UserProfile profile) {
+    public boolean canBeCreatedBy(RequestingUser profile) {
         OtpUser otpUser = profile.otpUser;
         if (userId == null) {
             if (otpUser == null) {
@@ -200,7 +200,7 @@ public class MonitoredTrip extends Model {
      * Confirm that the requesting user has the required permissions
      */
     @Override
-    public boolean canBeManagedBy(Auth0UserProfile user) {
+    public boolean canBeManagedBy(RequestingUser user) {
         // This should not be possible, but return false on a null userId just in case.
         if (userId == null) return false;
         // If the user is attempting to update someone else's monitored trip, they must be admin.

--- a/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
@@ -69,13 +69,12 @@ public class OtpUser extends AbstractUser {
             }
         }
 
-        if (deleteAuth0User) {
+        // Only attempt to delete Auth0 user if Otp user is not assigned to third party.
+        if (deleteAuth0User && applicationId.isEmpty()) {
             boolean auth0UserDeleted = super.delete();
             if (!auth0UserDeleted) {
                 LOG.warn("Aborting user deletion for {}", this.email);
-                // FIXME: This fails if an Api user is attempting to delete an Otp user they created. No Auth0 account
-                //  would have been created for this user.
-//                return false;
+                return false;
             }
         }
 

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.TestUtils.isEndToEnd;
 import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedRequest;
+import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Connection.setAuthDisabled;
 import static org.opentripplanner.middleware.controllers.api.ApiUserController.DEFAULT_USAGE_PLAN_ID;
 
@@ -39,6 +40,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
     private static final Logger LOG = LoggerFactory.getLogger(ApiKeyManagementTest.class);
     private static ApiUser apiUser;
     private static AdminUser adminUser;
+    private static boolean prevAuthState;
 
     /**
      * Create an {@link ApiUser} and an {@link AdminUser} prior to unit tests
@@ -48,6 +50,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         assumeTrue(isEndToEnd);
         // TODO: It might be useful to allow this to run without DISABLE_AUTH set to true (in an end-to-end environment
         //  using real tokens from Auth0.
+        prevAuthState = isAuthDisabled();
         setAuthDisabled(true);
         // Load config before checking if tests should run.
         OtpMiddlewareTest.setUp();
@@ -63,8 +66,9 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         assumeTrue(isEndToEnd);
         // refresh API key(s)
         apiUser = Persistence.apiUsers.getById(apiUser.id);
-        apiUser.delete(false);
+        apiUser.delete();
         Persistence.adminUsers.removeById(adminUser.id);
+        setAuthDisabled(prevAuthState);
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -3,7 +3,7 @@ package org.opentripplanner.middleware;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.models.AbstractUser;
 import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.otp.OtpDispatcherResponse;
@@ -54,7 +54,7 @@ public class TestUtils {
     }
 
     /**
-     * Send request to provided URL placing the Auth0 user id in the headers so that {@link Auth0UserProfile} can check
+     * Send request to provided URL placing the Auth0 user id in the headers so that {@link RequestingUser} can check
      * the database for a matching user. Returns the response.
      */
     public static HttpResponse<String> mockAuthenticatedRequest(String path, AbstractUser requestingUser, HttpUtils.REQUEST_METHOD requestMethod) {
@@ -107,7 +107,7 @@ public class TestUtils {
     }
 
     /**
-     * Send request to provided URL placing the Auth0 user id in the headers so that {@link Auth0UserProfile} can check
+     * Send request to provided URL placing the Auth0 user id in the headers so that {@link RequestingUser} can check
      * the database for a matching user. Returns the response.
      */
     public static HttpResponse<String> mockAuthenticatedPost(String path, AbstractUser requestingUser, String body) {


### PR DESCRIPTION
### Checklist

- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

First off, this is very much WIP. I was hoping that I wouldn't have to touch many classes, but it's ended up being a few. The initial focus was to satisfy the ApiUserFlowTest unit tests based on authenticating with an API key instead of Auth0. The API key authentication mirrors that of Auth0 and expects an 'x-api-key' header value. I think I have removed any Auth0 stuff that is related to Api users (no Auth0 account creating/deleting), but by no means done exhaustive testing.

If an Otp user created by an Api user attempts to access the otp-middleware it will fail because auth will go down the Auth0 route.

1) Does an API key represent the key id or value? The two appear to be interchangeable at the moment so this needs addressing.
2) I've made the assumption that if an Otp user does not have an application Id then they will have an Auth0 id when it comes to deletion, this might not be correct?

Still need to consider:

For monitored trips, third pary users cannot receive notifications via SMS/email (we need to add an HTTP endpoint whereby API users can check notification status for a monitored trip on behalf of this user class).





