### PR TITLE
Refactor api user check auth0

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
+++ b/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
@@ -16,7 +16,6 @@ import org.opentripplanner.middleware.controllers.api.TripHistoryController;
 import org.opentripplanner.middleware.docs.PublicApiDocGenerator;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.tripMonitor.jobs.MonitorAllTripsJob;
-import org.opentripplanner.middleware.utils.ConfigUtils;
 import org.opentripplanner.middleware.utils.HttpUtils;
 import org.opentripplanner.middleware.utils.Scheduler;
 import org.slf4j.Logger;
@@ -32,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.opentripplanner.middleware.controllers.api.ApiUserController.API_USER_PATH;
 import static org.opentripplanner.middleware.controllers.api.ApiUserController.AUTHENTICATE_PATH;
+import static org.opentripplanner.middleware.utils.ConfigUtils.loadConfig;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
@@ -45,7 +45,7 @@ public class OtpMiddlewareMain {
 
     public static void main(String[] args) throws IOException, InterruptedException {
         // Load configuration.
-        ConfigUtils.loadConfig(args);
+        loadConfig(args);
 
         // Connect to MongoDB.
         Persistence.initialize();

--- a/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
+++ b/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
@@ -131,9 +131,11 @@ public class OtpMiddlewareMain {
                 return "OK";
             });
 
-        // Security checks for admin and /secure/ endpoints.
+        // Security checks for admin and /secure/ endpoints. Excluding /authenticate so that API users can obtain a
+        // bearer token to authenticate against all other /secure/ endpoints.
         spark.before(API_PREFIX + "/secure/*", ((request, response) -> {
-            if (!request.requestMethod().equals("OPTIONS")) Auth0Connection.checkUser(request);
+            if (!request.requestMethod().equals("OPTIONS") && !request.pathInfo().endsWith("/authenticate"))
+                Auth0Connection.checkUser(request);
         }));
         spark.before(API_PREFIX + "admin/*", ((request, response) -> {
             if (!request.requestMethod().equals("OPTIONS")) {

--- a/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
+++ b/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
@@ -134,8 +134,9 @@ public class OtpMiddlewareMain {
         // Security checks for admin and /secure/ endpoints. Excluding /authenticate so that API users can obtain a
         // bearer token to authenticate against all other /secure/ endpoints.
         spark.before(API_PREFIX + "/secure/*", ((request, response) -> {
-            if (!request.requestMethod().equals("OPTIONS") && !request.pathInfo().endsWith("/authenticate"))
+            if (!request.requestMethod().equals("OPTIONS") && !request.pathInfo().endsWith("/authenticate")) {
                 Auth0Connection.checkUser(request);
+            }
         }));
         spark.before(API_PREFIX + "admin/*", ((request, response) -> {
             if (!request.requestMethod().equals("OPTIONS")) {

--- a/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
+++ b/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.opentripplanner.middleware.controllers.api.ApiUserController.API_USER_PATH;
+import static org.opentripplanner.middleware.controllers.api.ApiUserController.AUTHENTICATE_PATH;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
@@ -134,7 +136,7 @@ public class OtpMiddlewareMain {
         // Security checks for admin and /secure/ endpoints. Excluding /authenticate so that API users can obtain a
         // bearer token to authenticate against all other /secure/ endpoints.
         spark.before(API_PREFIX + "/secure/*", ((request, response) -> {
-            if (!request.requestMethod().equals("OPTIONS") && !request.pathInfo().endsWith("/authenticate")) {
+            if (!request.requestMethod().equals("OPTIONS") && !request.pathInfo().endsWith(API_USER_PATH + AUTHENTICATE_PATH)) {
                 Auth0Connection.checkUser(request);
             }
         }));

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -75,7 +75,7 @@ public class Auth0Connection {
                     LOG.info("New user is creating self. OK to proceed without existing user object for auth0UserId");
                 } else {
                     // Otherwise, if no valid user is found, halt the request.
-                    logMessageAndHalt(req, HttpStatus.NOT_FOUND_404, "User is unknown to Auth0 tenant.");
+                    logMessageAndHalt(req, HttpStatus.NOT_FOUND_404, "No user found in database associated with the provided auth token.");
                 }
             }
             // The user attribute is used on the server side to check user permissions and does not have all of the

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -144,11 +144,12 @@ public class Auth0Connection {
     }
 
     /**
-     * Check that an {@link ApiUser} is linked to an Api key.
+     * Check that the API key used in the incoming request is associated with the matching {@link ApiUser} (which is
+     * determined from the Authorization header).
      */
     //FIXME: Move this check into existing auth checks so it would be carried out automatically prior to any
     // business logic. Consider edge cases where a user can be both an API user and OTP user.
-    public static void linkApiKeyToApiUser(Request req) {
+    public static void ensureApiUserHasApiKey(Request req) {
         RequestingUser requestingUser = getUserFromRequest(req);
         String apiKeyValueFromHeader = req.headers("x-api-key");
         if (requestingUser.apiUser == null ||

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -279,7 +279,8 @@ public class Auth0Connection {
     }
 
     /**
-     * Confirm that the user's actions are on their items if not admin.
+     * Confirm that the user's actions are on their items if not admin. In the case of an Api user confirm that the
+     * user's actions, on Otp users, are Otp users they created initially.
      */
     public static void isAuthorized(String userId, Request request) {
         RequestingUser requestingUser = getUserFromRequest(request);
@@ -287,7 +288,7 @@ public class Auth0Connection {
         if (requestingUser.adminUser != null) {
             return;
         }
-        // If userId is defined, it must be set to a value associated with the a user.
+        // If userId is defined, it must be set to a value associated with a user.
         if (userId != null) {
             if (requestingUser.otpUser != null && requestingUser.otpUser.id.equals(userId)) {
                 // Otp user requesting their item.
@@ -298,7 +299,7 @@ public class Auth0Connection {
                 return;
             }
             if (requestingUser.apiUser != null) {
-                // Api user potentially requesting an item on behave of an Otp user they created.
+                // Api user potentially requesting an item on behalf of an Otp user they created.
                 OtpUser otpUser = Persistence.otpUsers.getById(userId);
                 if (otpUser != null && requestingUser.apiUser.id.equals(otpUser.applicationId)) {
                     return;

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -34,7 +34,6 @@ import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
  * This handles verifying the Auth0 token passed in the auth header (e.g., Authorization: Bearer MY_TOKEN of Spark HTTP
  * requests.
  */
-// TODO: Come up with a name that covers Auth0 and apiKey auth... could just remove the '0'?!
 public class Auth0Connection {
     private static final Logger LOG = LoggerFactory.getLogger(Auth0Connection.class);
     private static JWTVerifier verifier;
@@ -59,19 +58,6 @@ public class Auth0Connection {
             addUserToRequest(req, RequestingUser.createTestUser(req));
             return;
         }
-
-        // API user authenticated by API key
-        String apiKey = getApiKeyFromRequest(req);
-        if (apiKey != null) {
-            RequestingUser requestingUser = new RequestingUser(apiKey);
-            if (!isValidUser(requestingUser)) {
-                // Otherwise, if no valid user is found, halt the request.
-                logMessageAndHalt(req, HttpStatus.NOT_FOUND_404, "API key auth - Unknown user.");
-            }
-            addUserToRequest(req, requestingUser);
-            return;
-        }
-
         // Admin and OTP users authenticated by Bearer token
         String token = getTokenFromRequest(req);
         // Handle getting the verifier outside of the below verification try/catch, which is intended to catch issues
@@ -183,24 +169,6 @@ public class Auth0Connection {
         return req.attribute("user");
     }
 
-
-    /**
-     * Extract API key from Spark HTTP request (in Authorization header).
-     */
-    private static String getApiKeyFromRequest(Request req) {
-        if (!isApiKeyHeaderPresent(req)) {
-            // x-api-key header not present, fallback onto Auth0 check.
-            return null;
-        }
-
-        final String apiKey = req.headers("x-api-key");
-        if (apiKey == null) {
-            logMessageAndHalt(req, 401, "Could not find api key");
-        }
-
-        return apiKey;
-    }
-
     /**
      * Extract JWT token from Spark HTTP request (in Authorization header).
      */
@@ -308,5 +276,4 @@ public class Auth0Connection {
         }
         logMessageAndHalt(request, HttpStatus.FORBIDDEN_403, "Unauthorized access.");
     }
-
 }

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -73,7 +73,7 @@ public class Auth0Connection {
                     LOG.info("New user is creating self. OK to proceed without existing user object for auth0UserId");
                 } else {
                     // Otherwise, if no valid user is found, halt the request.
-                    JsonUtils.logMessageAndHalt(req, HttpStatus.NOT_FOUND_404, "Auth0 auth - Unknown user.");
+                    JsonUtils.logMessageAndHalt(req, HttpStatus.NOT_FOUND_404, "User is unknown to Auth0 tenant.");
                 }
             }
             // The user attribute is used on the server side to check user permissions and does not have all of the
@@ -244,7 +244,7 @@ public class Auth0Connection {
         }
         // If userId is defined, it must be set to a value associated with a user.
         if (userId != null) {
-            if (requestingUser.isFirstPartyUser() && requestingUser.otpUser.id.equals(userId)) {
+            if (requestingUser.otpUser != null && requestingUser.otpUser.id.equals(userId)) {
                 // Otp user requesting their item.
                 return;
             }

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -222,10 +222,19 @@ public class Auth0Connection {
     }
 
     /**
-     * Override the current {@link #authDisabled} value.
+     * Override the current {@link #authDisabled} value. This is used principally for setting up test environments that
+     * require auth to be disabled.
      */
     public static void setAuthDisabled(boolean authDisabled) {
         Auth0Connection.authDisabled = authDisabled;
+    }
+
+    /**
+     * Restore default {@link #authDisabled} value. This is used principally for tearing down test environments that
+     * require auth to be disabled.
+     */
+    public static void restoreDefaultAuthDisabled() {
+        setAuthDisabled(getDefaultAuthDisabled());
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -142,10 +142,11 @@ public class Auth0Connection {
     }
 
     /**
-     * Check if the incoming user is an admin user
+     * Check if the incoming user is an admin user. To be classed as an admin user, the user must not be any other user
+     * type.
      */
     public static boolean isUserAdmin(RequestingUser user) {
-        return user != null && user.adminUser != null;
+        return user != null && user.adminUser != null && user.apiUser == null && user.otpUser == null;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -244,18 +244,18 @@ public class Auth0Connection {
         }
         // If userId is defined, it must be set to a value associated with a user.
         if (userId != null) {
-            if (requestingUser.otpUser != null && requestingUser.otpUser.id.equals(userId)) {
+            if (requestingUser.isFirstPartyUser() && requestingUser.otpUser.id.equals(userId)) {
                 // Otp user requesting their item.
                 return;
             }
-            if (requestingUser.isThirdParty() && requestingUser.apiUser.id.equals(userId)) {
+            if (requestingUser.isThirdPartyUser() && requestingUser.apiUser.id.equals(userId)) {
                 // Api user requesting their item.
                 return;
             }
-            if (requestingUser.isThirdParty()) {
+            if (requestingUser.isThirdPartyUser()) {
                 // Api user potentially requesting an item on behalf of an Otp user they created.
                 OtpUser otpUser = Persistence.otpUsers.getById(userId);
-                if (otpUser != null && requestingUser.apiUser.id.equals(otpUser.applicationId)) {
+                if (otpUser != null && otpUser.canBeManagedBy(requestingUser)) {
                     return;
                 }
             }

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -17,7 +17,6 @@ import org.opentripplanner.middleware.models.AbstractUser;
 import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.persistence.Persistence;
-import org.opentripplanner.middleware.utils.ConfigUtils;
 import org.opentripplanner.middleware.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +26,8 @@ import spark.Response;
 
 import java.security.interfaces.RSAPublicKey;
 
+import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
+import static org.opentripplanner.middleware.utils.ConfigUtils.hasConfigProperty;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
@@ -185,7 +186,7 @@ public class Auth0Connection {
     private static JWTVerifier getVerifier(Request req, String token) {
         if (verifier == null) {
             try {
-                final String domain = "https://" + ConfigUtils.getConfigPropertyAsText("AUTH0_DOMAIN") + "/";
+                final String domain = "https://" + getConfigPropertyAsText("AUTH0_DOMAIN") + "/";
                 JwkProvider provider = new UrlJwkProvider(domain);
                 // Decode the token.
                 DecodedJWT jwt = JWT.decode(token);
@@ -209,8 +210,8 @@ public class Auth0Connection {
     }
 
     public static boolean getDefaultAuthDisabled() {
-        return ConfigUtils.hasConfigProperty("DISABLE_AUTH") &&
-            "true".equals(ConfigUtils.getConfigPropertyAsText("DISABLE_AUTH"));
+        return hasConfigProperty("DISABLE_AUTH") &&
+            "true".equals(getConfigPropertyAsText("DISABLE_AUTH"));
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -272,7 +272,7 @@ public class Auth0Users {
     /**
      * Extract from a complete Auth0 token just the access token. If the token is not available, return null instead.
      */
-    public static String getAuth0Token(String username, String password) {
+    public static String getAuth0AccessToken(String username, String password) {
         TokenHolder token = getCompleteAuth0Token(username, password);
         return (token == null) ? null : token.getAccessToken();
     }

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -12,7 +12,6 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.bugsnag.BugsnagReporter;
 import org.opentripplanner.middleware.models.AbstractUser;
 import org.opentripplanner.middleware.persistence.TypedPersistence;
-import org.opentripplanner.middleware.utils.ConfigUtils;
 import org.opentripplanner.middleware.utils.HttpUtils;
 import org.opentripplanner.middleware.utils.JsonUtils;
 import org.slf4j.Logger;
@@ -28,6 +27,7 @@ import java.util.UUID;
 
 import static com.mongodb.client.model.Filters.eq;
 import static org.opentripplanner.middleware.utils.ConfigUtils.getBooleanEnvVar;
+import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
@@ -35,12 +35,12 @@ import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
  * searchable fields and query syntax are here: https://auth0.com/docs/api/management/v2/user-search
  */
 public class Auth0Users {
-    public static final String AUTH0_DOMAIN = ConfigUtils.getConfigPropertyAsText("AUTH0_DOMAIN");
+    public static final String AUTH0_DOMAIN = getConfigPropertyAsText("AUTH0_DOMAIN");
     // This client/secret pair is for making requests for an API access token used with the Management API.
-    private static final String AUTH0_API_CLIENT = ConfigUtils.getConfigPropertyAsText("AUTH0_API_CLIENT");
-    private static final String AUTH0_API_SECRET = ConfigUtils.getConfigPropertyAsText("AUTH0_API_SECRET");
-    private static final String AUTH0_CLIENT_ID = ConfigUtils.getConfigPropertyAsText("AUTH0_CLIENT_ID");
-    private static final String AUTH0_CLIENT_SECRET = ConfigUtils.getConfigPropertyAsText("AUTH0_CLIENT_SECRET");
+    private static final String AUTH0_API_CLIENT = getConfigPropertyAsText("AUTH0_API_CLIENT");
+    private static final String AUTH0_API_SECRET = getConfigPropertyAsText("AUTH0_API_SECRET");
+    private static final String AUTH0_CLIENT_ID = getConfigPropertyAsText("AUTH0_CLIENT_ID");
+    private static final String AUTH0_CLIENT_SECRET = getConfigPropertyAsText("AUTH0_CLIENT_SECRET");
     private static final String DEFAULT_CONNECTION_TYPE = "Username-Password-Authentication";
     private static final String DEFAULT_AUDIENCE = "https://otp-middleware";
     private static final String MANAGEMENT_API_VERSION = "v2";

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.mongodb.client.model.Filters.eq;
-import static org.opentripplanner.middleware.utils.ConfigUtils.getBooleanEnvVar;
 import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
@@ -39,17 +38,10 @@ public class Auth0Users {
     // This client/secret pair is for making requests for an API access token used with the Management API.
     private static final String AUTH0_API_CLIENT = getConfigPropertyAsText("AUTH0_API_CLIENT");
     private static final String AUTH0_API_SECRET = getConfigPropertyAsText("AUTH0_API_SECRET");
-    private static final String AUTH0_CLIENT_ID = getConfigPropertyAsText("AUTH0_CLIENT_ID");
-    private static final String AUTH0_CLIENT_SECRET = getConfigPropertyAsText("AUTH0_CLIENT_SECRET");
     private static final String DEFAULT_CONNECTION_TYPE = "Username-Password-Authentication";
     private static final String DEFAULT_AUDIENCE = "https://otp-middleware";
     private static final String MANAGEMENT_API_VERSION = "v2";
     public static final String API_PATH = "/api/" + MANAGEMENT_API_VERSION;
-
-    /**
-     * Whether the end-to-end environment variable is enabled.
-     */
-    private static final boolean isEndToEnd = getBooleanEnvVar("RUN_E2E");
 
     /**
      * Cached API token so that we do not have to request a new one each time a Management API request is made.

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.mongodb.client.model.Filters.eq;
+import static org.opentripplanner.middleware.utils.ConfigUtils.getBooleanEnvVar;
 
 /**
  * This class contains methods for querying Auth0 users using the Auth0 User Management API. Auth0 docs describing the
@@ -43,6 +44,12 @@ public class Auth0Users {
     private static final String DEFAULT_AUDIENCE = "https://otp-middleware";
     private static final String MANAGEMENT_API_VERSION = "v2";
     public static final String API_PATH = "/api/" + MANAGEMENT_API_VERSION;
+
+    /**
+     * Whether the end-to-end environment variable is enabled.
+     */
+    private static final boolean isEndToEnd = getBooleanEnvVar("RUN_E2E");
+
     /**
      * Cached API token so that we do not have to request a new one each time a Management API request is made.
      */
@@ -251,8 +258,8 @@ public class Auth0Users {
             username,
             password,
             DEFAULT_AUDIENCE, // must match an API identifier
-            AUTH0_API_CLIENT, // Auth0 application client ID
-            AUTH0_API_SECRET // Auth0 application client secret
+            (isEndToEnd) ? AUTH0_CLIENT_ID : AUTH0_API_CLIENT, // Auth0 application client ID
+            (isEndToEnd) ? AUTH0_CLIENT_SECRET : AUTH0_API_SECRET // Auth0 application client secret
         );
         return HttpUtils.httpRequestRawResponse(
             URI.create(String.format("https://%s/oauth/token", AUTH0_DOMAIN)),

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 
 import static com.mongodb.client.model.Filters.eq;
 import static org.opentripplanner.middleware.utils.ConfigUtils.getBooleanEnvVar;
+import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
  * This class contains methods for querying Auth0 users using the Auth0 User Management API. Auth0 docs describing the
@@ -196,12 +197,12 @@ public class Auth0Users {
         U userWithEmail = userStore.getOneFiltered(eq("email", user.email));
         if (userWithEmail != null) {
             // TODO: Does this need to change to allow multiple applications to create otpuser's with the same email?
-            JsonUtils.logMessageAndHalt(req, 400, "User with email already exists in database!");
+            logMessageAndHalt(req, 400, "User with email already exists in database!");
         }
         // Check for pre-existing user in Auth0 and create if not exists.
         User auth0UserProfile = getUserByEmail(user.email, true);
         if (auth0UserProfile == null) {
-            JsonUtils.logMessageAndHalt(req, HttpStatus.INTERNAL_SERVER_ERROR_500, "Error creating user for email " + user.email);
+            logMessageAndHalt(req, HttpStatus.INTERNAL_SERVER_ERROR_500, "Error creating user for email " + user.email);
         }
         LOG.info("Created new Auth0 user ({}) for user {}", auth0UserProfile.getId(), user.id);
         return auth0UserProfile;
@@ -212,7 +213,7 @@ public class Auth0Users {
      */
     public static <U extends AbstractUser> void validateUser(U user, Request req) {
         if (!isValidEmail(user.email)) {
-            JsonUtils.logMessageAndHalt(req, HttpStatus.BAD_REQUEST_400, "Email address is invalid.");
+            logMessageAndHalt(req, HttpStatus.BAD_REQUEST_400, "Email address is invalid.");
         }
     }
 
@@ -224,11 +225,11 @@ public class Auth0Users {
         // Verify that email address for user has not changed.
         // TODO: should we permit changing email addresses? This would require making an update to Auth0.
         if (!preExistingUser.email.equals(user.email)) {
-            JsonUtils.logMessageAndHalt(req, HttpStatus.BAD_REQUEST_400, "Cannot change user email address!");
+            logMessageAndHalt(req, HttpStatus.BAD_REQUEST_400, "Cannot change user email address!");
         }
         // Verify that Auth0 ID for user has not changed.
         if (!preExistingUser.auth0UserId.equals(user.auth0UserId)) {
-            JsonUtils.logMessageAndHalt(req, HttpStatus.BAD_REQUEST_400, "Cannot change Auth0 ID!");
+            logMessageAndHalt(req, HttpStatus.BAD_REQUEST_400, "Cannot change Auth0 ID!");
         }
     }
 

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -42,6 +42,7 @@ public class Auth0Users {
     private static final String AUTH0_CLIENT_ID = getConfigPropertyAsText("AUTH0_CLIENT_ID");
     private static final String AUTH0_CLIENT_SECRET = getConfigPropertyAsText("AUTH0_CLIENT_SECRET");
     private static final String DEFAULT_CONNECTION_TYPE = "Username-Password-Authentication";
+    private static final String DEFAULT_AUDIENCE = "https://otp-middleware";
     private static final String MANAGEMENT_API_VERSION = "v2";
     private static final String SEARCH_API_VERSION = "v3";
     public static final String API_PATH = "/api/" + MANAGEMENT_API_VERSION;
@@ -53,8 +54,8 @@ public class Auth0Users {
     private static final AuthAPI authAPI = new AuthAPI(AUTH0_DOMAIN, AUTH0_API_CLIENT, AUTH0_API_SECRET);
 
     /**
-     * Creates a standard user for the provided email address. Defaults to a random UUID password and connection type of
-     * {@link #DEFAULT_CONNECTION_TYPE}.
+     * Creates a standard user for the provided email address, password (Defaulted to a random UUID) and connection type
+     * of {@link #DEFAULT_CONNECTION_TYPE}.
      */
     public static User createAuth0UserForEmail(String email) throws Auth0Exception {
         return createAuth0UserForEmail(email, UUID.randomUUID().toString());
@@ -253,7 +254,7 @@ public class Auth0Users {
             "grant_type=password&username=%s&password=%s&audience=%s&scope=&client_id=%s&client_secret=%s",
             username,
             password,
-            "https://otp-middleware", // must match an API identifier
+            DEFAULT_AUDIENCE, // must match an API identifier
             AUTH0_CLIENT_ID, // Auth0 application client ID
             AUTH0_CLIENT_SECRET // Auth0 application client secret
         );

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -259,8 +259,8 @@ public class Auth0Users {
             username,
             password,
             DEFAULT_AUDIENCE, // must match an API identifier
-            (isEndToEnd) ? AUTH0_CLIENT_ID : AUTH0_API_CLIENT, // Auth0 application client ID
-            (isEndToEnd) ? AUTH0_CLIENT_SECRET : AUTH0_API_SECRET // Auth0 application client secret
+            AUTH0_API_CLIENT, // Auth0 application client ID
+            AUTH0_API_SECRET // Auth0 application client secret
         );
         return HttpUtils.httpRequestRawResponse(
             URI.create(String.format("https://%s/oauth/token", AUTH0_DOMAIN)),

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -242,8 +242,7 @@ public class Auth0Users {
     /**
      * Get an Auth0 oauth token for use in mocking user requests by using the Auth0 'Call Your API Using Resource Owner
      * Password Flow' approach. Auth0 setup can be reviewed here: https://auth0.com/docs/flows/call-your-api-using-resource-owner-password-flow.
-     * If the user is successfully validated by Auth0 a complete token is returned, which is extracted and returned
-     * to the caller. In all other cases, null is returned.
+     * If the user is successfully validated by Auth0 a complete token is returned. In all other cases, null is returned.
      */
     public static TokenHolder getCompleteAuth0Token(String username, String password) {
         if (Auth0Connection.isAuthDisabled()) return null;

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -251,8 +251,8 @@ public class Auth0Users {
             username,
             password,
             DEFAULT_AUDIENCE, // must match an API identifier
-            AUTH0_CLIENT_ID, // Auth0 application client ID
-            AUTH0_CLIENT_SECRET // Auth0 application client secret
+            AUTH0_API_CLIENT, // Auth0 application client ID
+            AUTH0_API_SECRET // Auth0 application client secret
         );
         return HttpUtils.httpRequestRawResponse(
             URI.create(String.format("https://%s/oauth/token", AUTH0_DOMAIN)),

--- a/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
@@ -67,7 +67,7 @@ public class RequestingUser {
     }
 
     /**
-     * Determine if the requesting user is a third party API user. A third party API user is classed as a user that has
+     * Determine if the requesting user is a third party API user. A third party API user is classified as a user that has
      * signed up for access to the otp-middleware API. These users are expected to make requests on behalf of the
      * OtpUsers they sign up, via a server application that authenticates via otp-middleware's authenticate
      * endpoint (/api/secure/application/authenticate). OtpUsers created for third party API users enjoy a more limited

--- a/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
@@ -74,11 +74,10 @@ public class RequestingUser {
     }
 
     /**
-     * Check if the incoming user is an admin user. To be classed as an admin user, the user must not be any other user
-     * type.
+     * Check if the incoming user is an admin user.
      */
     public boolean isAdmin() {
-        return adminUser != null && apiUser == null && otpUser == null;
+        return adminUser != null;
     }
 
 }

--- a/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
@@ -76,14 +76,6 @@ public class RequestingUser {
     }
 
     /**
-     * Determine if requesting user is a first party user. A first party user is a user coming directly from MOD UI.
-     */
-    public boolean isFirstPartyUser() {
-        // TODO: Look to enhance otp user check. Perhaps define specific field to indicate this?
-        return otpUser != null;
-    }
-
-    /**
      * Check if the incoming user is an admin user.
      */
     public boolean isAdmin() {

--- a/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
@@ -67,8 +67,11 @@ public class RequestingUser {
     }
 
     /**
-     * Determine if requesting user is a third party user. A third party user is classed as a user coming via the AWS
-     * API gateway.
+     * Determine if the requesting user is a third party API user. A third party API user is classed as a user that has
+     * signed up for access to the otp-middleware API. These users are expected to make requests on behalf of the
+     * OtpUsers they sign up, via a server application that authenticates via otp-middleware's authenticate
+     * endpoint (/api/secure/application/authenticate). OtpUsers created for third party API users enjoy a more limited
+     * range of activities (e.g., they cannot receive email/SMS notifications from otp-middleware).
      */
     public boolean isThirdPartyUser() {
         // TODO: Look to enhance api user check. Perhaps define specific field to indicate this?

--- a/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
@@ -16,17 +16,17 @@ import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthHeaderPr
  * User profile that is attached to an HTTP request.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Auth0UserProfile {
-    public final OtpUser otpUser;
-    public final ApiUser apiUser;
-    public final AdminUser adminUser;
-    public final String auth0UserId;
+public class RequestingUser {
+    public OtpUser otpUser;
+    public ApiUser apiUser;
+    public AdminUser adminUser;
+    public String auth0UserId;
 
     /**
      * Constructor is only used for creating a test user. If an Auth0 user id is provided check persistence for matching
      * user else create default user.
      */
-    private Auth0UserProfile(String auth0UserId) {
+    private RequestingUser(String auth0UserId) {
         if (auth0UserId == null) {
             this.auth0UserId = "user_id:string";
             otpUser = new OtpUser();
@@ -44,7 +44,7 @@ public class Auth0UserProfile {
     /**
      * Create a user profile from the request's JSON web token. Check persistence for stored user
      */
-    public Auth0UserProfile(DecodedJWT jwt) {
+    public RequestingUser(DecodedJWT jwt) {
         this.auth0UserId = jwt.getClaim("sub").asString();
         Bson withAuth0UserId = eq("auth0UserId", auth0UserId);
         otpUser = Persistence.otpUsers.getOneFiltered(withAuth0UserId);
@@ -52,17 +52,25 @@ public class Auth0UserProfile {
         apiUser = Persistence.apiUsers.getOneFiltered(withAuth0UserId);
     }
 
+    public RequestingUser(String apiKey, boolean isApiUser) {
+        apiUser = getApiUserForApiKey(apiKey);
+    }
+
+    private ApiUser getApiUserForApiKey(String apiKey) {
+        return Persistence.apiUsers.getOneFiltered();
+    }
+
     /**
      * Utility method for creating a test user. If a Auth0 user Id is defined within the Authorization header param
      * define test user based on this.
      */
-    static Auth0UserProfile createTestUser(Request req) {
+    static RequestingUser createTestUser(Request req) {
         String auth0UserId = null;
         if (isAuthHeaderPresent(req)) {
             // If the auth header has been provided get the Auth0 user id from it. This is different from normal
             // operation as the parameter will only contain the Auth0 user id and not "Bearer token".
             auth0UserId = req.headers("Authorization");
         }
-        return new Auth0UserProfile(auth0UserId);
+        return new RequestingUser(auth0UserId);
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
@@ -67,4 +67,11 @@ public class RequestingUser {
 
         return new RequestingUser(auth0UserId);
     }
+
+    /**
+     * Determine if requesting user is a third party user.
+     */
+    public boolean isThirdPartyUser() {
+        return apiUser != null;
+    }
 }

--- a/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
@@ -67,10 +67,20 @@ public class RequestingUser {
     }
 
     /**
-     * Determine if requesting user is a third party user.
+     * Determine if requesting user is a third party user. A third party user is classed as a user coming via the AWS
+     * API gateway.
      */
-    public boolean isThirdParty() {
+    public boolean isThirdPartyUser() {
+        // TODO: Look to enhance api user check. Perhaps define specific field to indicate this?
         return apiUser != null;
+    }
+
+    /**
+     * Determine if requesting user is a first party user. A first party user is a user coming directly from MOD UI.
+     */
+    public boolean isFirstPartyUser() {
+        // TODO: Look to enhance otp user check. Perhaps define specific field to indicate this?
+        return otpUser != null;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/RequestingUser.java
@@ -6,6 +6,7 @@ import com.mongodb.client.model.Filters;
 import org.bson.conversions.Bson;
 import org.opentripplanner.middleware.models.AdminUser;
 import org.opentripplanner.middleware.models.ApiUser;
+import org.opentripplanner.middleware.models.Model;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.persistence.Persistence;
 import spark.Request;
@@ -85,4 +86,10 @@ public class RequestingUser {
         return adminUser != null;
     }
 
+    /**
+     * Check if this requesting user can manage the specified entity.
+     */
+    public boolean canManageEntity(Model model) {
+        return model != null && model.canBeManagedBy(this);
+    }
 }

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -3,7 +3,6 @@ package org.opentripplanner.middleware.controllers.api;
 import com.auth0.json.mgmt.jobs.Job;
 import com.auth0.json.mgmt.users.User;
 import com.beerboy.ss.ApiEndpoint;
-import com.beerboy.ss.descriptor.MethodDescriptor;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
 import org.opentripplanner.middleware.auth.RequestingUser;
@@ -18,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
+import static com.beerboy.ss.descriptor.MethodDescriptor.path;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
@@ -46,14 +46,14 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
         // by spark as 'GET user with id "fromtoken"', which we don't want).
         ApiEndpoint modifiedEndpoint = baseEndpoint
             // Get user from token.
-            .get(MethodDescriptor.path(ROOT_ROUTE + TOKEN_PATH)
+            .get(path(ROOT_ROUTE + TOKEN_PATH)
                     .withDescription("Retrieves an " + persistence.clazz.getSimpleName() + " entity using an Auth0 access token passed in an Authorization header.")
                     .withProduces(HttpUtils.JSON_ONLY)
                     .withResponseType(persistence.clazz),
                 this::getUserFromRequest, JsonUtils::toJson
             )
             // Resend verification email
-            .get(MethodDescriptor.path(ROOT_ROUTE + VERIFICATION_EMAIL_PATH)
+            .get(path(ROOT_ROUTE + VERIFICATION_EMAIL_PATH)
                     .withDescription("Triggers a job to resend the Auth0 verification email.")
                     .withResponseType(Job.class),
                 this::resendVerificationEmail, JsonUtils::toJson

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -18,6 +18,8 @@ import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
+import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
+
 /**
  * Implementation of the {@link ApiController} abstract class for managing users. This controller connects with Auth0
  * services using the hooks provided by {@link ApiController}.
@@ -80,7 +82,7 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
         // but have not completed the account setup form yet.
         // For those users, the user profile would be 404 not found (as opposed to 403 forbidden).
         if (user == null) {
-            JsonUtils.logMessageAndHalt(req,
+            logMessageAndHalt(req,
                 HttpStatus.NOT_FOUND_404,
                 String.format(NO_USER_WITH_AUTH0_ID_MESSAGE, profile.auth0UserId),
                 null);

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -8,6 +8,7 @@ import org.opentripplanner.middleware.auth.Auth0Connection;
 import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.auth.Auth0Users;
 import org.opentripplanner.middleware.models.AbstractUser;
+import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.persistence.TypedPersistence;
 import org.opentripplanner.middleware.utils.JsonUtils;
@@ -105,7 +106,7 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
         RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         // TODO: If MOD UI is to be an ApiUser, we may want to do an additional check here to determine if this is a
         //  first-party API user (MOD UI) or third party.
-        if (requestingUser.apiUser != null && user instanceof OtpUser) {
+        if (requestingUser.apiUser != null && user instanceof OtpUser || user instanceof ApiUser) {
             // Do not create Auth0 account for OtpUsers created on behalf of third party API users.
             return user;
         } else {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -103,7 +103,7 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
         RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         // TODO: If MOD UI is to be an ApiUser, we may want to do an additional check here to determine if this is a
         //  first-party API user (MOD UI) or third party.
-        if (requestingUser.isThirdParty() && user instanceof OtpUser) {
+        if (requestingUser.isThirdPartyUser() && user instanceof OtpUser) {
             // Do not create Auth0 account for OtpUsers created on behalf of third party API users.
             return user;
         } else {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -8,7 +8,6 @@ import org.opentripplanner.middleware.auth.Auth0Connection;
 import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.auth.Auth0Users;
 import org.opentripplanner.middleware.models.AbstractUser;
-import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.persistence.TypedPersistence;
 import org.opentripplanner.middleware.utils.JsonUtils;
@@ -106,7 +105,7 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
         RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         // TODO: If MOD UI is to be an ApiUser, we may want to do an additional check here to determine if this is a
         //  first-party API user (MOD UI) or third party.
-        if (requestingUser.apiUser != null && user instanceof OtpUser || user instanceof ApiUser) {
+        if (requestingUser.apiUser != null && user instanceof OtpUser) {
             // Do not create Auth0 account for OtpUsers created on behalf of third party API users.
             return user;
         } else {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AdminUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AdminUserController.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.middleware.controllers.api;
 
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.models.AdminUser;
 import org.opentripplanner.middleware.persistence.Persistence;
 
@@ -18,7 +18,7 @@ public class AdminUserController extends AbstractUserController<AdminUser> {
     }
 
     @Override
-    protected AdminUser getUserProfile(Auth0UserProfile profile) {
+    protected AdminUser getUserProfile(RequestingUser profile) {
         return profile.adminUser;
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiController.java
@@ -205,7 +205,7 @@ public abstract class ApiController<T extends Model> implements Endpoint {
             // OtpUserController. Therefore, the request should be limited to return just the entity matching the
             // requesting user.
             return persistence.getResponseList(Filters.eq("_id", requestingUser.otpUser.id), offset, limit);
-        } else if (requestingUser.isThirdParty()) {
+        } else if (requestingUser.isThirdPartyUser()) {
             // A user id must be provided if the request is being made by a third party user.
             JsonUtils.logMessageAndHalt(req,
                 HttpStatus.BAD_REQUEST_400,

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiController.java
@@ -194,7 +194,7 @@ public abstract class ApiController<T extends Model> implements Endpoint {
         RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         if (userId != null) {
             OtpUser otpUser = Persistence.otpUsers.getById(userId);
-            if(otpUser != null && otpUser.canBeManagedBy(requestingUser)) {
+            if (otpUser != null && otpUser.canBeManagedBy(requestingUser)) {
                 return persistence.getResponseList(Filters.eq(USER_ID_PARAM, userId), offset, limit);
             } else {
                 res.status(HttpStatus.FORBIDDEN_403);

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
@@ -74,7 +74,6 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
             // Authenticate user with Auth0
             .post(path(AUTHENTICATE_PATH)
                     .withDescription("Authenticates ApiUser with Auth0.")
-                    .withPathParam().withName(ID_PARAM).withDescription("The user ID.").and()
                     .withQueryParam().withName(USERNAME_PARAM).withRequired(true)
                     .withDescription("Auth0 username (usually email address).").and()
                     .withQueryParam().withName(PASSWORD_PARAM).withRequired(true)

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
@@ -3,7 +3,7 @@ package org.opentripplanner.middleware.controllers.api;
 import com.beerboy.ss.ApiEndpoint;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.models.ApiKey;
 import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.persistence.Persistence;
@@ -90,7 +90,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
      */
     private ApiUser createApiKeyForApiUser(Request req, Response res) {
         ApiUser targetUser = getApiUser(req);
-        Auth0UserProfile requestingUser = Auth0Connection.getUserFromRequest(req);
+        RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         String usagePlanId = req.queryParamOrDefault("usagePlanId", DEFAULT_USAGE_PLAN_ID);
         // If requester is not an admin user, force the usage plan ID to the default and enforce key limit. A non-admin
         // user should not be able to create an API key for any usage plan.
@@ -120,7 +120,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
      * Delete an api key from a given user's list of api keys (if present) and from AWS api gateway.
      */
     private ApiUser deleteApiKeyForApiUser(Request req, Response res) {
-        Auth0UserProfile requestingUser = Auth0Connection.getUserFromRequest(req);
+        RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         // Do not permit key deletion unless user is an admin.
         if (!isUserAdmin(requestingUser)) {
             logMessageAndHalt(req, HttpStatus.FORBIDDEN_403, "Must be an admin to delete an API key.");
@@ -155,7 +155,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
     }
 
     @Override
-    protected ApiUser getUserProfile(Auth0UserProfile profile) {
+    protected ApiUser getUserProfile(RequestingUser profile) {
         return profile.apiUser;
     }
 
@@ -199,7 +199,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
      * Get an Api user from Mongo DB based on the provided user id. Make sure user is admin or managing self.
      */
     private static ApiUser getApiUser(Request req) {
-        Auth0UserProfile requestingUser = Auth0Connection.getUserFromRequest(req);
+        RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         String userId = HttpUtils.getRequiredParamFromRequest(req, ID_PARAM);
         ApiUser apiUser = Persistence.apiUsers.getById(userId);
         if (apiUser == null) {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
@@ -33,7 +33,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
     private static final Logger LOG = LoggerFactory.getLogger(ApiUserController.class);
     public static final String DEFAULT_USAGE_PLAN_ID = ConfigUtils.getConfigPropertyAsText("DEFAULT_USAGE_PLAN_ID");
     private static final String API_KEY_PATH = "/apikey";
-    private static final String AUTHENTICATE_PATH = "/authenticate";
+    public static final String AUTHENTICATE_PATH = "/authenticate";
     private static final int API_KEY_LIMIT_PER_USER = 2;
     private static final String API_KEY_ID_PARAM = "/:apiKeyId";
     public static final String API_USER_PATH = "secure/application";

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
@@ -2,7 +2,6 @@ package org.opentripplanner.middleware.controllers.api;
 
 import com.auth0.json.auth.TokenHolder;
 import com.beerboy.ss.ApiEndpoint;
-import com.beerboy.ss.descriptor.MethodDescriptor;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
 import org.opentripplanner.middleware.auth.Auth0Users;
@@ -11,7 +10,6 @@ import org.opentripplanner.middleware.models.ApiKey;
 import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.utils.ApiGatewayUtils;
-import org.opentripplanner.middleware.utils.ConfigUtils;
 import org.opentripplanner.middleware.utils.CreateApiKeyException;
 import org.opentripplanner.middleware.utils.HttpUtils;
 import org.opentripplanner.middleware.utils.JsonUtils;
@@ -23,6 +21,8 @@ import spark.Response;
 
 import java.net.http.HttpResponse;
 
+import static com.beerboy.ss.descriptor.MethodDescriptor.path;
+import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
@@ -31,7 +31,7 @@ import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
  */
 public class ApiUserController extends AbstractUserController<ApiUser> {
     private static final Logger LOG = LoggerFactory.getLogger(ApiUserController.class);
-    public static final String DEFAULT_USAGE_PLAN_ID = ConfigUtils.getConfigPropertyAsText("DEFAULT_USAGE_PLAN_ID");
+    public static final String DEFAULT_USAGE_PLAN_ID = getConfigPropertyAsText("DEFAULT_USAGE_PLAN_ID");
     private static final String API_KEY_PATH = "/apikey";
     public static final String AUTHENTICATE_PATH = "/authenticate";
     private static final int API_KEY_LIMIT_PER_USER = 2;
@@ -51,7 +51,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
         LOG.info("Registering path {}.", ROOT_ROUTE + ID_PATH + API_KEY_PATH);
         ApiEndpoint modifiedEndpoint = baseEndpoint
             // Create API key
-            .post(MethodDescriptor.path(ID_PATH + API_KEY_PATH)
+            .post(path(ID_PATH + API_KEY_PATH)
                     .withDescription("Creates API key for ApiUser (with optional AWS API Gateway usage plan ID).")
                     .withPathParam().withName(ID_PARAM).withRequired(true).withDescription("The user ID")
                     .and()
@@ -62,7 +62,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
                 this::createApiKeyForApiUser, JsonUtils::toJson
             )
             // Delete API key
-            .delete(MethodDescriptor.path(ID_PATH + API_KEY_PATH + API_KEY_ID_PARAM)
+            .delete(path(ID_PATH + API_KEY_PATH + API_KEY_ID_PARAM)
                     .withDescription("Deletes API key for ApiUser.")
                     .withPathParam().withName(ID_PARAM).withDescription("The user ID.")
                     .and()
@@ -72,7 +72,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
                     .withResponseType(persistence.clazz),
                 this::deleteApiKeyForApiUser, JsonUtils::toJson)
             // Authenticate user with Auth0
-            .post(MethodDescriptor.path(AUTHENTICATE_PATH)
+            .post(path(AUTHENTICATE_PATH)
                     .withDescription("Authenticates ApiUser with Auth0.")
                     .withPathParam().withName(ID_PARAM).withDescription("The user ID.").and()
                     .withQueryParam().withName(USERNAME_PARAM).withRequired(true)
@@ -89,8 +89,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
     }
 
     /**
-     * Authenticate user with Auth0 based on username (email) and password. If successful, confirm that the provided API
-     * key is return the complete Auth0
+     * Authenticate user with Auth0 based on username (email) and password. If successful, return the complete Auth0
      * token else log message and halt.
      */
     private TokenHolder authenticateAuth0User(Request req, Response res) {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
@@ -163,7 +163,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
                 "An api key id is required",
                 null);
         }
-        if (targetUser != null && !targetUser.hasKey(apiKeyId)) {
+        if (targetUser != null && !targetUser.hasApiKeyId(apiKeyId)) {
             logMessageAndHalt(req,
                 HttpStatus.NOT_FOUND_404,
                 String.format("User id (%s) does not have expected api key id (%s)", targetUser.id, apiKeyId),
@@ -241,7 +241,7 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
             );
         }
 
-        if (!apiUser.canBeManagedBy(requestingUser)) {
+        if (!requestingUser.canManageEntity(apiUser)) {
             logMessageAndHalt(req, HttpStatus.FORBIDDEN_403, "Must be an admin to perform this operation.");
         }
         return apiUser;

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/LogController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/LogController.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
+
 /**
  * Sets up HTTP endpoints for getting logging and request summary information from AWS Cloudwatch and API Gateway.
  */
@@ -81,7 +83,7 @@ public class LogController implements Endpoint {
         // If the user is not an admin, the list of API keys is defaulted to their keys.
         if (!requestingUser.isAdmin()) {
             if (requestingUser.apiUser == null) {
-                JsonUtils.logMessageAndHalt(req, HttpStatus.FORBIDDEN_403, "Action is not permitted for user.");
+                logMessageAndHalt(req, HttpStatus.FORBIDDEN_403, "Action is not permitted for user.");
                 return null;
             }
             apiKeys = requestingUser.apiUser.apiKeys;
@@ -109,7 +111,7 @@ public class LogController implements Endpoint {
                 .collect(Collectors.toList());
         } catch (Exception e) {
             // Catch any issues with bad request parameters (e.g., invalid API keyId or bad date format).
-            JsonUtils.logMessageAndHalt(req, HttpStatus.BAD_REQUEST_400, "Error requesting usage results", e);
+            logMessageAndHalt(req, HttpStatus.BAD_REQUEST_400, "Error requesting usage results", e);
         }
 
         return null;

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/LogController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/LogController.java
@@ -3,7 +3,6 @@ package org.opentripplanner.middleware.controllers.api;
 import com.amazonaws.services.apigateway.model.GetUsageResult;
 import com.beerboy.ss.SparkSwagger;
 import com.beerboy.ss.descriptor.EndpointDescriptor;
-import com.beerboy.ss.descriptor.MethodDescriptor;
 import com.beerboy.ss.rest.Endpoint;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
@@ -23,6 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.beerboy.ss.descriptor.MethodDescriptor.path;
+import static org.opentripplanner.middleware.utils.DateTimeUtils.DEFAULT_DATE_FORMAT_PATTERN;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
@@ -44,26 +45,26 @@ public class LogController implements Endpoint {
         restApi.endpoint(
             EndpointDescriptor.endpointPath(ROOT_ROUTE).withDescription("Interface for retrieving API logs from AWS."),
             HttpUtils.NO_FILTER
-        ).get(MethodDescriptor.path(ROOT_ROUTE)
+        ).get(path(ROOT_ROUTE)
                 .withDescription("Gets a list of all API usage logs.")
                 .withQueryParam()
                 .withName("keyId")
                 .withDescription("If specified, restricts the search to the specified AWS API key ID.").and()
                 .withQueryParam()
                 .withName("startDate")
-                .withPattern(DateTimeUtils.DEFAULT_DATE_FORMAT_PATTERN)
+                .withPattern(DEFAULT_DATE_FORMAT_PATTERN)
                 .withDefaultValue("30 days prior to the current date")
                 .withDescription(String.format(
                     "If specified, the earliest date (format %s) for which usage logs are retrieved.",
-                    DateTimeUtils.DEFAULT_DATE_FORMAT_PATTERN
+                    DEFAULT_DATE_FORMAT_PATTERN
                 )).and()
                 .withQueryParam()
                 .withName("endDate")
-                .withPattern(DateTimeUtils.DEFAULT_DATE_FORMAT_PATTERN)
+                .withPattern(DEFAULT_DATE_FORMAT_PATTERN)
                 .withDefaultValue("The current date")
                 .withDescription(String.format(
                     "If specified, the latest date (format %s) for which usage logs are retrieved.",
-                    DateTimeUtils.DEFAULT_DATE_FORMAT_PATTERN
+                    DEFAULT_DATE_FORMAT_PATTERN
                 )).and()
                 .withProduces(HttpUtils.JSON_ONLY)
                 // Note: unlike what the name suggests, withResponseAsCollection does not generate an array
@@ -95,7 +96,7 @@ public class LogController implements Endpoint {
         LocalDateTime now = DateTimeUtils.nowAsLocalDateTime();
         // TODO: Future work might modify this so that we accept multiple API key IDs for a single request (depends on
         //  how third party developer accounts are structured).
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DateTimeUtils.DEFAULT_DATE_FORMAT_PATTERN);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT_PATTERN);
         String startDate = req.queryParamOrDefault("startDate", formatter.format(now.minusDays(30)));
         String endDate = req.queryParamOrDefault("endDate", formatter.format(now));
         try {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/LogController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/LogController.java
@@ -5,7 +5,7 @@ import com.beerboy.ss.SparkSwagger;
 import com.beerboy.ss.rest.Endpoint;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.models.ApiKey;
 import org.opentripplanner.middleware.models.ApiUsageResult;
 import org.opentripplanner.middleware.utils.ApiGatewayUtils;
@@ -80,7 +80,7 @@ public class LogController implements Endpoint {
     private static List<ApiUsageResult> getUsageLogs(Request req, Response res) {
         // Get list of API keys (if present) from request.
         List<ApiKey> apiKeys = getApiKeyIdsFromRequest(req);
-        Auth0UserProfile requestingUser = Auth0Connection.getUserFromRequest(req);
+        RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         // If the user is not an admin, the list of API keys is defaulted to their keys.
         if (!isUserAdmin(requestingUser)) {
             if (requestingUser.apiUser == null) {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -142,7 +142,7 @@ public class OtpRequestProcessor implements Endpoint {
             // Api user making a trip request on behalf of an Otp user. In this case, the Otp user id must be provided
             // as a query parameter.
             otpUser = Persistence.otpUsers.getById(userId);
-            if (otpUser == null) {
+            if (otpUser == null && userId != null) {
                 logMessageAndHalt(request, HttpStatus.NOT_FOUND_404, "The specified user id was not found.");
             } else if (!otpUser.canBeManagedBy(requestingUser)) {
                 logMessageAndHalt(request,

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -59,7 +59,8 @@ public class OtpRequestProcessor implements Endpoint {
         ParameterDescriptor USER_ID = ParameterDescriptor.newBuilder()
             .withName(USER_ID_PARAM)
             .withRequired(false)
-            .withDescription("If a third party user is making a trip request on behalf of an OTP user, the OTP user id must be specified.").build();
+            .withDescription("If a third-party application is making a trip plan request on behalf of an end user (OtpUser), the user id must be specified.")
+            .build();
         restApi.endpoint(
             EndpointDescriptor.endpointPath(OTP_PROXY_ENDPOINT).withDescription("Proxy interface for OTP endpoints. " + OTP_DOC_LINK),
             HttpUtils.NO_FILTER
@@ -132,7 +133,7 @@ public class OtpRequestProcessor implements Endpoint {
 
         // Determine if the Otp request is being made by an actual Otp user or by a third party on behalf of an Otp user.
         OtpUser otpUser = null;
-        if (requestingUser.isFirstPartyUser()) {
+        if (requestingUser.otpUser != null) {
             // Otp user making a trip request for self.
             otpUser = requestingUser.otpUser;
         } else if (requestingUser.isThirdPartyUser()) {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -24,7 +24,6 @@ import static com.beerboy.ss.descriptor.EndpointDescriptor.endpointPath;
 import static com.beerboy.ss.descriptor.MethodDescriptor.path;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
-import static org.opentripplanner.middleware.auth.Auth0Connection.isApiKeyHeaderPresent;
 import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthHeaderPresent;
 import static org.opentripplanner.middleware.otp.OtpDispatcher.OTP_API_ROOT;
 import static org.opentripplanner.middleware.otp.OtpDispatcher.OTP_PLAN_ENDPOINT;
@@ -107,10 +106,9 @@ public class OtpRequestProcessor implements Endpoint {
      */
     private static void handlePlanTripResponse(Request request, OtpDispatcherResponse otpDispatcherResponse) {
 
-        // If the Auth header is present, this indicates that the request was made by a logged in user. If the Api key
-        // header is present, this indicates that the request was made by an Api user. If either are present we should
-        // store trip history (but we verify this preference before doing so).
-        if (!isAuthHeaderPresent(request) && !isApiKeyHeaderPresent(request)) {
+        // If the Auth header is present, this indicates that the request was made by a logged in user. If present
+        // we should store trip history (but we verify this preference before doing so).
+        if (!isAuthHeaderPresent(request)) {
             LOG.debug("Anonymous user, trip history not stored");
             return;
         }
@@ -139,7 +137,7 @@ public class OtpRequestProcessor implements Endpoint {
             if (otpUser != null && !otpUser.canBeManagedBy(requestingUser)) {
                 logMessageAndHalt(request,
                     HttpStatus.FORBIDDEN_403,
-                    String.format("Api user: %s not authorized to make trip requests for Otp user: %s",
+                    String.format("User: %s not authorized to make trip requests for user: %s",
                         requestingUser.apiUser.email,
                         otpUser.email));
             }

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -131,16 +131,16 @@ public class OtpRequestProcessor implements Endpoint {
         if (requestingUser.otpUser == null && requestingUser.apiUser == null) {
             return;
         }
-
-        // Determine if the Otp request is being made by an actual Otp user or by a third party on behalf of an Otp user.
+        // If a user id is provided, the assumption is that an Api user is making a plan request on behalf of an Otp user.
+        String userId = request.queryParams(USER_ID_PARAM);
         OtpUser otpUser = null;
-        if (requestingUser.otpUser != null) {
+        if (requestingUser.otpUser != null && userId == null) {
             // Otp user making a trip request for self.
             otpUser = requestingUser.otpUser;
-        } else if (requestingUser.isThirdPartyUser()) {
+        } else if (requestingUser.apiUser != null) {
             // Api user making a trip request on behalf of an Otp user. In this case, the Otp user id must be provided
             // as a query parameter.
-            otpUser = Persistence.otpUsers.getById(request.queryParams(USER_ID_PARAM));
+            otpUser = Persistence.otpUsers.getById(userId);
             if (otpUser != null && !otpUser.canBeManagedBy(requestingUser)) {
                 logMessageAndHalt(request,
                     HttpStatus.FORBIDDEN_403,

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -4,7 +4,7 @@ import com.beerboy.ss.SparkSwagger;
 import com.beerboy.ss.rest.Endpoint;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.models.TripRequest;
 import org.opentripplanner.middleware.models.TripSummary;
 import org.opentripplanner.middleware.otp.OtpDispatcher;
@@ -25,7 +25,6 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthHeaderPresent;
 import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
-import static org.opentripplanner.middleware.otp.OtpDispatcher.OTP_API_ROOT;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
@@ -132,7 +131,7 @@ public class OtpRequestProcessor implements Endpoint {
         long tripStorageStartTime = DateTimeUtils.currentTimeMillis();
 
         Auth0Connection.checkUser(request);
-        Auth0UserProfile profile = Auth0Connection.getUserFromRequest(request);
+        RequestingUser profile = Auth0Connection.getUserFromRequest(request);
 
         final boolean storeTripHistory = profile != null && profile.otpUser != null && profile.otpUser.storeTripHistory;
         // only save trip details if the user has given consent and a response from OTP is provided

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -2,7 +2,6 @@ package org.opentripplanner.middleware.controllers.api;
 
 import com.beerboy.ss.SparkSwagger;
 import com.beerboy.ss.descriptor.EndpointDescriptor;
-import com.beerboy.ss.descriptor.MethodDescriptor;
 import com.beerboy.ss.descriptor.ParameterDescriptor;
 import com.beerboy.ss.rest.Endpoint;
 import org.eclipse.jetty.http.HttpStatus;
@@ -17,7 +16,6 @@ import org.opentripplanner.middleware.otp.response.OtpResponse;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.utils.DateTimeUtils;
 import org.opentripplanner.middleware.utils.HttpUtils;
-import org.opentripplanner.middleware.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;
@@ -25,6 +23,7 @@ import spark.Request;
 import javax.ws.rs.core.MediaType;
 import java.util.List;
 
+import static com.beerboy.ss.descriptor.MethodDescriptor.path;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
@@ -66,8 +65,7 @@ public class OtpRequestProcessor implements Endpoint {
         restApi.endpoint(
             EndpointDescriptor.endpointPath(OTP_PROXY_ENDPOINT).withDescription("Proxy interface for OTP endpoints. " + OTP_DOC_LINK),
             HttpUtils.NO_FILTER
-        ).get(
-            MethodDescriptor.path("/*")
+        ).get(path("/*")
                 .withDescription("Forwards any GET request to OTP. " + OTP_DOC_LINK)
                 .withQueryParam(USER_ID)
                 .withProduces(List.of(MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML)),
@@ -130,7 +128,7 @@ public class OtpRequestProcessor implements Endpoint {
         Auth0Connection.checkUser(request);
         RequestingUser requestingUser = Auth0Connection.getUserFromRequest(request);
         // A requesting user (Otp or third party user) is required to proceed.
-        if (requestingUser == null) {
+        if (requestingUser.otpUser == null && requestingUser.apiUser == null) {
             return;
         }
 

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
@@ -5,7 +5,7 @@ import com.twilio.rest.verify.v2.service.Verification;
 import com.twilio.rest.verify.v2.service.VerificationCheck;
 import org.eclipse.jetty.http.HttpStatus;
 import com.mongodb.client.model.Filters;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.bugsnag.BugsnagReporter;
 import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.models.OtpUser;
@@ -80,7 +80,7 @@ public class OtpUserController extends AbstractUserController<OtpUser> {
     }
 
     @Override
-    protected OtpUser getUserProfile(Auth0UserProfile profile) {
+    protected OtpUser getUserProfile(RequestingUser profile) {
         return profile.otpUser;
     }
 

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
@@ -44,12 +44,12 @@ public class OtpUserController extends AbstractUserController<OtpUser> {
     @Override
     OtpUser preCreateHook(OtpUser user, Request req) {
         RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
-        String apiKeyFromHeader = req.headers("x-api-key");
-        // If third party and an api key is present user is attempting to create an OTP user.
-        if (requestingUser.apiUser != null && apiKeyFromHeader != null) {
+        // If an Api user is present it is assumed an attempt is being made to create an OTP user.
+        if (requestingUser.apiUser != null) {
+            String apiKeyFromHeader = req.headers("x-api-key");
             // Check API key and assign user to appropriate third-party application. Note: this is only relevant for
             // instances of otp-middleware running behind API Gateway.
-            if (requestingUser.apiUser.hasToken(apiKeyFromHeader)) {
+            if (apiKeyFromHeader != null && requestingUser.apiUser.hasToken(apiKeyFromHeader)) {
                 // If third party and using their own api key, assign to new OTP user.
                 user.applicationId = requestingUser.apiUser.id;
             } else {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
@@ -47,7 +47,7 @@ public class OtpUserController extends AbstractUserController<OtpUser> {
         if (requestingUser.apiUser != null) {
             // Check API key and assign user to appropriate third-party application. Note: this is only relevant for
             // instances of otp-middleware running behind API Gateway.
-            Auth0Connection.linkApiKeyToApiUser(req);
+            Auth0Connection.ensureApiUserHasApiKey(req);
             user.applicationId = requestingUser.apiUser.id;
         }
         return super.preCreateHook(user, req);

--- a/src/main/java/org/opentripplanner/middleware/docs/PublicApiDocGenerator.java
+++ b/src/main/java/org/opentripplanner/middleware/docs/PublicApiDocGenerator.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
+import static org.opentripplanner.middleware.utils.ConfigUtils.getVersionFromJar;
 
 /**
  * Class that generates an enhanced public-facing documentation, in OpenAPI 2.0 (Swagger) format,
@@ -109,7 +110,7 @@ public class PublicApiDocGenerator {
         // Overwrite top-level parameters.
         swaggerRoot.put("host", AWS_API_SERVER);
         swaggerRoot.put("basePath", "/" + AWS_API_STAGE);
-        ((ObjectNode) swaggerRoot.get("info")).put("version", ConfigUtils.getVersionFromJar());
+        ((ObjectNode) swaggerRoot.get("info")).put("version", getVersionFromJar());
 
 
         // Generate output file.

--- a/src/main/java/org/opentripplanner/middleware/models/AbstractUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/AbstractUser.java
@@ -2,7 +2,7 @@ package org.opentripplanner.middleware.models;
 
 import com.auth0.exception.Auth0Exception;
 import org.opentripplanner.middleware.auth.Auth0Connection;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.auth.Permission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +44,7 @@ public abstract class AbstractUser extends Model {
      * permissions) or if the requesting user has permission to manage the entity type.
      */
     @Override
-    public boolean canBeManagedBy(Auth0UserProfile user) {
+    public boolean canBeManagedBy(RequestingUser user) {
         // If the user is attempting to update someone else's profile, they must be an admin.
         boolean isManagingSelf = this.auth0UserId.equals(user.auth0UserId);
         if (isManagingSelf) {

--- a/src/main/java/org/opentripplanner/middleware/models/AbstractUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/AbstractUser.java
@@ -31,12 +31,6 @@ public abstract class AbstractUser extends Model {
      */
     public String auth0UserId = UUID.randomUUID().toString();
 
-    /**
-     * Random api key for testing.
-     */
-    public String apiKey = UUID.randomUUID().toString();
-
-
     /** Whether a user is also a Data Tools user */
     public boolean isDataToolsUser;
     /**

--- a/src/main/java/org/opentripplanner/middleware/models/AbstractUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/AbstractUser.java
@@ -30,6 +30,13 @@ public abstract class AbstractUser extends Model {
      * value, so the stored user will contain the value from Auth0 (e.g., "auth0|abcd1234").
      */
     public String auth0UserId = UUID.randomUUID().toString();
+
+    /**
+     * Random api key for testing.
+     */
+    public String apiKey = UUID.randomUUID().toString();
+
+
     /** Whether a user is also a Data Tools user */
     public boolean isDataToolsUser;
     /**

--- a/src/main/java/org/opentripplanner/middleware/models/AdminUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/AdminUser.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.middleware.models;
 
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.auth.Permission;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.slf4j.Logger;
@@ -31,7 +31,7 @@ public class AdminUser extends AbstractUser {
      * TODO: Change to application admin?
      */
     @Override
-    public boolean canBeCreatedBy(Auth0UserProfile user) {
+    public boolean canBeCreatedBy(RequestingUser user) {
         return isUserAdmin(user);
     }
 

--- a/src/main/java/org/opentripplanner/middleware/models/AdminUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/AdminUser.java
@@ -6,8 +6,6 @@ import org.opentripplanner.middleware.persistence.Persistence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.opentripplanner.middleware.auth.Auth0Connection.isUserAdmin;
-
 /**
  * Represents an administrative user of the OTP Admin Dashboard (otp-admin-ui).
  */
@@ -32,7 +30,7 @@ public class AdminUser extends AbstractUser {
      */
     @Override
     public boolean canBeCreatedBy(RequestingUser user) {
-        return isUserAdmin(user);
+        return user.isAdmin();
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/middleware/models/ApiUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ApiUser.java
@@ -87,4 +87,32 @@ public class ApiUser extends AbstractUser {
     public static ApiUser userForApiKey(String apiKeyId) {
         return Persistence.apiUsers.getOneFiltered(Filters.elemMatch("apiKeys", Filters.eq("keyId", apiKeyId)));
     }
+
+    /**
+     * @return the first {@link ApiUser} found with an {@link ApiKey#value} in {@link #apiKeys} that matches the
+     * provided apiKeyValue.
+     */
+    public static ApiUser userForApiKeyValue(String apiKeyValue) {
+        return Persistence.apiUsers.getOneFiltered(Filters.elemMatch("apiKeys", Filters.eq("value", apiKeyValue)));
+    }
+
+    /**
+     * Shorthand method to determine if an API user has an API key.
+     */
+    public boolean hasKey(String apiKeyId) {
+        return apiKeys
+            .stream()
+            .anyMatch(apiKey -> apiKeyId.equals(apiKey.keyId));
+    }
+
+    /**
+     * Shorthand method to determine if an API user has an API token (value).
+     */
+    public boolean hasToken(String apiKeyValue) {
+        return apiKeys
+            .stream()
+            .anyMatch(apiKey -> apiKeyValue.equals(apiKey.value));
+    }
+
+
 }

--- a/src/main/java/org/opentripplanner/middleware/models/ApiUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ApiUser.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.middleware.models;
 
-import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.utils.ApiGatewayUtils;
 import org.opentripplanner.middleware.utils.CreateApiKeyException;
@@ -41,13 +40,28 @@ public class ApiUser extends AbstractUser {
     public String name;
 
     /**
-     * Delete API user's API keys (from AWS), self (from Mongo).
+     * Delete API user details including Auth0 user.
      */
     @Override
     public boolean delete() {
+        return delete(true);
+    }
+
+    /**
+     * Delete API user's API keys (from AWS), self (from Mongo). Optionally delete user from Auth0.
+     */
+    public boolean delete(boolean deleteAuth0User) {
         for (ApiKey apiKey : apiKeys) {
             if (!ApiGatewayUtils.deleteApiKey(apiKey)) {
                 LOG.error("Could not delete API key for user {}. Aborting delete user.", apiKey.keyId);
+                return false;
+            }
+        }
+
+        if (deleteAuth0User) {
+            boolean auth0UserDeleted = super.delete();
+            if (!auth0UserDeleted) {
+                LOG.warn("Aborting user deletion for {}", this.email);
                 return false;
             }
         }
@@ -73,26 +87,4 @@ public class ApiUser extends AbstractUser {
     public static ApiUser userForApiKey(String apiKeyId) {
         return Persistence.apiUsers.getOneFiltered(Filters.elemMatch("apiKeys", Filters.eq("keyId", apiKeyId)));
     }
-
-    /**
-     * @return the first {@link ApiUser} found with an {@link ApiKey#value} in {@link #apiKeys} that matches the
-     * provided api key value.
-     */
-    public static ApiUser userForApiKeyValue(String apiKeyValue) {
-        return Persistence.apiUsers.getOneFiltered(Filters.elemMatch("apiKeys", Filters.eq("value", apiKeyValue)));
-    }
-
-    /**
-     * Confirm that the requesting user has the required permissions
-     */
-    @Override
-    public boolean canBeManagedBy(RequestingUser requestingUser) {
-        if (requestingUser.apiUser != null && requestingUser.apiUser.id.equals(id)) {
-            // Otp user was created by this Api user.
-            return true;
-        }
-        // Fallback to Model#userCanManage.
-        return super.canBeManagedBy(requestingUser);
-    }
-
 }

--- a/src/main/java/org/opentripplanner/middleware/models/ApiUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ApiUser.java
@@ -97,18 +97,18 @@ public class ApiUser extends AbstractUser {
     }
 
     /**
-     * Shorthand method to determine if an API user has an API key.
+     * Shorthand method to determine if an API user has an API key id.
      */
-    public boolean hasKey(String apiKeyId) {
+    public boolean hasApiKeyId(String apiKeyId) {
         return apiKeys
             .stream()
             .anyMatch(apiKey -> apiKeyId.equals(apiKey.keyId));
     }
 
     /**
-     * Shorthand method to determine if an API user has an API token (value).
+     * Shorthand method to determine if an API user has an API key value.
      */
-    public boolean hasToken(String apiKeyValue) {
+    public boolean hasApiKeyValue(String apiKeyValue) {
         return apiKeys
             .stream()
             .anyMatch(apiKey -> apiKeyValue.equals(apiKey.value));

--- a/src/main/java/org/opentripplanner/middleware/models/Model.java
+++ b/src/main/java/org/opentripplanner/middleware/models/Model.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.middleware.models;
 
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 
 import java.io.Serializable;
 import java.util.Date;
@@ -27,7 +27,7 @@ public class Model implements Serializable {
      * This is a basic authorization check for any entity to determine if a user can create the entity. By default any
      * user can create any entity. This method should be overridden if there are more restrictions needed.
      */
-    public boolean canBeCreatedBy(Auth0UserProfile user) {
+    public boolean canBeCreatedBy(RequestingUser user) {
         return true;
     }
 
@@ -35,7 +35,7 @@ public class Model implements Serializable {
      * This is a basic authorization check for any entity to determine if a user can manage it. This method
      * should be overridden in subclasses in order to provide more fine-grained checks.
      */
-    public boolean canBeManagedBy(Auth0UserProfile user) {
+    public boolean canBeManagedBy(RequestingUser user) {
         // TODO: Check if user has application administrator permission?
         return isUserAdmin(user);
     }

--- a/src/main/java/org/opentripplanner/middleware/models/Model.java
+++ b/src/main/java/org/opentripplanner/middleware/models/Model.java
@@ -8,8 +8,6 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
 
-import static org.opentripplanner.middleware.auth.Auth0Connection.isUserAdmin;
-
 public class Model implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -38,7 +36,7 @@ public class Model implements Serializable {
      */
     public boolean canBeManagedBy(RequestingUser user) {
         // TODO: Check if user has application administrator permission?
-        return isUserAdmin(user);
+        return user.isAdmin();
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -243,7 +243,7 @@ public class MonitoredTrip extends Model {
 
         if (belongsToUser) {
             return true;
-        } else if (requestingUser.isThirdPartyUser()) {
+        } else if (requestingUser.apiUser != null) {
             // get the required OTP user to confirm they are associated with the requesting API user.
             OtpUser otpUser = Persistence.otpUsers.getById(userId);
             if (otpUser != null && otpUser.canBeManagedBy(requestingUser)) {

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -1,8 +1,6 @@
 package org.opentripplanner.middleware.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mongodb.client.model.Filters;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -248,7 +246,7 @@ public class MonitoredTrip extends Model {
         } else if (requestingUser.apiUser != null) {
             // get the required OTP user to confirm they are associated with the requesting API user.
             OtpUser otpUser = Persistence.otpUsers.getById(userId);
-            if (otpUser != null && otpUser.canBeManagedBy(requestingUser)) {
+            if (requestingUser.canManageEntity(otpUser)) {
                 return true;
             }
         } else if (requestingUser.isAdmin()) {

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.middleware.models;
 
 import org.bson.conversions.Bson;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.auth.Permission;
 import org.opentripplanner.middleware.otp.OtpDispatcherResponse;
 import org.opentripplanner.middleware.otp.response.Itinerary;
@@ -179,7 +179,7 @@ public class MonitoredTrip extends Model {
     }
 
     @Override
-    public boolean canBeCreatedBy(Auth0UserProfile profile) {
+    public boolean canBeCreatedBy(RequestingUser profile) {
         OtpUser otpUser = profile.otpUser;
         if (userId == null) {
             if (otpUser == null) {
@@ -200,7 +200,7 @@ public class MonitoredTrip extends Model {
      * Confirm that the requesting user has the required permissions
      */
     @Override
-    public boolean canBeManagedBy(Auth0UserProfile user) {
+    public boolean canBeManagedBy(RequestingUser user) {
         // This should not be possible, but return false on a null userId just in case.
         if (userId == null) return false;
         // If the user is attempting to update someone else's monitored trip, they must be admin.

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -237,16 +237,16 @@ public class MonitoredTrip extends Model {
         // OTP user is assigned to that API.
         boolean belongsToUser = false;
         // Monitored trip can only be owned by an OtpUser (not an ApiUser or AdminUser).
-        if (requestingUser.otpUser != null) {
+        if (requestingUser.isFirstPartyUser()) {
             belongsToUser = userId.equals(requestingUser.otpUser.id);
         }
 
         if (belongsToUser) {
             return true;
-        } else if (requestingUser.isThirdParty()) {
+        } else if (requestingUser.isThirdPartyUser()) {
             // get the required OTP user to confirm they are associated with the requesting API user.
             OtpUser otpUser = Persistence.otpUsers.getById(userId);
-            if (otpUser != null && requestingUser.apiUser.id.equals(otpUser.applicationId)) {
+            if (otpUser != null && otpUser.canBeManagedBy(requestingUser)) {
                 return true;
             }
         } else if (requestingUser.isAdmin()) {

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -212,7 +212,7 @@ public class MonitoredTrip extends Model {
 
         if (belongsToUser) {
             return true;
-        } else if (requestingUser.apiUser != null) {
+        } else if (requestingUser.isThirdPartyUser()) {
             // get the required OTP user to confirm they are associated with the requesting API user.
             OtpUser otpUser = Persistence.otpUsers.getById(userId);
             if (otpUser != null && requestingUser.apiUser.id.equals(otpUser.applicationId)) {

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.middleware.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mongodb.client.model.Filters;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -322,16 +324,6 @@ public class MonitoredTrip extends Model {
             new URI(String.format("http://example.com/plan?%s", queryParams)),
             StandardCharsets.UTF_8
         ).stream().collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue));
-    }
-
-    /**
-     * Check if the trip is planned with the target time being an arriveBy or departAt query.
-     *
-     * @return true, if the trip's target time is for an arriveBy query
-     */
-    public boolean isArriveBy() throws URISyntaxException {
-        // if arriveBy is not included in query params, OTP will default to false, so initialize to false
-        return parseQueryParams().getOrDefault("arriveBy", "false").equals("true");
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -237,7 +237,7 @@ public class MonitoredTrip extends Model {
         // OTP user is assigned to that API.
         boolean belongsToUser = false;
         // Monitored trip can only be owned by an OtpUser (not an ApiUser or AdminUser).
-        if (requestingUser.isFirstPartyUser()) {
+        if (requestingUser.otpUser != null) {
             belongsToUser = userId.equals(requestingUser.otpUser.id);
         }
 

--- a/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
@@ -86,7 +86,7 @@ public class OtpUser extends AbstractUser {
      */
     @Override
     public boolean canBeManagedBy(RequestingUser requestingUser) {
-        if (requestingUser.isThirdPartyUser() && requestingUser.apiUser.id.equals(applicationId)) {
+        if (requestingUser.apiUser.id.equals(applicationId)) {
             // Otp user was created by this Api user.
             return true;
         }

--- a/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
@@ -69,13 +69,12 @@ public class OtpUser extends AbstractUser {
             }
         }
 
-        if (deleteAuth0User) {
+        // Only attempt to delete Auth0 user if Otp user is not assigned to third party.
+        if (deleteAuth0User && applicationId.isEmpty()) {
             boolean auth0UserDeleted = super.delete();
             if (!auth0UserDeleted) {
                 LOG.warn("Aborting user deletion for {}", this.email);
-                // FIXME: This fails if an Api user is attempting to delete an Otp user they created. No Auth0 account
-                //  would have been created for this user.
-//                return false;
+                return false;
             }
         }
 

--- a/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
@@ -44,7 +44,7 @@ public class OtpUser extends AbstractUser {
     public boolean storeTripHistory;
 
     @JsonIgnore
-    /** If this user was created by an Api user, this parameter will match the Api user's id */
+    /** If this user was created by an {@link ApiUser}, this parameter will match the {@link ApiUser}'s id */
     public String applicationId;
 
     @Override

--- a/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
@@ -86,7 +86,7 @@ public class OtpUser extends AbstractUser {
      */
     @Override
     public boolean canBeManagedBy(RequestingUser requestingUser) {
-        if (requestingUser.apiUser != null && requestingUser.apiUser.id.equals(applicationId)) {
+        if (requestingUser.isThirdPartyUser() && requestingUser.apiUser.id.equals(applicationId)) {
             // Otp user was created by this Api user.
             return true;
         }

--- a/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
@@ -86,7 +86,7 @@ public class OtpUser extends AbstractUser {
      */
     @Override
     public boolean canBeManagedBy(RequestingUser requestingUser) {
-        if (requestingUser.isThirdPartyUser() && requestingUser.apiUser.id.equals(applicationId)) {
+        if (requestingUser.isThirdParty() && requestingUser.apiUser.id.equals(applicationId)) {
             // Otp user was created by this Api user.
             return true;
         }

--- a/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
@@ -86,7 +86,7 @@ public class OtpUser extends AbstractUser {
      */
     @Override
     public boolean canBeManagedBy(RequestingUser requestingUser) {
-        if (requestingUser.isThirdParty() && requestingUser.apiUser.id.equals(applicationId)) {
+        if (requestingUser.isThirdPartyUser() && requestingUser.apiUser.id.equals(applicationId)) {
             // Otp user was created by this Api user.
             return true;
         }

--- a/src/main/java/org/opentripplanner/middleware/tripMonitor/Main.java
+++ b/src/main/java/org/opentripplanner/middleware/tripMonitor/Main.java
@@ -8,10 +8,12 @@ import org.opentripplanner.middleware.utils.Scheduler;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import static org.opentripplanner.middleware.utils.ConfigUtils.loadConfig;
+
 public class Main {
     public static void main(String[] args) throws IOException {
         // Load configuration.
-        ConfigUtils.loadConfig(args);
+        loadConfig(args);
 
         // Connect to MongoDB.
         Persistence.initialize();

--- a/src/main/java/org/opentripplanner/middleware/tripMonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripMonitor/jobs/CheckMonitoredTrip.java
@@ -14,7 +14,6 @@ import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.LocalizedAlert;
 import org.opentripplanner.middleware.otp.response.OtpResponse;
 import org.opentripplanner.middleware.persistence.Persistence;
-import org.opentripplanner.middleware.utils.ConfigUtils;
 import org.opentripplanner.middleware.utils.DateTimeUtils;
 import org.opentripplanner.middleware.utils.NotificationUtils;
 import org.slf4j.Logger;

--- a/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
@@ -15,6 +15,8 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.util.Date;
 
+import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
+
 /**
  * Date and time specific utils. All timing in this application should be obtained by using this method in order to
  * ensure that the correct system clock is used. During testing, the internal clock is often set to a fixed instant to
@@ -143,7 +145,7 @@ public class DateTimeUtils {
      * timezone identifier of the first agency that it finds.
      */
     public static ZoneId getOtpZoneId() {
-        String otpTzId = ConfigUtils.getConfigPropertyAsText("OTP_TIMEZONE");
+        String otpTzId = getConfigPropertyAsText("OTP_TIMEZONE");
         if (otpTzId == null) {
             throw new RuntimeException("OTP_TIMEZONE is not defined in config!");
         }

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -239,7 +239,7 @@ paths:
         "200":
           description: "successful operation"
           schema:
-            type: "string"
+            $ref: "#/definitions/TokenHolder"
   /api/secure/application/fromtoken:
     get:
       tags:
@@ -826,6 +826,20 @@ definitions:
         type: "boolean"
       name:
         type: "string"
+  TokenHolder:
+    type: "object"
+    properties:
+      accessToken:
+        type: "string"
+      idToken:
+        type: "string"
+      refreshToken:
+        type: "string"
+      tokenType:
+        type: "string"
+      expiresIn:
+        type: "integer"
+        format: "int64"
   EncodedPolyline:
     type: "object"
     properties:

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   description: "OpenTripPlanner Middleware API"
-  version: "Local Build"
+  version: ""
   title: "OTP Middleware"
   termsOfService: ""
   contact:
@@ -12,348 +12,47 @@ info:
   license:
     name: "MIT License"
     url: "https://opensource.org/licenses/MIT"
-host: null
-basePath: "/null"
+host: "localhost:4567"
+basePath: "/"
 tags:
-  - name: "api/secure/monitoredtrip"
-    description: "Interface for querying and managing 'MonitoredTrip' entities."
-  - name: "api/secure/triprequests"
-    description: "Interface for retrieving trip requests."
-  - name: "api/secure/user"
-    description: "Interface for querying and managing 'OtpUser' entities."
-  - name: "otp"
-    description: "Proxy interface for OTP endpoints. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
+- name: "api/admin/user"
+  description: "Interface for querying and managing 'AdminUser' entities."
+- name: "api/secure/application"
+  description: "Interface for querying and managing 'ApiUser' entities."
+- name: "api/secure/monitoredtrip"
+  description: "Interface for querying and managing 'MonitoredTrip' entities."
+- name: "api/secure/triprequests"
+  description: "Interface for retrieving trip requests."
+- name: "api/secure/user"
+  description: "Interface for querying and managing 'OtpUser' entities."
+- name: "api/secure/logs"
+  description: "Interface for retrieving API logs from AWS."
+- name: "api/admin/bugsnag/eventsummary"
+  description: "Interface for reporting and retrieving application errors using Bugsnag."
+- name: "otp"
+  description: "Proxy interface for OTP endpoints. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
     \ API documentation</a> for OTP's supported API resources."
-  - name: "pelias"
-    description: "Proxy interface for Pelias geocoder. Refer to <a href='https://github.com/pelias/documentation/#endpoint-descriptions'>Pelias\
-    \ Geocoder Documentation</a> for API resources supported by Pelias Geocoder."
 schemes:
-  - "https"
+- "https"
 paths:
-  /api/secure/monitoredtrip:
+  /api/admin/user/fromtoken:
     get:
       tags:
-        - "api/secure/monitoredtrip"
-      description: "Gets a list of all 'MonitoredTrip' entities."
-      produces:
-        - "application/json"
-      parameters: []
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/MonitoredTrip"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
-    post:
-      tags:
-        - "api/secure/monitoredtrip"
-      description: "Creates a 'MonitoredTrip' entity."
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
-      parameters:
-        - in: "body"
-          description: "Body object description"
-          required: true
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
-  /api/secure/monitoredtrip/{id}:
-    get:
-      tags:
-        - "api/secure/monitoredtrip"
-      description: "Returns the 'MonitoredTrip' entity with the specified id, or 404\
-        \ if not found."
-      produces:
-        - "application/json"
-      parameters:
-        - name: "id"
-          in: "path"
-          description: "The id of the entity to search."
-          required: true
-          type: "string"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
-    put:
-      tags:
-        - "api/secure/monitoredtrip"
-      description: "Updates and returns the 'MonitoredTrip' entity with the specified\
-        \ id, or 404 if not found."
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
-      parameters:
-        - name: "id"
-          in: "path"
-          description: "The id of the entity to update."
-          required: true
-          type: "string"
-        - in: "body"
-          description: "Body object description"
-          required: true
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
-    delete:
-      tags:
-        - "api/secure/monitoredtrip"
-      description: "Deletes the 'MonitoredTrip' entity with the specified id if it\
-        \ exists."
-      produces:
-        - "application/json"
-      parameters:
-        - name: "id"
-          in: "path"
-          description: "The id of the entity to delete."
-          required: true
-          type: "string"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
-  /api/secure/triprequests:
-    get:
-      tags:
-        - "api/secure/triprequests"
-      description: "Gets a list of all trip requests for a user."
-      produces:
-        - "application/json"
-      parameters:
-        - name: "userId"
-          in: "query"
-          description: "The OTP user for which to retrieve trip requests."
-          required: false
-          type: "string"
-        - name: "limit"
-          in: "query"
-          description: "If specified, the maximum number of trip requests to return,\
-          \ starting from the most recent."
-          required: false
-          type: "string"
-          default: "10"
-        - name: "fromDate"
-          in: "query"
-          description: "If specified, the earliest date (format yyyy-MM-dd) for which\
-          \ trip requests are retrieved."
-          required: false
-          type: "string"
-          default: "The current date"
-          pattern: "yyyy-MM-dd"
-        - name: "toDate"
-          in: "query"
-          description: "If specified, the latest date (format yyyy-MM-dd) for which\
-          \ usage logs are retrieved."
-          required: false
-          type: "string"
-          default: "The current date"
-          pattern: "yyyy-MM-dd"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/TripRequest"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
-  /api/secure/user:
-    get:
-      tags:
-        - "api/secure/user"
-      description: "Gets a list of all 'OtpUser' entities."
-      produces:
-        - "application/json"
-      parameters: []
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/OtpUser"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
-    post:
-      tags:
-        - "api/secure/user"
-      description: "Creates a 'OtpUser' entity."
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
-      parameters:
-        - in: "body"
-          description: "Body object description"
-          required: true
-          schema:
-            $ref: "#/definitions/OtpUser"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/OtpUser"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
-  /api/secure/user/fromtoken:
-    get:
-      tags:
-        - "api/secure/user"
-      description: "Retrieves an OtpUser entity using an Auth0 access token passed\
+      - "api/admin/user"
+      description: "Retrieves an AdminUser entity using an Auth0 access token passed\
         \ in an Authorization header."
       produces:
-        - "application/json"
+      - "application/json"
       parameters: []
       responses:
         "200":
           description: "successful operation"
           schema:
-            $ref: "#/definitions/OtpUser"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
-  /api/secure/user/verification-email:
+            $ref: "#/definitions/AdminUser"
+  /api/admin/user/verification-email:
     get:
       tags:
-        - "api/secure/user"
+      - "api/admin/user"
       description: "Triggers a job to resend the Auth0 verification email."
       parameters: []
       responses:
@@ -361,274 +60,692 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/Job"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
-  /api/secure/user/{id}:
+  /api/admin/user:
     get:
       tags:
-        - "api/secure/user"
-      description: "Returns the 'OtpUser' entity with the specified id, or 404 if\
+      - "api/admin/user"
+      description: "Gets a list of all 'AdminUser' entities."
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AdminUser[]"
+    post:
+      tags:
+      - "api/admin/user"
+      description: "Creates a 'AdminUser' entity."
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        description: "Body object description"
+        required: true
+        schema:
+          $ref: "#/definitions/AdminUser"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AdminUser"
+  /api/admin/user/{id}:
+    get:
+      tags:
+      - "api/admin/user"
+      description: "Returns the 'AdminUser' entity with the specified id, or 404 if\
         \ not found."
       produces:
-        - "application/json"
+      - "application/json"
       parameters:
-        - name: "id"
-          in: "path"
-          description: "The id of the entity to search."
-          required: true
-          type: "string"
+      - name: "id"
+        in: "path"
+        description: "The id of the entity to search."
+        required: true
+        type: "string"
       responses:
         "200":
           description: "successful operation"
           schema:
-            $ref: "#/definitions/OtpUser"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
+            $ref: "#/definitions/AdminUser"
     put:
       tags:
-        - "api/secure/user"
-      description: "Updates and returns the 'OtpUser' entity with the specified id,\
-        \ or 404 if not found."
+      - "api/admin/user"
+      description: "Updates and returns the 'AdminUser' entity with the specified\
+        \ id, or 404 if not found."
       consumes:
-        - "application/json"
+      - "application/json"
       produces:
-        - "application/json"
+      - "application/json"
       parameters:
-        - name: "id"
-          in: "path"
-          description: "The id of the entity to update."
-          required: true
-          type: "string"
-        - in: "body"
-          description: "Body object description"
-          required: true
-          schema:
-            $ref: "#/definitions/OtpUser"
+      - name: "id"
+        in: "path"
+        description: "The id of the entity to update."
+        required: true
+        type: "string"
+      - in: "body"
+        description: "Body object description"
+        required: true
+        schema:
+          $ref: "#/definitions/AdminUser"
       responses:
         "200":
           description: "successful operation"
           schema:
-            $ref: "#/definitions/OtpUser"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
+            $ref: "#/definitions/AdminUser"
     delete:
       tags:
-        - "api/secure/user"
-      description: "Deletes the 'OtpUser' entity with the specified id if it exists."
+      - "api/admin/user"
+      description: "Deletes the 'AdminUser' entity with the specified id if it exists."
       produces:
-        - "application/json"
+      - "application/json"
       parameters:
-        - name: "id"
-          in: "path"
-          description: "The id of the entity to delete."
-          required: true
-          type: "string"
+      - name: "id"
+        in: "path"
+        description: "The id of the entity to delete."
+        required: true
+        type: "string"
       responses:
         "200":
           description: "successful operation"
           schema:
-            $ref: "#/definitions/OtpUser"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
+            $ref: "#/definitions/AdminUser"
+  /api/secure/application/{id}/apikey:
+    post:
+      tags:
+      - "api/secure/application"
+      description: "Creates API key for ApiUser (with optional AWS API Gateway usage\
+        \ plan ID)."
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The user ID"
+        required: true
+        type: "string"
+      - name: "usagePlanId"
+        in: "query"
+        description: "Optional AWS API Gateway usage plan ID."
+        required: false
+        type: "string"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ApiUser"
+  /api/secure/application/{id}/apikey/{apiKeyId}:
+    delete:
+      tags:
+      - "api/secure/application"
+      description: "Deletes API key for ApiUser."
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The user ID."
+        required: true
+        type: "string"
+      - name: "apiKeyId"
+        in: "path"
+        description: "The ID of the API key."
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ApiUser"
+  /api/secure/application/{id}/authenticate:
+    post:
+      tags:
+      - "api/secure/application"
+      description: "Authenticates ApiUser with Auth0."
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The user ID."
+        required: true
+        type: "string"
+      - name: "username"
+        in: "query"
+        description: "Auth0 username (usually email address)."
+        required: false
+        type: "string"
+      - name: "password"
+        in: "query"
+        description: "Auth0 password."
+        required: false
+        type: "string"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "string"
+  /api/secure/application/fromtoken:
+    get:
+      tags:
+      - "api/secure/application"
+      description: "Retrieves an ApiUser entity using an Auth0 access token passed\
+        \ in an Authorization header."
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ApiUser"
+  /api/secure/application/verification-email:
+    get:
+      tags:
+      - "api/secure/application"
+      description: "Triggers a job to resend the Auth0 verification email."
+      parameters: []
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Job"
+  /api/secure/application:
+    get:
+      tags:
+      - "api/secure/application"
+      description: "Gets a list of all 'ApiUser' entities."
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ApiUser[]"
+    post:
+      tags:
+      - "api/secure/application"
+      description: "Creates a 'ApiUser' entity."
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        description: "Body object description"
+        required: true
+        schema:
+          $ref: "#/definitions/ApiUser"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ApiUser"
+  /api/secure/application/{id}:
+    get:
+      tags:
+      - "api/secure/application"
+      description: "Returns the 'ApiUser' entity with the specified id, or 404 if\
+        \ not found."
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The id of the entity to search."
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ApiUser"
+    put:
+      tags:
+      - "api/secure/application"
+      description: "Updates and returns the 'ApiUser' entity with the specified id,\
+        \ or 404 if not found."
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The id of the entity to update."
+        required: true
+        type: "string"
+      - in: "body"
+        description: "Body object description"
+        required: true
+        schema:
+          $ref: "#/definitions/ApiUser"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ApiUser"
+    delete:
+      tags:
+      - "api/secure/application"
+      description: "Deletes the 'ApiUser' entity with the specified id if it exists."
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The id of the entity to delete."
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ApiUser"
+  /api/secure/monitoredtrip:
+    get:
+      tags:
+      - "api/secure/monitoredtrip"
+      description: "Gets a list of all 'MonitoredTrip' entities."
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/MonitoredTrip[]"
+    post:
+      tags:
+      - "api/secure/monitoredtrip"
+      description: "Creates a 'MonitoredTrip' entity."
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        description: "Body object description"
+        required: true
+        schema:
+          $ref: "#/definitions/MonitoredTrip"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/MonitoredTrip"
+  /api/secure/monitoredtrip/{id}:
+    get:
+      tags:
+      - "api/secure/monitoredtrip"
+      description: "Returns the 'MonitoredTrip' entity with the specified id, or 404\
+        \ if not found."
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The id of the entity to search."
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/MonitoredTrip"
+    put:
+      tags:
+      - "api/secure/monitoredtrip"
+      description: "Updates and returns the 'MonitoredTrip' entity with the specified\
+        \ id, or 404 if not found."
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The id of the entity to update."
+        required: true
+        type: "string"
+      - in: "body"
+        description: "Body object description"
+        required: true
+        schema:
+          $ref: "#/definitions/MonitoredTrip"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/MonitoredTrip"
+    delete:
+      tags:
+      - "api/secure/monitoredtrip"
+      description: "Deletes the 'MonitoredTrip' entity with the specified id if it\
+        \ exists."
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The id of the entity to delete."
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/MonitoredTrip"
+  /api/secure/triprequests:
+    get:
+      tags:
+      - "api/secure/triprequests"
+      description: "Gets a list of all trip requests for a user."
+      produces:
+      - "application/json"
+      parameters:
+      - name: "userId"
+        in: "query"
+        description: "The OTP user for which to retrieve trip requests."
+        required: false
+        type: "string"
+      - name: "limit"
+        in: "query"
+        description: "If specified, the maximum number of trip requests to return,\
+          \ starting from the most recent."
+        required: false
+        type: "string"
+        default: "10"
+      - name: "fromDate"
+        in: "query"
+        description: "If specified, the earliest date (format yyyy-MM-dd) for which\
+          \ trip requests are retrieved."
+        required: false
+        type: "string"
+        default: "The current date"
+        pattern: "yyyy-MM-dd"
+      - name: "toDate"
+        in: "query"
+        description: "If specified, the latest date (format yyyy-MM-dd) for which\
+          \ usage logs are retrieved."
+        required: false
+        type: "string"
+        default: "The current date"
+        pattern: "yyyy-MM-dd"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/TripRequest"
   /api/secure/user/{id}/verify_sms:
     get:
       tags:
-        - "api/secure/user"
+      - "api/secure/user"
       description: "Request an SMS verification to be sent to an OtpUser's phone number."
       parameters:
-        - name: "id"
-          in: "path"
-          description: "The id of the OtpUser."
-          required: true
-          type: "string"
+      - name: "id"
+        in: "path"
+        description: "The id of the OtpUser."
+        required: true
+        type: "string"
       responses:
         "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/VerificationResult"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
   /api/secure/user/{id}/verify_sms/{code}:
     post:
       tags:
-        - "api/secure/user"
+      - "api/secure/user"
       description: "Verify an OtpUser's phone number with a verification code."
       parameters:
-        - name: "id"
-          in: "path"
-          description: "The id of the OtpUser."
-          required: true
-          type: "string"
-        - name: "code"
-          in: "path"
-          description: "The SMS verification code."
-          required: true
-          type: "string"
+      - name: "id"
+        in: "path"
+        description: "The id of the OtpUser."
+        required: true
+        type: "string"
+      - name: "code"
+        in: "path"
+        description: "The SMS verification code."
+        required: true
+        type: "string"
       responses:
         "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/VerificationResult"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-      security:
-        - api_key: []
-        - bearer_token: []
+  /api/secure/user/fromtoken:
+    get:
+      tags:
+      - "api/secure/user"
+      description: "Retrieves an OtpUser entity using an Auth0 access token passed\
+        \ in an Authorization header."
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/OtpUser"
+  /api/secure/user/verification-email:
+    get:
+      tags:
+      - "api/secure/user"
+      description: "Triggers a job to resend the Auth0 verification email."
+      parameters: []
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Job"
+  /api/secure/user:
+    get:
+      tags:
+      - "api/secure/user"
+      description: "Gets a list of all 'OtpUser' entities."
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/OtpUser[]"
+    post:
+      tags:
+      - "api/secure/user"
+      description: "Creates a 'OtpUser' entity."
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        description: "Body object description"
+        required: true
+        schema:
+          $ref: "#/definitions/OtpUser"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/OtpUser"
+  /api/secure/user/{id}:
+    get:
+      tags:
+      - "api/secure/user"
+      description: "Returns the 'OtpUser' entity with the specified id, or 404 if\
+        \ not found."
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The id of the entity to search."
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/OtpUser"
+    put:
+      tags:
+      - "api/secure/user"
+      description: "Updates and returns the 'OtpUser' entity with the specified id,\
+        \ or 404 if not found."
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The id of the entity to update."
+        required: true
+        type: "string"
+      - in: "body"
+        description: "Body object description"
+        required: true
+        schema:
+          $ref: "#/definitions/OtpUser"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/OtpUser"
+    delete:
+      tags:
+      - "api/secure/user"
+      description: "Deletes the 'OtpUser' entity with the specified id if it exists."
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The id of the entity to delete."
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/OtpUser"
+  /api/secure/logs:
+    get:
+      tags:
+      - "api/secure/logs"
+      description: "Gets a list of all API usage logs."
+      produces:
+      - "application/json"
+      parameters:
+      - name: "keyId"
+        in: "query"
+        description: "If specified, restricts the search to the specified AWS API\
+          \ key ID."
+        required: false
+        type: "string"
+      - name: "startDate"
+        in: "query"
+        description: "If specified, the earliest date (format yyyy-MM-dd) for which\
+          \ usage logs are retrieved."
+        required: false
+        type: "string"
+        default: "30 days prior to the current date"
+        pattern: "yyyy-MM-dd"
+      - name: "endDate"
+        in: "query"
+        description: "If specified, the latest date (format yyyy-MM-dd) for which\
+          \ usage logs are retrieved."
+        required: false
+        type: "string"
+        default: "The current date"
+        pattern: "yyyy-MM-dd"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ApiUsageResult"
+  /api/admin/bugsnag/eventsummary:
+    get:
+      tags:
+      - "api/admin/bugsnag/eventsummary"
+      description: "Gets a list of all Bugsnag event summaries."
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BugsnagEvent"
   /otp/*:
     get:
       tags:
-        - "otp"
+      - "otp"
       description: "Forwards any GET request to OTP. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
         \ API documentation</a> for OTP's supported API resources."
       produces:
-        - "application/json"
-        - "application/xml"
+      - "application/json"
+      - "application/xml"
       parameters: []
       responses:
         "200":
           description: "successful operation"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
-  /pelias/*:
-    get:
-      tags:
-        - "pelias"
-      description: "Forwards any GET request to Pelias Geocoder. Refer to <a href='https://github.com/pelias/documentation/#endpoint-descriptions'>Pelias\
-        \ Geocoder Documentation</a> for API resources supported by Pelias Geocoder."
-      produces:
-        - "application/json"
-      parameters: []
-      security:
-        - api_key: []
-      responses:
-        "200":
-          description: "successful operation"
-        "400":
-          $ref: "#/responses/400"
-        "401":
-          $ref: "#/responses/401"
-        "403":
-          $ref: "#/responses/403"
-        "404":
-          $ref: "#/responses/404"
-        "500":
-          $ref: "#/responses/500"
-        default:
-          $ref: "#/responses/default"
 definitions:
-  AbstractUser:
+  AdminUser:
     type: "object"
-    required:
-      - "auth0UserId"
-      - "email"
+  Job:
+    type: "object"
     properties:
-      email:
+      status:
         type: "string"
-        description: "Email address for contact. This must be unique in the collection."
-      auth0UserId:
+      type:
         type: "string"
-        description: "Auth0 user name."
-      isDataToolsUser:
+      createdAt:
+        type: "string"
+        format: "date"
+      id:
+        type: "string"
+  AdminUser[]:
+    type: "object"
+  ApiKey:
+    type: "object"
+    properties:
+      keyId:
+        type: "string"
+      name:
+        type: "string"
+      value:
+        type: "string"
+  ApiUser:
+    type: "object"
+    properties:
+      apiKeys:
+        type: "array"
+        items:
+          $ref: "#/definitions/ApiKey"
+      appName:
+        type: "string"
+      appPurpose:
+        type: "string"
+      appUrl:
+        type: "string"
+      company:
+        type: "string"
+      hasConsentedToTerms:
         type: "boolean"
-        description: "Determines whether this user has access to OTP Data Tools."
-    description: "An abstract user."
-  Currency:
+      name:
+        type: "string"
+  ApiUser[]:
     type: "object"
-    properties:
-      symbol:
-        type: "string"
-      currency:
-        type: "string"
-      defaultFractionDigits:
-        type: "integer"
-        format: "int32"
-      currencyCode:
-        type: "string"
+  MonitoredTrip[]:
+    type: "object"
   EncodedPolyline:
     type: "object"
     properties:
@@ -639,32 +756,6 @@ definitions:
       length:
         type: "integer"
         format: "int32"
-  Fare:
-    type: "object"
-    properties:
-      regular:
-        $ref: "#/definitions/Price"
-      student:
-        $ref: "#/definitions/Price"
-      senior:
-        $ref: "#/definitions/Price"
-      tram:
-        $ref: "#/definitions/Price"
-      special:
-        $ref: "#/definitions/Price"
-      youth:
-        $ref: "#/definitions/Price"
-  FareComponent:
-    type: "object"
-    properties:
-      fareId:
-        type: "string"
-      price:
-        $ref: "#/definitions/Price"
-      routes:
-        type: "array"
-        items:
-          type: "string"
   FareDetails:
     type: "object"
     properties:
@@ -692,66 +783,45 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/FareComponent"
-  FareWrapper:
+  Step:
     type: "object"
     properties:
-      fare:
-        $ref: "#/definitions/Fare"
-      details:
-        $ref: "#/definitions/FareDetails"
-  Itinerary:
-    type: "object"
-    properties:
-      duration:
-        type: "integer"
-        format: "int64"
-      startTime:
-        type: "string"
-        format: "date"
-      endTime:
-        type: "string"
-        format: "date"
-      walkTime:
-        type: "integer"
-        format: "int64"
-      transitTime:
-        type: "integer"
-        format: "int64"
-      waitingTime:
-        type: "integer"
-        format: "int64"
-      walkDistance:
+      distance:
         type: "number"
         format: "double"
-      walkLimitExceeded:
+      relativeDirection:
+        type: "string"
+      streetName:
+        type: "string"
+      absoluteDirection:
+        type: "string"
+      stayOn:
         type: "boolean"
-      elevationLost:
+      area:
+        type: "boolean"
+      bogusName:
+        type: "boolean"
+      lon:
         type: "number"
         format: "double"
-      elevationGained:
+      lat:
         type: "number"
         format: "double"
-      transfers:
-        type: "integer"
-        format: "int32"
-      fare:
-        $ref: "#/definitions/FareWrapper"
-      legs:
-        type: "array"
-        items:
-          $ref: "#/definitions/Leg"
-  Job:
+  Fare:
     type: "object"
     properties:
-      status:
-        type: "string"
-      type:
-        type: "string"
-      createdAt:
-        type: "string"
-        format: "date"
-      id:
-        type: "string"
+      regular:
+        $ref: "#/definitions/Price"
+      student:
+        $ref: "#/definitions/Price"
+      senior:
+        $ref: "#/definitions/Price"
+      tram:
+        $ref: "#/definitions/Price"
+      special:
+        $ref: "#/definitions/Price"
+      youth:
+        $ref: "#/definitions/Price"
   Leg:
     type: "object"
     properties:
@@ -834,6 +904,128 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/LocalizedAlert"
+  Price:
+    type: "object"
+    properties:
+      currency:
+        $ref: "#/definitions/Currency"
+      cents:
+        type: "integer"
+        format: "int32"
+  Currency:
+    type: "object"
+    properties:
+      symbol:
+        type: "string"
+      currency:
+        type: "string"
+      defaultFractionDigits:
+        type: "integer"
+        format: "int32"
+      currencyCode:
+        type: "string"
+  Itinerary:
+    type: "object"
+    properties:
+      duration:
+        type: "integer"
+        format: "int64"
+      startTime:
+        type: "string"
+        format: "date"
+      endTime:
+        type: "string"
+        format: "date"
+      walkTime:
+        type: "integer"
+        format: "int64"
+      transitTime:
+        type: "integer"
+        format: "int64"
+      waitingTime:
+        type: "integer"
+        format: "int64"
+      walkDistance:
+        type: "number"
+        format: "double"
+      walkLimitExceeded:
+        type: "boolean"
+      elevationLost:
+        type: "number"
+        format: "double"
+      elevationGained:
+        type: "number"
+        format: "double"
+      transfers:
+        type: "integer"
+        format: "int32"
+      fare:
+        $ref: "#/definitions/FareWrapper"
+      legs:
+        type: "array"
+        items:
+          $ref: "#/definitions/Leg"
+  FareComponent:
+    type: "object"
+    properties:
+      fareId:
+        type: "string"
+      price:
+        $ref: "#/definitions/Price"
+      routes:
+        type: "array"
+        items:
+          type: "string"
+  FareWrapper:
+    type: "object"
+    properties:
+      fare:
+        $ref: "#/definitions/Fare"
+      details:
+        $ref: "#/definitions/FareDetails"
+  Place:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      lon:
+        type: "number"
+        format: "double"
+      lat:
+        type: "number"
+        format: "double"
+      departure:
+        type: "string"
+        format: "date"
+      orig:
+        type: "string"
+      vertexType:
+        type: "string"
+      stopId:
+        type: "string"
+      arrival:
+        type: "string"
+        format: "date"
+      stopIndex:
+        type: "integer"
+        format: "int32"
+      stopSequence:
+        type: "integer"
+        format: "int32"
+      stopCode:
+        type: "string"
+      platformCode:
+        type: "string"
+      zoneId:
+        type: "string"
+      bikeShareId:
+        type: "string"
+      networks:
+        type: "array"
+        items:
+          type: "string"
+      address:
+        type: "string"
   LocalizedAlert:
     type: "object"
     properties:
@@ -894,102 +1086,6 @@ definitions:
         format: "int32"
       notifyOnItineraryChange:
         type: "boolean"
-  OtpUser:
-    allOf:
-      - $ref: "#/definitions/AbstractUser"
-      - type: "object"
-        properties:
-          hasConsentedToTerms:
-            type: "boolean"
-          isPhoneNumberVerified:
-            type: "boolean"
-          notificationChannel:
-            type: "string"
-          phoneNumber:
-            type: "string"
-          savedLocations:
-            type: "array"
-            items:
-              $ref: "#/definitions/UserLocation"
-          storeTripHistory:
-            type: "boolean"
-          applicationId:
-            type: "string"
-  Place:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      lon:
-        type: "number"
-        format: "double"
-      lat:
-        type: "number"
-        format: "double"
-      departure:
-        type: "string"
-        format: "date"
-      orig:
-        type: "string"
-      vertexType:
-        type: "string"
-      stopId:
-        type: "string"
-      arrival:
-        type: "string"
-        format: "date"
-      stopIndex:
-        type: "integer"
-        format: "int32"
-      stopSequence:
-        type: "integer"
-        format: "int32"
-      stopCode:
-        type: "string"
-      platformCode:
-        type: "string"
-      zoneId:
-        type: "string"
-      bikeShareId:
-        type: "string"
-      networks:
-        type: "array"
-        items:
-          type: "string"
-      address:
-        type: "string"
-  Price:
-    type: "object"
-    properties:
-      currency:
-        $ref: "#/definitions/Currency"
-      cents:
-        type: "integer"
-        format: "int32"
-  Step:
-    type: "object"
-    properties:
-      distance:
-        type: "number"
-        format: "double"
-      relativeDirection:
-        type: "string"
-      streetName:
-        type: "string"
-      absoluteDirection:
-        type: "string"
-      stayOn:
-        type: "boolean"
-      area:
-        type: "boolean"
-      bogusName:
-        type: "boolean"
-      lon:
-        type: "number"
-        format: "double"
-      lat:
-        type: "number"
-        format: "double"
   TripRequest:
     type: "object"
     properties:
@@ -1003,6 +1099,15 @@ definitions:
         type: "string"
       queryParams:
         type: "string"
+  VerificationResult:
+    type: "object"
+    properties:
+      sid:
+        type: "string"
+      status:
+        type: "string"
+      valid:
+        type: "boolean"
   UserLocation:
     type: "object"
     properties:
@@ -1020,44 +1125,83 @@ definitions:
         type: "string"
       type:
         type: "string"
-  VerificationResult:
+  OtpUser:
     type: "object"
     properties:
-      sid:
-        type: "string"
-      status:
-        type: "string"
-      valid:
+      hasConsentedToTerms:
         type: "boolean"
+      isPhoneNumberVerified:
+        type: "boolean"
+      notificationChannel:
+        type: "string"
+      phoneNumber:
+        type: "string"
+      savedLocations:
+        type: "array"
+        items:
+          $ref: "#/definitions/UserLocation"
+      storeTripHistory:
+        type: "boolean"
+      applicationId:
+        type: "string"
+  OtpUser[]:
+    type: "object"
+  GetUsageResult:
+    type: "object"
+    properties:
+      usagePlanId:
+        type: "string"
+      startDate:
+        type: "string"
+      endDate:
+        type: "string"
+      position:
+        type: "string"
+      items:
+        $ref: "#/definitions/Map"
+  ApiUsageResult:
+    type: "object"
+    properties:
+      result:
+        $ref: "#/definitions/GetUsageResult"
+      apiUsers:
+        $ref: "#/definitions/Map"
+  App:
+    type: "object"
+    properties:
+      releaseStage:
+        type: "string"
+  BugsnagEvent:
+    type: "object"
+    properties:
+      eventDataId:
+        type: "string"
+      projectId:
+        type: "string"
+      errorId:
+        type: "string"
+      receivedAt:
+        type: "string"
+        format: "date"
+      exceptions:
+        type: "array"
+        items:
+          $ref: "#/definitions/EventException"
+      severity:
+        type: "string"
+      context:
+        type: "string"
+      unhandled:
+        type: "boolean"
+      app:
+        $ref: "#/definitions/App"
+  EventException:
+    type: "object"
+    properties:
+      errorClass:
+        type: "string"
+      message:
+        type: "string"
 externalDocs:
   description: ""
   url: ""
-securityDefinitions:
-  api_key:
-    description: "API key header authentication."
-    in: "header"
-    name: "x-api-key"
-    type: "apiKey"
-  bearer_token:
-    description: "Bearer token authentication using Auth0."
-    in: "header"
-    name: "Authorization"
-    type: "apiKey"
-responses:
-  "400":
-    description: "The request was not formed properly (e.g., some required parameters\
-      \ may be missing). See the details of the returned response to determine the\
-      \ exact issue."
-  "401":
-    description: "The server was not able to authenticate the request. This can happen\
-      \ if authentication headers are missing or malformed, or the authentication\
-      \ server cannot be reached."
-  "403":
-    description: "The requesting user is not allowed to perform the request."
-  "404":
-    description: "The requested item was not found."
-  "500":
-    description: "An error occurred while performing the request. Contact an API administrator\
-      \ for more information."
-  default:
-    description: "An unexpected error occurred."

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -778,7 +778,13 @@ paths:
       produces:
       - "application/json"
       - "application/xml"
-      parameters: []
+      parameters:
+      - name: "userId"
+        in: "query"
+        description: "If a third party user is making a trip request on behalf of\
+          \ an OTP user, the OTP user id must be specified."
+        required: false
+        type: "string"
       responses:
         "200":
           description: "successful operation"

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   description: "OpenTripPlanner Middleware API"
-  version: ""
+  version: "Local Build"
   title: "OTP Middleware"
   termsOfService: ""
   contact:
@@ -12,502 +12,348 @@ info:
   license:
     name: "MIT License"
     url: "https://opensource.org/licenses/MIT"
-host: "localhost:4567"
-basePath: "/"
+host: null
+basePath: "/null"
 tags:
-- name: "api/admin/user"
-  description: "Interface for querying and managing 'AdminUser' entities."
-- name: "api/secure/application"
-  description: "Interface for querying and managing 'ApiUser' entities."
-- name: "api/secure/monitoredtrip"
-  description: "Interface for querying and managing 'MonitoredTrip' entities."
-- name: "api/secure/triprequests"
-  description: "Interface for retrieving trip requests."
-- name: "api/secure/user"
-  description: "Interface for querying and managing 'OtpUser' entities."
-- name: "api/secure/logs"
-  description: "Interface for retrieving API logs from AWS."
-- name: "api/admin/bugsnag/eventsummary"
-  description: "Interface for reporting and retrieving application errors using Bugsnag."
-- name: "otp"
-  description: "Proxy interface for OTP endpoints. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
+  - name: "api/secure/monitoredtrip"
+    description: "Interface for querying and managing 'MonitoredTrip' entities."
+  - name: "api/secure/triprequests"
+    description: "Interface for retrieving trip requests."
+  - name: "api/secure/user"
+    description: "Interface for querying and managing 'OtpUser' entities."
+  - name: "otp"
+    description: "Proxy interface for OTP endpoints. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
     \ API documentation</a> for OTP's supported API resources."
+  - name: "pelias"
+    description: "Proxy interface for Pelias geocoder. Refer to <a href='https://github.com/pelias/documentation/#endpoint-descriptions'>Pelias\
+    \ Geocoder Documentation</a> for API resources supported by Pelias Geocoder."
 schemes:
-- "https"
+  - "https"
 paths:
-  /api/admin/user/fromtoken:
-    get:
-      tags:
-      - "api/admin/user"
-      description: "Retrieves an AdminUser entity using an Auth0 access token passed\
-        \ in an Authorization header."
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AdminUser"
-  /api/admin/user/verification-email:
-    get:
-      tags:
-      - "api/admin/user"
-      description: "Triggers a job to resend the Auth0 verification email."
-      parameters: []
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
-  /api/admin/user:
-    get:
-      tags:
-      - "api/admin/user"
-      description: "Gets a list of all 'AdminUser' entities."
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AdminUser[]"
-    post:
-      tags:
-      - "api/admin/user"
-      description: "Creates a 'AdminUser' entity."
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        description: "Body object description"
-        required: true
-        schema:
-          $ref: "#/definitions/AdminUser"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AdminUser"
-  /api/admin/user/{id}:
-    get:
-      tags:
-      - "api/admin/user"
-      description: "Returns the 'AdminUser' entity with the specified id, or 404 if\
-        \ not found."
-      produces:
-      - "application/json"
-      parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the entity to search."
-        required: true
-        type: "string"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AdminUser"
-    put:
-      tags:
-      - "api/admin/user"
-      description: "Updates and returns the 'AdminUser' entity with the specified\
-        \ id, or 404 if not found."
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the entity to update."
-        required: true
-        type: "string"
-      - in: "body"
-        description: "Body object description"
-        required: true
-        schema:
-          $ref: "#/definitions/AdminUser"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AdminUser"
-    delete:
-      tags:
-      - "api/admin/user"
-      description: "Deletes the 'AdminUser' entity with the specified id if it exists."
-      produces:
-      - "application/json"
-      parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the entity to delete."
-        required: true
-        type: "string"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AdminUser"
-  /api/secure/application/{id}/apikey:
-    post:
-      tags:
-      - "api/secure/application"
-      description: "Creates API key for ApiUser (with optional AWS API Gateway usage\
-        \ plan ID)."
-      produces:
-      - "application/json"
-      parameters:
-      - name: "id"
-        in: "path"
-        description: "The user ID"
-        required: true
-        type: "string"
-      - name: "usagePlanId"
-        in: "query"
-        description: "Optional AWS API Gateway usage plan ID."
-        required: false
-        type: "string"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ApiUser"
-  /api/secure/application/{id}/apikey/{apiKeyId}:
-    delete:
-      tags:
-      - "api/secure/application"
-      description: "Deletes API key for ApiUser."
-      produces:
-      - "application/json"
-      parameters:
-      - name: "id"
-        in: "path"
-        description: "The user ID."
-        required: true
-        type: "string"
-      - name: "apiKeyId"
-        in: "path"
-        description: "The ID of the API key."
-        required: true
-        type: "string"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ApiUser"
-  /api/secure/application/fromtoken:
-    get:
-      tags:
-      - "api/secure/application"
-      description: "Retrieves an ApiUser entity using an Auth0 access token passed\
-        \ in an Authorization header."
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ApiUser"
-  /api/secure/application/verification-email:
-    get:
-      tags:
-      - "api/secure/application"
-      description: "Triggers a job to resend the Auth0 verification email."
-      parameters: []
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
-  /api/secure/application:
-    get:
-      tags:
-      - "api/secure/application"
-      description: "Gets a list of all 'ApiUser' entities."
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ApiUser[]"
-    post:
-      tags:
-      - "api/secure/application"
-      description: "Creates a 'ApiUser' entity."
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        description: "Body object description"
-        required: true
-        schema:
-          $ref: "#/definitions/ApiUser"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ApiUser"
-  /api/secure/application/{id}:
-    get:
-      tags:
-      - "api/secure/application"
-      description: "Returns the 'ApiUser' entity with the specified id, or 404 if\
-        \ not found."
-      produces:
-      - "application/json"
-      parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the entity to search."
-        required: true
-        type: "string"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ApiUser"
-    put:
-      tags:
-      - "api/secure/application"
-      description: "Updates and returns the 'ApiUser' entity with the specified id,\
-        \ or 404 if not found."
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the entity to update."
-        required: true
-        type: "string"
-      - in: "body"
-        description: "Body object description"
-        required: true
-        schema:
-          $ref: "#/definitions/ApiUser"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ApiUser"
-    delete:
-      tags:
-      - "api/secure/application"
-      description: "Deletes the 'ApiUser' entity with the specified id if it exists."
-      produces:
-      - "application/json"
-      parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the entity to delete."
-        required: true
-        type: "string"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ApiUser"
   /api/secure/monitoredtrip:
     get:
       tags:
-      - "api/secure/monitoredtrip"
+        - "api/secure/monitoredtrip"
       description: "Gets a list of all 'MonitoredTrip' entities."
       produces:
-      - "application/json"
+        - "application/json"
       parameters: []
       responses:
         "200":
           description: "successful operation"
           schema:
-            $ref: "#/definitions/MonitoredTrip[]"
+            type: "array"
+            items:
+              $ref: "#/definitions/MonitoredTrip"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
     post:
       tags:
-      - "api/secure/monitoredtrip"
+        - "api/secure/monitoredtrip"
       description: "Creates a 'MonitoredTrip' entity."
       consumes:
-      - "application/json"
+        - "application/json"
       produces:
-      - "application/json"
+        - "application/json"
       parameters:
-      - in: "body"
-        description: "Body object description"
-        required: true
-        schema:
-          $ref: "#/definitions/MonitoredTrip"
+        - in: "body"
+          description: "Body object description"
+          required: true
+          schema:
+            $ref: "#/definitions/MonitoredTrip"
       responses:
         "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/MonitoredTrip"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
   /api/secure/monitoredtrip/{id}:
     get:
       tags:
-      - "api/secure/monitoredtrip"
+        - "api/secure/monitoredtrip"
       description: "Returns the 'MonitoredTrip' entity with the specified id, or 404\
         \ if not found."
       produces:
-      - "application/json"
+        - "application/json"
       parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the entity to search."
-        required: true
-        type: "string"
+        - name: "id"
+          in: "path"
+          description: "The id of the entity to search."
+          required: true
+          type: "string"
       responses:
         "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/MonitoredTrip"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
     put:
       tags:
-      - "api/secure/monitoredtrip"
+        - "api/secure/monitoredtrip"
       description: "Updates and returns the 'MonitoredTrip' entity with the specified\
         \ id, or 404 if not found."
       consumes:
-      - "application/json"
+        - "application/json"
       produces:
-      - "application/json"
+        - "application/json"
       parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the entity to update."
-        required: true
-        type: "string"
-      - in: "body"
-        description: "Body object description"
-        required: true
-        schema:
-          $ref: "#/definitions/MonitoredTrip"
+        - name: "id"
+          in: "path"
+          description: "The id of the entity to update."
+          required: true
+          type: "string"
+        - in: "body"
+          description: "Body object description"
+          required: true
+          schema:
+            $ref: "#/definitions/MonitoredTrip"
       responses:
         "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/MonitoredTrip"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
     delete:
       tags:
-      - "api/secure/monitoredtrip"
+        - "api/secure/monitoredtrip"
       description: "Deletes the 'MonitoredTrip' entity with the specified id if it\
         \ exists."
       produces:
-      - "application/json"
+        - "application/json"
       parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the entity to delete."
-        required: true
-        type: "string"
+        - name: "id"
+          in: "path"
+          description: "The id of the entity to delete."
+          required: true
+          type: "string"
       responses:
         "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/MonitoredTrip"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
   /api/secure/triprequests:
     get:
       tags:
-      - "api/secure/triprequests"
+        - "api/secure/triprequests"
       description: "Gets a list of all trip requests for a user."
       produces:
-      - "application/json"
+        - "application/json"
       parameters:
-      - name: "userId"
-        in: "query"
-        description: "The OTP user for which to retrieve trip requests."
-        required: false
-        type: "string"
-      - name: "limit"
-        in: "query"
-        description: "If specified, the maximum number of trip requests to return,\
+        - name: "userId"
+          in: "query"
+          description: "The OTP user for which to retrieve trip requests."
+          required: false
+          type: "string"
+        - name: "limit"
+          in: "query"
+          description: "If specified, the maximum number of trip requests to return,\
           \ starting from the most recent."
-        required: false
-        type: "string"
-        default: "10"
-      - name: "fromDate"
-        in: "query"
-        description: "If specified, the earliest date (format yyyy-MM-dd) for which\
+          required: false
+          type: "string"
+          default: "10"
+        - name: "fromDate"
+          in: "query"
+          description: "If specified, the earliest date (format yyyy-MM-dd) for which\
           \ trip requests are retrieved."
-        required: false
-        type: "string"
-        default: "The current date"
-        pattern: "yyyy-MM-dd"
-      - name: "toDate"
-        in: "query"
-        description: "If specified, the latest date (format yyyy-MM-dd) for which\
+          required: false
+          type: "string"
+          default: "The current date"
+          pattern: "yyyy-MM-dd"
+        - name: "toDate"
+          in: "query"
+          description: "If specified, the latest date (format yyyy-MM-dd) for which\
           \ usage logs are retrieved."
-        required: false
-        type: "string"
-        default: "The current date"
-        pattern: "yyyy-MM-dd"
+          required: false
+          type: "string"
+          default: "The current date"
+          pattern: "yyyy-MM-dd"
       responses:
         "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/TripRequest"
-  /api/secure/user/{id}/verify_sms:
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
+  /api/secure/user:
     get:
       tags:
-      - "api/secure/user"
-      description: "Request an SMS verification to be sent to an OtpUser's phone number."
-      parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the OtpUser."
-        required: true
-        type: "string"
+        - "api/secure/user"
+      description: "Gets a list of all 'OtpUser' entities."
+      produces:
+        - "application/json"
+      parameters: []
       responses:
         "200":
           description: "successful operation"
           schema:
-            $ref: "#/definitions/VerificationResult"
-  /api/secure/user/{id}/verify_sms/{code}:
+            type: "array"
+            items:
+              $ref: "#/definitions/OtpUser"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
     post:
       tags:
-      - "api/secure/user"
-      description: "Verify an OtpUser's phone number with a verification code."
+        - "api/secure/user"
+      description: "Creates a 'OtpUser' entity."
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
       parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the OtpUser."
-        required: true
-        type: "string"
-      - name: "code"
-        in: "path"
-        description: "The SMS verification code."
-        required: true
-        type: "string"
+        - in: "body"
+          description: "Body object description"
+          required: true
+          schema:
+            $ref: "#/definitions/OtpUser"
       responses:
         "200":
           description: "successful operation"
           schema:
-            $ref: "#/definitions/VerificationResult"
+            $ref: "#/definitions/OtpUser"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
   /api/secure/user/fromtoken:
     get:
       tags:
-      - "api/secure/user"
+        - "api/secure/user"
       description: "Retrieves an OtpUser entity using an Auth0 access token passed\
         \ in an Authorization header."
       produces:
-      - "application/json"
+        - "application/json"
       parameters: []
       responses:
         "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/OtpUser"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
   /api/secure/user/verification-email:
     get:
       tags:
-      - "api/secure/user"
+        - "api/secure/user"
       description: "Triggers a job to resend the Auth0 verification email."
       parameters: []
       responses:
@@ -515,209 +361,274 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/Job"
-  /api/secure/user:
-    get:
-      tags:
-      - "api/secure/user"
-      description: "Gets a list of all 'OtpUser' entities."
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/OtpUser[]"
-    post:
-      tags:
-      - "api/secure/user"
-      description: "Creates a 'OtpUser' entity."
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        description: "Body object description"
-        required: true
-        schema:
-          $ref: "#/definitions/OtpUser"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/OtpUser"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
   /api/secure/user/{id}:
     get:
       tags:
-      - "api/secure/user"
+        - "api/secure/user"
       description: "Returns the 'OtpUser' entity with the specified id, or 404 if\
         \ not found."
       produces:
-      - "application/json"
+        - "application/json"
       parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the entity to search."
-        required: true
-        type: "string"
+        - name: "id"
+          in: "path"
+          description: "The id of the entity to search."
+          required: true
+          type: "string"
       responses:
         "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/OtpUser"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
     put:
       tags:
-      - "api/secure/user"
+        - "api/secure/user"
       description: "Updates and returns the 'OtpUser' entity with the specified id,\
         \ or 404 if not found."
       consumes:
-      - "application/json"
+        - "application/json"
       produces:
-      - "application/json"
+        - "application/json"
       parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the entity to update."
-        required: true
-        type: "string"
-      - in: "body"
-        description: "Body object description"
-        required: true
-        schema:
-          $ref: "#/definitions/OtpUser"
+        - name: "id"
+          in: "path"
+          description: "The id of the entity to update."
+          required: true
+          type: "string"
+        - in: "body"
+          description: "Body object description"
+          required: true
+          schema:
+            $ref: "#/definitions/OtpUser"
       responses:
         "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/OtpUser"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
     delete:
       tags:
-      - "api/secure/user"
+        - "api/secure/user"
       description: "Deletes the 'OtpUser' entity with the specified id if it exists."
       produces:
-      - "application/json"
+        - "application/json"
       parameters:
-      - name: "id"
-        in: "path"
-        description: "The id of the entity to delete."
-        required: true
-        type: "string"
+        - name: "id"
+          in: "path"
+          description: "The id of the entity to delete."
+          required: true
+          type: "string"
       responses:
         "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/OtpUser"
-  /api/secure/logs:
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
+  /api/secure/user/{id}/verify_sms:
     get:
       tags:
-      - "api/secure/logs"
-      description: "Gets a list of all API usage logs."
-      produces:
-      - "application/json"
+        - "api/secure/user"
+      description: "Request an SMS verification to be sent to an OtpUser's phone number."
       parameters:
-      - name: "keyId"
-        in: "query"
-        description: "If specified, restricts the search to the specified AWS API\
-          \ key ID."
-        required: false
-        type: "string"
-      - name: "startDate"
-        in: "query"
-        description: "If specified, the earliest date (format yyyy-MM-dd) for which\
-          \ usage logs are retrieved."
-        required: false
-        type: "string"
-        default: "30 days prior to the current date"
-        pattern: "yyyy-MM-dd"
-      - name: "endDate"
-        in: "query"
-        description: "If specified, the latest date (format yyyy-MM-dd) for which\
-          \ usage logs are retrieved."
-        required: false
-        type: "string"
-        default: "The current date"
-        pattern: "yyyy-MM-dd"
+        - name: "id"
+          in: "path"
+          description: "The id of the OtpUser."
+          required: true
+          type: "string"
       responses:
         "200":
           description: "successful operation"
           schema:
-            $ref: "#/definitions/ApiUsageResult"
-  /api/admin/bugsnag/eventsummary:
-    get:
+            $ref: "#/definitions/VerificationResult"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
+  /api/secure/user/{id}/verify_sms/{code}:
+    post:
       tags:
-      - "api/admin/bugsnag/eventsummary"
-      description: "Gets a list of all Bugsnag event summaries."
-      produces:
-      - "application/json"
-      parameters: []
+        - "api/secure/user"
+      description: "Verify an OtpUser's phone number with a verification code."
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "The id of the OtpUser."
+          required: true
+          type: "string"
+        - name: "code"
+          in: "path"
+          description: "The SMS verification code."
+          required: true
+          type: "string"
       responses:
         "200":
           description: "successful operation"
           schema:
-            $ref: "#/definitions/BugsnagEvent"
+            $ref: "#/definitions/VerificationResult"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+      security:
+        - api_key: []
+        - bearer_token: []
   /otp/*:
     get:
       tags:
-      - "otp"
+        - "otp"
       description: "Forwards any GET request to OTP. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
         \ API documentation</a> for OTP's supported API resources."
       produces:
-      - "application/json"
-      - "application/xml"
+        - "application/json"
+        - "application/xml"
       parameters: []
       responses:
         "200":
           description: "successful operation"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
+  /pelias/*:
+    get:
+      tags:
+        - "pelias"
+      description: "Forwards any GET request to Pelias Geocoder. Refer to <a href='https://github.com/pelias/documentation/#endpoint-descriptions'>Pelias\
+        \ Geocoder Documentation</a> for API resources supported by Pelias Geocoder."
+      produces:
+        - "application/json"
+      parameters: []
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: "successful operation"
+        "400":
+          $ref: "#/responses/400"
+        "401":
+          $ref: "#/responses/401"
+        "403":
+          $ref: "#/responses/403"
+        "404":
+          $ref: "#/responses/404"
+        "500":
+          $ref: "#/responses/500"
+        default:
+          $ref: "#/responses/default"
 definitions:
-  AdminUser:
+  AbstractUser:
     type: "object"
-  Job:
-    type: "object"
+    required:
+      - "auth0UserId"
+      - "email"
     properties:
-      status:
+      email:
         type: "string"
-      type:
+        description: "Email address for contact. This must be unique in the collection."
+      auth0UserId:
         type: "string"
-      createdAt:
-        type: "string"
-        format: "date"
-      id:
-        type: "string"
-  AdminUser[]:
-    type: "object"
-  ApiKey:
-    type: "object"
-    properties:
-      keyId:
-        type: "string"
-      name:
-        type: "string"
-      value:
-        type: "string"
-  ApiUser:
-    type: "object"
-    properties:
-      apiKeys:
-        type: "array"
-        items:
-          $ref: "#/definitions/ApiKey"
-      appName:
-        type: "string"
-      appPurpose:
-        type: "string"
-      appUrl:
-        type: "string"
-      company:
-        type: "string"
-      hasConsentedToTerms:
+        description: "Auth0 user name."
+      isDataToolsUser:
         type: "boolean"
-      name:
+        description: "Determines whether this user has access to OTP Data Tools."
+    description: "An abstract user."
+  Currency:
+    type: "object"
+    properties:
+      symbol:
         type: "string"
-  ApiUser[]:
-    type: "object"
-  MonitoredTrip[]:
-    type: "object"
+      currency:
+        type: "string"
+      defaultFractionDigits:
+        type: "integer"
+        format: "int32"
+      currencyCode:
+        type: "string"
   EncodedPolyline:
     type: "object"
     properties:
@@ -728,6 +639,32 @@ definitions:
       length:
         type: "integer"
         format: "int32"
+  Fare:
+    type: "object"
+    properties:
+      regular:
+        $ref: "#/definitions/Price"
+      student:
+        $ref: "#/definitions/Price"
+      senior:
+        $ref: "#/definitions/Price"
+      tram:
+        $ref: "#/definitions/Price"
+      special:
+        $ref: "#/definitions/Price"
+      youth:
+        $ref: "#/definitions/Price"
+  FareComponent:
+    type: "object"
+    properties:
+      fareId:
+        type: "string"
+      price:
+        $ref: "#/definitions/Price"
+      routes:
+        type: "array"
+        items:
+          type: "string"
   FareDetails:
     type: "object"
     properties:
@@ -755,45 +692,66 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/FareComponent"
-  Step:
+  FareWrapper:
     type: "object"
     properties:
-      distance:
-        type: "number"
-        format: "double"
-      relativeDirection:
-        type: "string"
-      streetName:
-        type: "string"
-      absoluteDirection:
-        type: "string"
-      stayOn:
-        type: "boolean"
-      area:
-        type: "boolean"
-      bogusName:
-        type: "boolean"
-      lon:
-        type: "number"
-        format: "double"
-      lat:
-        type: "number"
-        format: "double"
-  Fare:
+      fare:
+        $ref: "#/definitions/Fare"
+      details:
+        $ref: "#/definitions/FareDetails"
+  Itinerary:
     type: "object"
     properties:
-      regular:
-        $ref: "#/definitions/Price"
-      student:
-        $ref: "#/definitions/Price"
-      senior:
-        $ref: "#/definitions/Price"
-      tram:
-        $ref: "#/definitions/Price"
-      special:
-        $ref: "#/definitions/Price"
-      youth:
-        $ref: "#/definitions/Price"
+      duration:
+        type: "integer"
+        format: "int64"
+      startTime:
+        type: "string"
+        format: "date"
+      endTime:
+        type: "string"
+        format: "date"
+      walkTime:
+        type: "integer"
+        format: "int64"
+      transitTime:
+        type: "integer"
+        format: "int64"
+      waitingTime:
+        type: "integer"
+        format: "int64"
+      walkDistance:
+        type: "number"
+        format: "double"
+      walkLimitExceeded:
+        type: "boolean"
+      elevationLost:
+        type: "number"
+        format: "double"
+      elevationGained:
+        type: "number"
+        format: "double"
+      transfers:
+        type: "integer"
+        format: "int32"
+      fare:
+        $ref: "#/definitions/FareWrapper"
+      legs:
+        type: "array"
+        items:
+          $ref: "#/definitions/Leg"
+  Job:
+    type: "object"
+    properties:
+      status:
+        type: "string"
+      type:
+        type: "string"
+      createdAt:
+        type: "string"
+        format: "date"
+      id:
+        type: "string"
   Leg:
     type: "object"
     properties:
@@ -876,128 +834,6 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/LocalizedAlert"
-  Price:
-    type: "object"
-    properties:
-      currency:
-        $ref: "#/definitions/Currency"
-      cents:
-        type: "integer"
-        format: "int32"
-  Currency:
-    type: "object"
-    properties:
-      symbol:
-        type: "string"
-      currency:
-        type: "string"
-      defaultFractionDigits:
-        type: "integer"
-        format: "int32"
-      currencyCode:
-        type: "string"
-  Itinerary:
-    type: "object"
-    properties:
-      duration:
-        type: "integer"
-        format: "int64"
-      startTime:
-        type: "string"
-        format: "date"
-      endTime:
-        type: "string"
-        format: "date"
-      walkTime:
-        type: "integer"
-        format: "int64"
-      transitTime:
-        type: "integer"
-        format: "int64"
-      waitingTime:
-        type: "integer"
-        format: "int64"
-      walkDistance:
-        type: "number"
-        format: "double"
-      walkLimitExceeded:
-        type: "boolean"
-      elevationLost:
-        type: "number"
-        format: "double"
-      elevationGained:
-        type: "number"
-        format: "double"
-      transfers:
-        type: "integer"
-        format: "int32"
-      fare:
-        $ref: "#/definitions/FareWrapper"
-      legs:
-        type: "array"
-        items:
-          $ref: "#/definitions/Leg"
-  FareComponent:
-    type: "object"
-    properties:
-      fareId:
-        type: "string"
-      price:
-        $ref: "#/definitions/Price"
-      routes:
-        type: "array"
-        items:
-          type: "string"
-  FareWrapper:
-    type: "object"
-    properties:
-      fare:
-        $ref: "#/definitions/Fare"
-      details:
-        $ref: "#/definitions/FareDetails"
-  Place:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      lon:
-        type: "number"
-        format: "double"
-      lat:
-        type: "number"
-        format: "double"
-      departure:
-        type: "string"
-        format: "date"
-      orig:
-        type: "string"
-      vertexType:
-        type: "string"
-      stopId:
-        type: "string"
-      arrival:
-        type: "string"
-        format: "date"
-      stopIndex:
-        type: "integer"
-        format: "int32"
-      stopSequence:
-        type: "integer"
-        format: "int32"
-      stopCode:
-        type: "string"
-      platformCode:
-        type: "string"
-      zoneId:
-        type: "string"
-      bikeShareId:
-        type: "string"
-      networks:
-        type: "array"
-        items:
-          type: "string"
-      address:
-        type: "string"
   LocalizedAlert:
     type: "object"
     properties:
@@ -1058,6 +894,102 @@ definitions:
         format: "int32"
       notifyOnItineraryChange:
         type: "boolean"
+  OtpUser:
+    allOf:
+      - $ref: "#/definitions/AbstractUser"
+      - type: "object"
+        properties:
+          hasConsentedToTerms:
+            type: "boolean"
+          isPhoneNumberVerified:
+            type: "boolean"
+          notificationChannel:
+            type: "string"
+          phoneNumber:
+            type: "string"
+          savedLocations:
+            type: "array"
+            items:
+              $ref: "#/definitions/UserLocation"
+          storeTripHistory:
+            type: "boolean"
+          applicationId:
+            type: "string"
+  Place:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      lon:
+        type: "number"
+        format: "double"
+      lat:
+        type: "number"
+        format: "double"
+      departure:
+        type: "string"
+        format: "date"
+      orig:
+        type: "string"
+      vertexType:
+        type: "string"
+      stopId:
+        type: "string"
+      arrival:
+        type: "string"
+        format: "date"
+      stopIndex:
+        type: "integer"
+        format: "int32"
+      stopSequence:
+        type: "integer"
+        format: "int32"
+      stopCode:
+        type: "string"
+      platformCode:
+        type: "string"
+      zoneId:
+        type: "string"
+      bikeShareId:
+        type: "string"
+      networks:
+        type: "array"
+        items:
+          type: "string"
+      address:
+        type: "string"
+  Price:
+    type: "object"
+    properties:
+      currency:
+        $ref: "#/definitions/Currency"
+      cents:
+        type: "integer"
+        format: "int32"
+  Step:
+    type: "object"
+    properties:
+      distance:
+        type: "number"
+        format: "double"
+      relativeDirection:
+        type: "string"
+      streetName:
+        type: "string"
+      absoluteDirection:
+        type: "string"
+      stayOn:
+        type: "boolean"
+      area:
+        type: "boolean"
+      bogusName:
+        type: "boolean"
+      lon:
+        type: "number"
+        format: "double"
+      lat:
+        type: "number"
+        format: "double"
   TripRequest:
     type: "object"
     properties:
@@ -1071,15 +1003,6 @@ definitions:
         type: "string"
       queryParams:
         type: "string"
-  VerificationResult:
-    type: "object"
-    properties:
-      sid:
-        type: "string"
-      status:
-        type: "string"
-      valid:
-        type: "boolean"
   UserLocation:
     type: "object"
     properties:
@@ -1097,83 +1020,44 @@ definitions:
         type: "string"
       type:
         type: "string"
-  OtpUser:
+  VerificationResult:
     type: "object"
     properties:
-      hasConsentedToTerms:
+      sid:
+        type: "string"
+      status:
+        type: "string"
+      valid:
         type: "boolean"
-      isPhoneNumberVerified:
-        type: "boolean"
-      notificationChannel:
-        type: "string"
-      phoneNumber:
-        type: "string"
-      savedLocations:
-        type: "array"
-        items:
-          $ref: "#/definitions/UserLocation"
-      storeTripHistory:
-        type: "boolean"
-      applicationId:
-        type: "string"
-  OtpUser[]:
-    type: "object"
-  GetUsageResult:
-    type: "object"
-    properties:
-      usagePlanId:
-        type: "string"
-      startDate:
-        type: "string"
-      endDate:
-        type: "string"
-      position:
-        type: "string"
-      items:
-        $ref: "#/definitions/Map"
-  ApiUsageResult:
-    type: "object"
-    properties:
-      result:
-        $ref: "#/definitions/GetUsageResult"
-      apiUsers:
-        $ref: "#/definitions/Map"
-  App:
-    type: "object"
-    properties:
-      releaseStage:
-        type: "string"
-  BugsnagEvent:
-    type: "object"
-    properties:
-      eventDataId:
-        type: "string"
-      projectId:
-        type: "string"
-      errorId:
-        type: "string"
-      receivedAt:
-        type: "string"
-        format: "date"
-      exceptions:
-        type: "array"
-        items:
-          $ref: "#/definitions/EventException"
-      severity:
-        type: "string"
-      context:
-        type: "string"
-      unhandled:
-        type: "boolean"
-      app:
-        $ref: "#/definitions/App"
-  EventException:
-    type: "object"
-    properties:
-      errorClass:
-        type: "string"
-      message:
-        type: "string"
 externalDocs:
   description: ""
   url: ""
+securityDefinitions:
+  api_key:
+    description: "API key header authentication."
+    in: "header"
+    name: "x-api-key"
+    type: "apiKey"
+  bearer_token:
+    description: "Bearer token authentication using Auth0."
+    in: "header"
+    name: "Authorization"
+    type: "apiKey"
+responses:
+  "400":
+    description: "The request was not formed properly (e.g., some required parameters\
+      \ may be missing). See the details of the returned response to determine the\
+      \ exact issue."
+  "401":
+    description: "The server was not able to authenticate the request. This can happen\
+      \ if authentication headers are missing or malformed, or the authentication\
+      \ server cannot be reached."
+  "403":
+    description: "The requesting user is not allowed to perform the request."
+  "404":
+    description: "The requested item was not found."
+  "500":
+    description: "An error occurred while performing the request. Contact an API administrator\
+      \ for more information."
+  default:
+    description: "An unexpected error occurred."

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -80,6 +80,11 @@ paths:
         required: false
         type: "string"
         default: "0"
+      - name: "userId"
+        in: "query"
+        description: "If specified, the required user id."
+        required: false
+        type: "string"
       responses:
         "200":
           description: "successful operation"
@@ -285,6 +290,11 @@ paths:
         required: false
         type: "string"
         default: "0"
+      - name: "userId"
+        in: "query"
+        description: "If specified, the required user id."
+        required: false
+        type: "string"
       responses:
         "200":
           description: "successful operation"
@@ -390,6 +400,11 @@ paths:
         required: false
         type: "string"
         default: "0"
+      - name: "userId"
+        in: "query"
+        description: "If specified, the required user id."
+        required: false
+        type: "string"
       responses:
         "200":
           description: "successful operation"
@@ -604,6 +619,11 @@ paths:
         required: false
         type: "string"
         default: "0"
+      - name: "userId"
+        in: "query"
+        description: "If specified, the required user id."
+        required: false
+        type: "string"
       responses:
         "200":
           description: "successful operation"

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -217,7 +217,7 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/ApiUser"
-  /api/secure/application/{id}/authenticate:
+  /api/secure/application/authenticate:
     post:
       tags:
       - "api/secure/application"
@@ -225,11 +225,6 @@ paths:
       produces:
       - "application/json"
       parameters:
-      - name: "id"
-        in: "path"
-        description: "The user ID."
-        required: true
-        type: "string"
       - name: "username"
         in: "query"
         description: "Auth0 username (usually email address)."
@@ -781,8 +776,8 @@ paths:
       parameters:
       - name: "userId"
         in: "query"
-        description: "If a third party user is making a trip request on behalf of\
-          \ an OTP user, the OTP user id must be specified."
+        description: "If a third-party application is making a trip plan request on\
+          \ behalf of an end user (OtpUser), the user id must be specified."
         required: false
         type: "string"
       responses:

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -161,7 +161,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     private HttpResponse<String> createApiKeyRequest(String targetUserId, AbstractUser requestingUser) {
         String path = String.format("api/secure/application/%s/apikey", targetUserId);
-        return mockAuthenticatedRequest(path, requestingUser, HttpUtils.REQUEST_METHOD.POST);
+        return mockAuthenticatedRequest(path, "", requestingUser, HttpUtils.REQUEST_METHOD.POST, true);
     }
 
     /**
@@ -169,6 +169,6 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     private static HttpResponse<String> deleteApiKeyRequest(String targetUserId, String apiKeyId, AbstractUser requestingUser) {
         String path = String.format("api/secure/application/%s/apikey/%s", targetUserId, apiKeyId);
-        return mockAuthenticatedRequest(path, requestingUser, HttpUtils.REQUEST_METHOD.DELETE);
+        return mockAuthenticatedRequest(path, "", requestingUser, HttpUtils.REQUEST_METHOD.DELETE, true);
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.TestUtils.isEndToEnd;
 import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedRequest;
+import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Connection.setAuthDisabled;
 import static org.opentripplanner.middleware.controllers.api.ApiUserController.DEFAULT_USAGE_PLAN_ID;
 
@@ -39,6 +40,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
     private static final Logger LOG = LoggerFactory.getLogger(ApiKeyManagementTest.class);
     private static ApiUser apiUser;
     private static AdminUser adminUser;
+    private static boolean prevAuthState;
 
     /**
      * Create an {@link ApiUser} and an {@link AdminUser} prior to unit tests
@@ -48,6 +50,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         assumeTrue(isEndToEnd);
         // TODO: It might be useful to allow this to run without DISABLE_AUTH set to true (in an end-to-end environment
         //  using real tokens from Auth0.
+        prevAuthState = isAuthDisabled();
         setAuthDisabled(true);
         // Load config before checking if tests should run.
         OtpMiddlewareTest.setUp();
@@ -63,8 +66,9 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         assumeTrue(isEndToEnd);
         // refresh API key(s)
         apiUser = Persistence.apiUsers.getById(apiUser.id);
-        apiUser.delete(false);
+        apiUser.delete();
         Persistence.adminUsers.removeById(adminUser.id);
+        setAuthDisabled(prevAuthState);
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -24,7 +24,9 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.TestUtils.isEndToEnd;
 import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedDelete;
 import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedRequest;
+import static org.opentripplanner.middleware.auth.Auth0Connection.getDefaultAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthDisabled;
+import static org.opentripplanner.middleware.auth.Auth0Connection.restoreDefaultAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Connection.setAuthDisabled;
 import static org.opentripplanner.middleware.controllers.api.ApiUserController.DEFAULT_USAGE_PLAN_ID;
 
@@ -41,7 +43,6 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
     private static final Logger LOG = LoggerFactory.getLogger(ApiKeyManagementTest.class);
     private static ApiUser apiUser;
     private static AdminUser adminUser;
-    private static boolean prevAuthState;
 
     /**
      * Create an {@link ApiUser} and an {@link AdminUser} prior to unit tests
@@ -51,7 +52,6 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         assumeTrue(isEndToEnd);
         // TODO: It might be useful to allow this to run without DISABLE_AUTH set to true (in an end-to-end environment
         //  using real tokens from Auth0.
-        prevAuthState = isAuthDisabled();
         setAuthDisabled(true);
         // Load config before checking if tests should run.
         OtpMiddlewareTest.setUp();
@@ -69,7 +69,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
         apiUser = Persistence.apiUsers.getById(apiUser.id);
         apiUser.delete();
         Persistence.adminUsers.removeById(adminUser.id);
-        setAuthDisabled(prevAuthState);
+        restoreDefaultAuthDisabled();
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiKeyManagementTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.TestUtils.isEndToEnd;
+import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedDelete;
 import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedRequest;
 import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Connection.setAuthDisabled;
@@ -161,7 +162,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     private HttpResponse<String> createApiKeyRequest(String targetUserId, AbstractUser requestingUser) {
         String path = String.format("api/secure/application/%s/apikey", targetUserId);
-        return mockAuthenticatedRequest(path, "", requestingUser, HttpUtils.REQUEST_METHOD.POST, true);
+        return mockAuthenticatedRequest(path, "", requestingUser, HttpUtils.REQUEST_METHOD.POST);
     }
 
     /**
@@ -169,6 +170,6 @@ public class ApiKeyManagementTest extends OtpMiddlewareTest {
      */
     private static HttpResponse<String> deleteApiKeyRequest(String targetUserId, String apiKeyId, AbstractUser requestingUser) {
         String path = String.format("api/secure/application/%s/apikey/%s", targetUserId, apiKeyId);
-        return mockAuthenticatedRequest(path, "", requestingUser, HttpUtils.REQUEST_METHOD.DELETE, true);
+        return mockAuthenticatedDelete(path, requestingUser);
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
@@ -25,6 +25,7 @@ import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -156,6 +157,14 @@ public class ApiUserFlowTest {
 
         assertEquals(HttpStatus.OK_200, createUserResponse.statusCode());
 
+        // Request all Otp users created by an Api user. This will work and return all Otp users.
+        HttpResponse<String> getAllOtpUsersCreatedByApiUser = authenticatedGet("api/secure/user",
+            headers
+        );
+        assertEquals(HttpStatus.OK_200, getAllOtpUsersCreatedByApiUser.statusCode());
+        ResponseList otpUsers = JsonUtils.getPOJOFromJSON(getAllOtpUsersCreatedByApiUser.body(), ResponseList.class);
+        assertEquals(1, otpUsers.total);
+
         // Attempt to create a monitored trip for an Otp user using mock authentication. This will fail because the user
         // was created by an Api user and therefore does not have a Auth0 account.
         OtpUser otpUserResponse = JsonUtils.getPOJOFromJSON(createUserResponse.body(), OtpUser.class);
@@ -189,7 +198,7 @@ public class ApiUserFlowTest {
         );
         assertEquals(HttpStatus.OK_200, getAllMonitoredTripsForOtpUser.statusCode());
 
-        // Request all monitored trips for an Otp user authenticating as an Api user. Without defining the user id. This
+        // Request all monitored trips for an Otp user authenticating as an Api user, without defining the user id. This
         // will fail because an Api user must provide a user id.
         getAllMonitoredTripsForOtpUser = authenticatedRequest("api/secure/monitoredtrip",
             "",

--- a/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
@@ -4,7 +4,6 @@ import com.auth0.exception.Auth0Exception;
 import com.auth0.json.auth.TokenHolder;
 import com.auth0.json.mgmt.users.User;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;

--- a/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
@@ -3,6 +3,8 @@ package org.opentripplanner.middleware;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.auth.TokenHolder;
 import com.auth0.json.mgmt.users.User;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -140,7 +142,7 @@ public class ApiUserFlowTest {
      *   5. Delete user and verify that their associated objects are also deleted.
      */
     @Test
-    public void canSimulateApiUserFlow() throws URISyntaxException {
+    public void canSimulateApiUserFlow() throws URISyntaxException, JsonProcessingException {
 
         // Define the header values to be used in requests from this point forward.
         HashMap<String, String> apiUserHeaders = new HashMap<>();
@@ -174,7 +176,7 @@ public class ApiUserFlowTest {
         // Request all Otp users created by an Api user. This will work and return all Otp users.
         HttpResponse<String> getAllOtpUsersCreatedByApiUser = makeGetRequest(OTP_USER_PATH, apiUserHeaders);
         assertEquals(HttpStatus.OK_200, getAllOtpUsersCreatedByApiUser.statusCode());
-        ResponseList<OtpUser> otpUsers = JsonUtils.getPOJOFromJSON(getAllOtpUsersCreatedByApiUser.body(), ResponseList.class);
+        ResponseList<OtpUser> otpUsers = JsonUtils.getResponseListFromJSON(getAllOtpUsersCreatedByApiUser.body(), OtpUser.class);
         assertEquals(1, otpUsers.total);
 
         // Attempt to create a monitored trip for an Otp user using mock authentication. This will fail because the user
@@ -257,10 +259,7 @@ public class ApiUserFlowTest {
         HttpResponse<String> tripRequestResponseAsApiUser = makeGetRequest(tripRequestsPath, apiUserHeaders);
         assertEquals(HttpStatus.OK_200, tripRequestResponseAsApiUser.statusCode());
 
-        ResponseList<TripRequest> tripRequests = JsonUtils.getPOJOFromJSON(
-            tripRequestResponseAsApiUser.body(),
-            ResponseList.class
-        );
+        ResponseList<TripRequest> tripRequests = JsonUtils.getResponseListFromJSON(tripRequestResponseAsApiUser.body(), TripRequest.class);
 
         // Delete Otp user authenticating as an Otp user. This will fail because the user was created by an Api user and
         // therefore does not have a Auth0 account.

--- a/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
@@ -76,7 +76,7 @@ public class ApiUserFlowTest {
     }
 
     /**
-     * Create an {@link ApiUser} and an {@link AdminUser} prior to unit tests
+     * Create an {@link ApiUser} and an {@link OtpUser} prior to unit tests
      */
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException, CreateApiKeyException {
@@ -162,6 +162,22 @@ public class ApiUserFlowTest {
         );
         assertEquals(HttpStatus.OK_200, createTripResponseAsApiUser.statusCode());
         MonitoredTrip monitoredTripResponse = JsonUtils.getPOJOFromJSON(createTripResponseAsApiUser.body(), MonitoredTrip.class);
+
+        // Request all monitored trip for an Otp user authenticating as an Api user.
+        HttpResponse<String> getAllMonitoredTripsForOtpUser = mockAuthenticatedRequest(String.format("api/secure/monitoredtrip?userId=%s",
+            otpUserResponse.id),
+            apiUser,
+            HttpUtils.REQUEST_METHOD.GET
+        );
+        assertEquals(HttpStatus.OK_200, getAllMonitoredTripsForOtpUser.statusCode());
+
+        // Request all monitored trip for an Otp user authenticating as an Api user. Without defining the user id.
+        getAllMonitoredTripsForOtpUser = mockAuthenticatedRequest("api/secure/monitoredtrip",
+            apiUser,
+            HttpUtils.REQUEST_METHOD.GET
+        );
+        assertEquals(HttpStatus.BAD_REQUEST_400, getAllMonitoredTripsForOtpUser.statusCode());
+
 
         // Plan trip with OTP proxy authenticating as an OTP user. Mock plan response will be returned. This will work
         // as an Otp user (created by MOD UI or an Api user) because the end point has no auth.

--- a/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
@@ -184,6 +184,7 @@ public class ApiUserFlowTest {
 
         // Create a monitored trip for the Otp user (API users are prevented from doing this).
         MonitoredTrip monitoredTrip = new MonitoredTrip(TestUtils.sendSamplePlanRequest());
+        monitoredTrip.updateAllDaysOfWeek(true);
         monitoredTrip.userId = otpUser.id;
         HttpResponse<String> createTripResponseAsOtpUser = mockAuthenticatedRequest(
             MONITORED_TRIP_PATH,

--- a/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
@@ -24,15 +24,15 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.TestUtils.TEMP_AUTH0_USER_PASSWORD;
-import static org.opentripplanner.middleware.TestUtils.authenticatedGet;
-import static org.opentripplanner.middleware.TestUtils.authenticatedRequest;
+import static org.opentripplanner.middleware.TestUtils.makeDeleteRequest;
+import static org.opentripplanner.middleware.TestUtils.makeGetRequest;
+import static org.opentripplanner.middleware.TestUtils.makeRequest;
 import static org.opentripplanner.middleware.TestUtils.isEndToEnd;
 import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedGet;
 import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedRequest;
@@ -70,6 +70,8 @@ public class ApiUserFlowTest {
     private static ApiUser apiUser;
     private static OtpUser otpUser;
     private static OtpUser otpUserMatchingApiUser;
+    private static final String OTP_USER_PATH = "api/secure/user";
+    private static final String MONITORED_TRIP_PATH = "api/secure/monitoredtrip";
 
     /**
      * Whether tests for this class should run. End to End must be enabled and Auth must NOT be disabled. This should be
@@ -130,46 +132,49 @@ public class ApiUserFlowTest {
 
     /**
      * Tests to confirm that an otp user, related monitored trip and plan can be created and deleted leaving no orphaned
-     * records. This also includes Auth0 users if auth is enabled.
+     * records. This also includes Auth0 users if auth is enabled. The basic script for this test is as follows:
+     *   1. Start with existing API User that has a valid API key.
+     *   2. Use the API key to make a request to the authenticate endpoint to get Auth0 token for further requests.
+     *   3. Create OTP user.
+     *   4. Make subsequent requests on behalf of OTP users.
+     *   5. Delete user and verify that their associated objects are also deleted.
      */
     @Test
     public void canSimulateApiUserFlow() throws URISyntaxException {
 
         // Define the header values to be used in requests from this point forward.
-        HashMap<String, String> headers = new HashMap<>();
-        headers.put("x-api-key", apiUser.apiKeys.get(0).value);
-
+        HashMap<String, String> apiUserHeaders = new HashMap<>();
+        apiUserHeaders.put("x-api-key", apiUser.apiKeys.get(0).value);
         // obtain Auth0 token for Api user.
-        String endpoint = String.format("api/secure/application/authenticate?username=%s&password=%s",
+        String authenticateEndpoint = String.format("api/secure/application/authenticate?username=%s&password=%s",
             apiUser.email,
             TEMP_AUTH0_USER_PASSWORD);
-        HttpResponse<String> getTokenResponse = authenticatedRequest(endpoint,
+        HttpResponse<String> getTokenResponse = makeRequest(authenticateEndpoint,
             "",
-            headers,
+            apiUserHeaders,
             HttpUtils.REQUEST_METHOD.POST
         );
-        LOG.info(getTokenResponse.body());
+        // Note: do not log the Auth0 token (could be a security risk).
+        LOG.info("Token response status: {}", getTokenResponse.statusCode());
         assertEquals(HttpStatus.OK_200, getTokenResponse.statusCode());
         TokenHolder tokenHolder = JsonUtils.getPOJOFromJSON(getTokenResponse.body(), TokenHolder.class);
 
         // Define the bearer value to be used in requests from this point forward.
-        headers.put("Authorization", "Bearer " + tokenHolder.getAccessToken());
+        apiUserHeaders.put("Authorization", "Bearer " + tokenHolder.getAccessToken());
 
         // create an Otp user authenticating as an Api user.
-        HttpResponse<String> createUserResponse = authenticatedRequest("api/secure/user",
+        HttpResponse<String> createUserResponse = makeRequest(OTP_USER_PATH,
             JsonUtils.toJson(otpUser),
-            headers,
+            apiUserHeaders,
             HttpUtils.REQUEST_METHOD.POST
         );
 
         assertEquals(HttpStatus.OK_200, createUserResponse.statusCode());
 
         // Request all Otp users created by an Api user. This will work and return all Otp users.
-        HttpResponse<String> getAllOtpUsersCreatedByApiUser = authenticatedGet("api/secure/user",
-            headers
-        );
+        HttpResponse<String> getAllOtpUsersCreatedByApiUser = makeGetRequest(OTP_USER_PATH, apiUserHeaders);
         assertEquals(HttpStatus.OK_200, getAllOtpUsersCreatedByApiUser.statusCode());
-        ResponseList otpUsers = JsonUtils.getPOJOFromJSON(getAllOtpUsersCreatedByApiUser.body(), ResponseList.class);
+        ResponseList<OtpUser> otpUsers = JsonUtils.getPOJOFromJSON(getAllOtpUsersCreatedByApiUser.body(), ResponseList.class);
         assertEquals(1, otpUsers.total);
 
         // Attempt to create a monitored trip for an Otp user using mock authentication. This will fail because the user
@@ -179,37 +184,41 @@ public class ApiUserFlowTest {
         // Create a monitored trip for the Otp user (API users are prevented from doing this).
         MonitoredTrip monitoredTrip = new MonitoredTrip(TestUtils.sendSamplePlanRequest());
         monitoredTrip.userId = otpUser.id;
-        HttpResponse<String> createTripResponseAsOtpUser = mockAuthenticatedRequest("api/secure/monitoredtrip",
+        HttpResponse<String> createTripResponseAsOtpUser = mockAuthenticatedRequest(
+            MONITORED_TRIP_PATH,
             JsonUtils.toJson(monitoredTrip),
             otpUserResponse,
-            HttpUtils.REQUEST_METHOD.POST,
-            true
+            HttpUtils.REQUEST_METHOD.POST
         );
         assertEquals(HttpStatus.UNAUTHORIZED_401, createTripResponseAsOtpUser.statusCode());
 
         // Create a monitored trip for an Otp user authenticating as an Api user. An Api user can create a monitored
         // trip for an Otp user they created.
-        HttpResponse<String> createTripResponseAsApiUser = authenticatedRequest("api/secure/monitoredtrip",
+        HttpResponse<String> createTripResponseAsApiUser = makeRequest(
+            MONITORED_TRIP_PATH,
             JsonUtils.toJson(monitoredTrip),
-            headers,
+            apiUserHeaders,
             HttpUtils.REQUEST_METHOD.POST
         );
         assertEquals(HttpStatus.OK_200, createTripResponseAsApiUser.statusCode());
-        MonitoredTrip monitoredTripResponse = JsonUtils.getPOJOFromJSON(createTripResponseAsApiUser.body(), MonitoredTrip.class);
+        MonitoredTrip monitoredTripResponse = JsonUtils.getPOJOFromJSON(
+            createTripResponseAsApiUser.body(),
+            MonitoredTrip.class
+        );
 
         // Request all monitored trips for an Otp user authenticating as an Api user. This will work and return all trips
         // matching the user id provided.
-        HttpResponse<String> getAllMonitoredTripsForOtpUser = authenticatedGet(String.format("api/secure/monitoredtrip?userId=%s",
-            otpUserResponse.id),
-            headers
+        HttpResponse<String> getAllMonitoredTripsForOtpUser = makeGetRequest(
+            String.format("api/secure/monitoredtrip?userId=%s", otpUserResponse.id),
+            apiUserHeaders
         );
         assertEquals(HttpStatus.OK_200, getAllMonitoredTripsForOtpUser.statusCode());
 
         // Request all monitored trips for an Otp user authenticating as an Api user, without defining the user id. This
         // will fail because an Api user must provide a user id.
-        getAllMonitoredTripsForOtpUser = authenticatedRequest("api/secure/monitoredtrip",
+        getAllMonitoredTripsForOtpUser = makeRequest(MONITORED_TRIP_PATH,
             "",
-            headers,
+            apiUserHeaders,
             HttpUtils.REQUEST_METHOD.GET
         );
         assertEquals(HttpStatus.BAD_REQUEST_400, getAllMonitoredTripsForOtpUser.statusCode());
@@ -221,10 +230,7 @@ public class ApiUserFlowTest {
         String otpQueryForOtpUserRequest = OTP_PROXY_ENDPOINT +
             OTP_PLAN_ENDPOINT +
             "?fromPlace=28.45119,-81.36818&toPlace=28.54834,-81.37745";
-        HttpResponse<String> planTripResponseAsOtpUser = mockAuthenticatedGet(otpQueryForOtpUserRequest,
-            otpUserResponse,
-            true
-        );
+        HttpResponse<String> planTripResponseAsOtpUser = mockAuthenticatedGet(otpQueryForOtpUserRequest, otpUserResponse);
         LOG.info("OTP user: Plan trip response: {}\n....", planTripResponseAsOtpUser.body().substring(0, 300));
         assertEquals(HttpStatus.OK_200, planTripResponseAsOtpUser.statusCode());
 
@@ -235,47 +241,36 @@ public class ApiUserFlowTest {
         String otpQueryForApiUserRequest = OTP_PROXY_ENDPOINT +
             OTP_PLAN_ENDPOINT +
             String.format("?fromPlace=28.45119,-81.36818&toPlace=28.54834,-81.37745&userId=%s",otpUserResponse.id);
-        HttpResponse<String> planTripResponseAsApiUser = authenticatedGet(otpQueryForApiUserRequest, headers);
+        HttpResponse<String> planTripResponseAsApiUser = makeGetRequest(otpQueryForApiUserRequest, apiUserHeaders);
         LOG.info("API user (on behalf of an Otp user): Plan trip response: {}\n....", planTripResponseAsApiUser.body().substring(0, 300));
         assertEquals(HttpStatus.OK_200, planTripResponseAsApiUser.statusCode());
 
         // Get trip request history for user authenticating as an Otp user. This will fail because the user was created
         // by an Api user and therefore does not have a Auth0 account.
-        HttpResponse<String> tripRequestResponseAsOtUser = mockAuthenticatedGet(String.format("api/secure/triprequests?userId=%s",
-            otpUserResponse.id),
-            otpUserResponse,
-            true
-        );
+        String tripRequestsPath = String.format("api/secure/triprequests?userId=%s", otpUserResponse.id);
+        HttpResponse<String> tripRequestResponseAsOtUser = mockAuthenticatedGet(tripRequestsPath, otpUserResponse);
 
         assertEquals(HttpStatus.UNAUTHORIZED_401, tripRequestResponseAsOtUser.statusCode());
 
         // Get trip request history for user authenticating as an Api user. This will work because an Api user is able
         // to get a trip on behalf of an Otp user they created.
-        HttpResponse<String> tripRequestResponseAsApiUser = authenticatedGet(String.format("api/secure/triprequests?userId=%s",
-            otpUserResponse.id),
-            headers
-        );
+        HttpResponse<String> tripRequestResponseAsApiUser = makeGetRequest(tripRequestsPath, apiUserHeaders);
         assertEquals(HttpStatus.OK_200, tripRequestResponseAsApiUser.statusCode());
 
-        ResponseList tripRequests = JsonUtils.getPOJOFromJSON(tripRequestResponseAsApiUser.body(), ResponseList.class);
+        ResponseList<TripRequest> tripRequests = JsonUtils.getPOJOFromJSON(
+            tripRequestResponseAsApiUser.body(),
+            ResponseList.class
+        );
 
         // Delete Otp user authenticating as an Otp user. This will fail because the user was created by an Api user and
         // therefore does not have a Auth0 account.
-        HttpResponse<String> deleteUserResponseAsOtpUser = mockAuthenticatedGet(
-            String.format("api/secure/user/%s", otpUserResponse.id),
-            otpUserResponse,
-            true
-        );
+        String otpUserPath = String.format("api/secure/user/%s", otpUserResponse.id);
+        HttpResponse<String> deleteUserResponseAsOtpUser = mockAuthenticatedGet(otpUserPath, otpUserResponse);
         assertEquals(HttpStatus.UNAUTHORIZED_401, deleteUserResponseAsOtpUser.statusCode());
 
         // Delete Otp user authenticating as an Api user. This will work because an Api user can delete an Otp user they
         // created.
-        HttpResponse<String> deleteUserResponseAsApiUser = authenticatedRequest(
-            String.format("api/secure/user/%s", otpUserResponse.id),
-            "",
-            headers,
-            HttpUtils.REQUEST_METHOD.DELETE
-        );
+        HttpResponse<String> deleteUserResponseAsApiUser = makeDeleteRequest(otpUserPath, apiUserHeaders);
         assertEquals(HttpStatus.OK_200, deleteUserResponseAsApiUser.statusCode());
 
         // Verify user no longer exists.
@@ -287,16 +282,14 @@ public class ApiUserFlowTest {
         assertNull(deletedTrip);
 
         // Verify trip request no longer exists.
-        LinkedHashMap trip = (LinkedHashMap) tripRequests.data.get(0);
-        TripRequest tripRequest = Persistence.tripRequests.getById(trip.get("id").toString());
-        assertNull(tripRequest);
+        TripRequest tripRequestFromResponse = tripRequests.data.get(0);
+        TripRequest tripRequestFromDb = Persistence.tripRequests.getById(tripRequestFromResponse.id);
+        assertNull(tripRequestFromDb);
 
         // Delete API user (this would happen through the OTP Admin portal).
-        HttpResponse<String> deleteApiUserResponse = authenticatedRequest(
+        HttpResponse<String> deleteApiUserResponse = makeDeleteRequest(
             String.format("api/secure/application/%s", apiUser.id),
-            "",
-            headers,
-            HttpUtils.REQUEST_METHOD.DELETE
+            apiUserHeaders
         );
         assertEquals(HttpStatus.OK_200, deleteApiUserResponse.statusCode());
 

--- a/src/test/java/org/opentripplanner/middleware/GetMonitoredTripsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/GetMonitoredTripsTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.TestUtils.TEMP_AUTH0_USER_PASSWORD;
 import static org.opentripplanner.middleware.TestUtils.isEndToEnd;
-import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedPost;
 import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedRequest;
 import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthDisabled;
 
@@ -117,25 +116,31 @@ public class GetMonitoredTripsTest {
         // Create trip as Otp user 1.
         MonitoredTrip monitoredTrip = new MonitoredTrip(TestUtils.sendSamplePlanRequest());
         monitoredTrip.userId = otpUser1.id;
-        HttpResponse<String> response = mockAuthenticatedPost("api/secure/monitoredtrip",
+        HttpResponse<String> response = mockAuthenticatedRequest("api/secure/monitoredtrip",
+            JsonUtils.toJson(monitoredTrip),
             otpUser1,
-            JsonUtils.toJson(monitoredTrip)
+            HttpUtils.REQUEST_METHOD.POST,
+            true
         );
         assertEquals(HttpStatus.OK_200, response.statusCode());
 
         // Create trip as Otp user 2.
         monitoredTrip = new MonitoredTrip(TestUtils.sendSamplePlanRequest());
         monitoredTrip.userId = otpUser2.id;
-        response = mockAuthenticatedPost("api/secure/monitoredtrip",
+        response = mockAuthenticatedRequest("api/secure/monitoredtrip",
+            JsonUtils.toJson(monitoredTrip),
             otpUser2,
-            JsonUtils.toJson(monitoredTrip)
+            HttpUtils.REQUEST_METHOD.POST,
+            true
         );
         assertEquals(HttpStatus.OK_200, response.statusCode());
 
         // Get trips for Otp user 2.
         response = mockAuthenticatedRequest("api/secure/monitoredtrip",
+            "",
             otpUser2,
-            HttpUtils.REQUEST_METHOD.GET
+            HttpUtils.REQUEST_METHOD.GET,
+            true
         );
         ResponseList tripRequests = JsonUtils.getPOJOFromJSON(response.body(), ResponseList.class);
 
@@ -145,8 +150,10 @@ public class GetMonitoredTripsTest {
 
         // Get trips for Otp user 2 defining user id.
         response = mockAuthenticatedRequest(String.format("api/secure/monitoredtrip?userId=%s", otpUser2.id),
+            "",
             otpUser2,
-            HttpUtils.REQUEST_METHOD.GET
+            HttpUtils.REQUEST_METHOD.GET,
+            true
         );
         tripRequests = JsonUtils.getPOJOFromJSON(response.body(), ResponseList.class);
 

--- a/src/test/java/org/opentripplanner/middleware/GetMonitoredTripsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/GetMonitoredTripsTest.java
@@ -1,0 +1,153 @@
+package org.opentripplanner.middleware;
+
+import com.auth0.exception.Auth0Exception;
+import com.auth0.json.mgmt.users.User;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.middleware.auth.Auth0Users;
+import org.opentripplanner.middleware.controllers.response.ResponseList;
+import org.opentripplanner.middleware.models.AdminUser;
+import org.opentripplanner.middleware.models.MonitoredTrip;
+import org.opentripplanner.middleware.models.OtpUser;
+import org.opentripplanner.middleware.persistence.Persistence;
+import org.opentripplanner.middleware.persistence.PersistenceUtil;
+import org.opentripplanner.middleware.utils.HttpUtils;
+import org.opentripplanner.middleware.utils.JsonUtils;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.opentripplanner.middleware.TestUtils.TEMP_AUTH0_USER_PASSWORD;
+import static org.opentripplanner.middleware.TestUtils.isEndToEnd;
+import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedPost;
+import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedRequest;
+import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthDisabled;
+
+/**
+ * Tests to simulate getting trips as an Otp user with enhanced admin credentials. The following config parameters must
+ * be set in configurations/default/env.yml for these end-to-end tests to run:
+ *
+ * AUTH0_DOMAIN set to a valid Auth0 domain.
+ *
+ * AUTH0_API_CLIENT set to a valid Auth0 application client id.
+ *
+ * AUTH0_API_SECRET set to a valid Auth0 application client secret.
+ *
+ * OTP_API_ROOT set to a live OTP instance (e.g. http://otp-server.example.com/otp).
+ *
+ * OTP_PLAN_ENDPOINT set to a live OTP plan endpoint (e.g. /routers/default/plan).
+ *
+ * The following environment variable must be set for these tests to run: - RUN_E2E=true.
+ *
+ * Auth0 must be correctly configured as described here: https://auth0.com/docs/flows/call-your-api-using-resource-owner-password-flow
+ */
+public class GetMonitoredTripsTest {
+    private static AdminUser adminUser;
+    private static OtpUser otpUser1;
+    private static OtpUser otpUser2;
+
+    /**
+     * Whether tests for this class should run. End to End must be enabled and Auth must NOT be disabled. This should be
+     * evaluated after the middleware application starts up (to ensure default disableAuth value has been applied from
+     * config).
+     */
+    private static boolean testsShouldRun() {
+        return isEndToEnd && !isAuthDisabled();
+    }
+
+    /**
+     * Create Otp and Admin user accounts. Create Auth0 account for just the Otp users. If
+     * an Auth0 account is created for the admin user it will fail because the email address already exists.
+     */
+    @BeforeAll
+    public static void setUp() throws IOException, InterruptedException {
+        // Load config before checking if tests should run.
+        OtpMiddlewareTest.setUp();
+        assumeTrue(testsShouldRun());
+        // Mock the OTP server TODO: Run a live OTP instance?
+        TestUtils.mockOtpServer();
+        String email = String.format("test-%s@example.com", UUID.randomUUID().toString());
+        otpUser1 = PersistenceUtil.createUser(String.format("test-%s@example.com", UUID.randomUUID().toString()));
+        otpUser2 = PersistenceUtil.createUser(email);
+        adminUser = PersistenceUtil.createAdminUser(email);
+        try {
+            User auth0User = Auth0Users.createAuth0UserForEmail(otpUser1.email, TEMP_AUTH0_USER_PASSWORD);
+            otpUser1.auth0UserId = auth0User.getId();
+            Persistence.otpUsers.replace(otpUser1.id, otpUser1);
+            auth0User = Auth0Users.createAuth0UserForEmail(otpUser2.email, TEMP_AUTH0_USER_PASSWORD);
+            otpUser2.auth0UserId = auth0User.getId();
+            Persistence.otpUsers.replace(otpUser2.id, otpUser2);
+            // Uncommenting will fail set-up because the email address already exists with Auth0.
+//            auth0User = createAuth0UserForEmail(otpUser.email, TEMP_AUTH0_USER_PASSWORD);
+            adminUser.auth0UserId = auth0User.getId();
+            Persistence.adminUsers.replace(adminUser.id, adminUser);
+        } catch (Auth0Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Delete the users if they were not already deleted during the test script.
+     */
+    @AfterAll
+    public static void tearDown() {
+        assumeTrue(testsShouldRun());
+        otpUser1 = Persistence.otpUsers.getById(otpUser1.id);
+        if (otpUser1 != null) otpUser1.delete(false);
+        otpUser2 = Persistence.otpUsers.getById(otpUser2.id);
+        if (otpUser2 != null) otpUser2.delete(false);
+        adminUser = Persistence.adminUsers.getById(adminUser.id);
+        if (adminUser != null) adminUser.delete();
+    }
+
+    /**
+     * Create trips for two different Otp users and attempt to get both trips with Otp user that has 'enhanced' admin
+     * credentials.
+     */
+    @Test
+    public void canGetOwnMonitoredTrips() {
+
+        // Create trip as Otp user 1.
+        MonitoredTrip monitoredTrip = new MonitoredTrip(TestUtils.sendSamplePlanRequest());
+        monitoredTrip.userId = otpUser1.id;
+        HttpResponse<String> response = mockAuthenticatedPost("api/secure/monitoredtrip",
+            otpUser1,
+            JsonUtils.toJson(monitoredTrip)
+        );
+        assertEquals(HttpStatus.OK_200, response.statusCode());
+
+        // Create trip as Otp user 2.
+        monitoredTrip = new MonitoredTrip(TestUtils.sendSamplePlanRequest());
+        monitoredTrip.userId = otpUser2.id;
+        response = mockAuthenticatedPost("api/secure/monitoredtrip",
+            otpUser2,
+            JsonUtils.toJson(monitoredTrip)
+        );
+        assertEquals(HttpStatus.OK_200, response.statusCode());
+
+        // Get trips for Otp user 2.
+        response = mockAuthenticatedRequest("api/secure/monitoredtrip",
+            otpUser2,
+            HttpUtils.REQUEST_METHOD.GET
+        );
+        ResponseList tripRequests = JsonUtils.getPOJOFromJSON(response.body(), ResponseList.class);
+
+        // Although Otp user 2 has 'enhanced' admin credentials a single trip will be returned.
+        assertEquals(1, tripRequests.data.size());
+
+        // Get trips for Otp user 2 defining user id.
+        response = mockAuthenticatedRequest(String.format("api/secure/monitoredtrip?userId=%s", otpUser2.id),
+            otpUser2,
+            HttpUtils.REQUEST_METHOD.GET
+        );
+        tripRequests = JsonUtils.getPOJOFromJSON(response.body(), ResponseList.class);
+
+        // Just the trip for Otp user 2 will be returned.
+        assertEquals(1, tripRequests.data.size());
+    }
+}

--- a/src/test/java/org/opentripplanner/middleware/GetMonitoredTripsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/GetMonitoredTripsTest.java
@@ -117,6 +117,7 @@ public class GetMonitoredTripsTest {
 
         // Create trip as Otp user 1.
         MonitoredTrip monitoredTrip = new MonitoredTrip(TestUtils.sendSamplePlanRequest());
+        monitoredTrip.updateAllDaysOfWeek(true);
         monitoredTrip.userId = soloOtpUser.id;
         HttpResponse<String> createTrip1Response = mockAuthenticatedRequest(MONITORED_TRIP_PATH,
             JsonUtils.toJson(monitoredTrip),
@@ -127,6 +128,7 @@ public class GetMonitoredTripsTest {
 
         // Create trip as Otp user 2.
         monitoredTrip = new MonitoredTrip(TestUtils.sendSamplePlanRequest());
+        monitoredTrip.updateAllDaysOfWeek(true);
         monitoredTrip.userId = multiOtpUser.id;
         HttpResponse<String> createTripResponse2 = mockAuthenticatedRequest(MONITORED_TRIP_PATH,
             JsonUtils.toJson(monitoredTrip),

--- a/src/test/java/org/opentripplanner/middleware/GetMonitoredTripsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/GetMonitoredTripsTest.java
@@ -2,6 +2,8 @@ package org.opentripplanner.middleware;
 
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.mgmt.users.User;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -111,7 +113,7 @@ public class GetMonitoredTripsTest {
      * credentials.
      */
     @Test
-    public void canGetOwnMonitoredTrips() throws URISyntaxException {
+    public void canGetOwnMonitoredTrips() throws URISyntaxException, JsonProcessingException {
 
         // Create trip as Otp user 1.
         MonitoredTrip monitoredTrip = new MonitoredTrip(TestUtils.sendSamplePlanRequest());
@@ -135,14 +137,14 @@ public class GetMonitoredTripsTest {
 
         // Get trips for solo Otp user.
         HttpResponse<String> soloTripsResponse = mockAuthenticatedGet(MONITORED_TRIP_PATH, soloOtpUser);
-        ResponseList<MonitoredTrip> soloTrips = JsonUtils.getPOJOFromJSON(soloTripsResponse.body(), ResponseList.class);
+        ResponseList<MonitoredTrip> soloTrips = JsonUtils.getResponseListFromJSON(soloTripsResponse.body(), MonitoredTrip.class);
 
         // Expect only 1 trip for solo Otp user.
         assertEquals(1, soloTrips.data.size());
 
         // Get trips for multi Otp user/admin user.
         HttpResponse<String> multiTripsResponse = mockAuthenticatedGet(MONITORED_TRIP_PATH, multiOtpUser);
-        ResponseList<MonitoredTrip> multiTrips = JsonUtils.getPOJOFromJSON(multiTripsResponse.body(), ResponseList.class);
+        ResponseList<MonitoredTrip> multiTrips = JsonUtils.getResponseListFromJSON(multiTripsResponse.body(), MonitoredTrip.class);
 
         // Multi Otp user has 'enhanced' admin credentials both trips will be returned. The expectation here is that the UI
         // will always provide the user id to prevent this (as with the next test).
@@ -154,7 +156,7 @@ public class GetMonitoredTripsTest {
             String.format("api/secure/monitoredtrip?userId=%s", multiOtpUser.id),
             multiOtpUser
         );
-        ResponseList<MonitoredTrip> tripsFiltered = JsonUtils.getPOJOFromJSON(tripsFilteredResponse.body(), ResponseList.class);
+        ResponseList<MonitoredTrip> tripsFiltered = JsonUtils.getResponseListFromJSON(tripsFilteredResponse.body(), MonitoredTrip.class);
         // Just the trip for Otp user 2 will be returned.
         assertEquals(1, tripsFiltered.data.size());
     }

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -42,6 +42,11 @@ public class TestUtils {
     static final String TEMP_AUTH0_USER_PASSWORD = UUID.randomUUID().toString();
 
     /**
+     * x-api-key used when auth is disabled.
+     */
+    static final String TEMP_X_API_KEY = UUID.randomUUID().toString();
+
+    /**
      * Whether the end-to-end environment variable is enabled.
      */
     public static final boolean isEndToEnd = getBooleanEnvVar("RUN_E2E");
@@ -102,7 +107,7 @@ public class TestUtils {
         // the request when received.
         if (isAuthDisabled()) {
             headers.put("Authorization", requestingUser.auth0UserId);
-            headers.put("x-api-key", requestingUser.apiKey);
+            headers.put("x-api-key", TEMP_X_API_KEY);
             return headers;
         }
 

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -37,6 +37,11 @@ public class TestUtils {
     private static final ObjectMapper mapper = new ObjectMapper();
 
     /**
+     * Base URL for application running during testing.
+     */
+    private static final String BASE_URL = "http://localhost:4567/";
+
+    /**
      * Password used to create and validate temporary Auth0 users
      */
     static final String TEMP_AUTH0_USER_PASSWORD = UUID.randomUUID().toString();
@@ -119,13 +124,12 @@ public class TestUtils {
 
 
     /**
-     * Send request to provided URL placing the Auth0 user id in the headers so that {@link RequestingUser} can check
-     * the database for a matching user.
+     * Send request to provided URL.
      */
-    static HttpResponse<String> authenticatedRequest(String path, String body, HashMap<String, String> headers,
-                                                     HttpUtils.REQUEST_METHOD requestMethod) {
+    static HttpResponse<String> makeRequest(String path, String body, HashMap<String, String> headers,
+                                            HttpUtils.REQUEST_METHOD requestMethod) {
         return HttpUtils.httpRequestRawResponse(
-            URI.create("http://localhost:4567/" + path),
+            URI.create(BASE_URL + path),
             1000,
             requestMethod,
             headers,
@@ -134,12 +138,11 @@ public class TestUtils {
     }
 
     /**
-     * Send 'get' request to provided URL placing the Auth0 user id in the headers so that {@link RequestingUser} can
-     * check the database for a matching user.
+     * Send 'get' request to provided URL.
      */
-    static HttpResponse<String> authenticatedGet(String path, HashMap<String, String> headers) {
+    static HttpResponse<String> makeGetRequest(String path, HashMap<String, String> headers) {
         return HttpUtils.httpRequestRawResponse(
-            URI.create("http://localhost:4567/" + path),
+            URI.create(BASE_URL + path),
             1000,
             HttpUtils.REQUEST_METHOD.GET,
             headers,
@@ -148,20 +151,40 @@ public class TestUtils {
     }
 
     /**
-     * Construct http headers according to caller request and then make an authenticated call.
+     * Send 'delete' request to provided URL.
+     */
+    static HttpResponse<String> makeDeleteRequest(String path, HashMap<String, String> headers) {
+        return HttpUtils.httpRequestRawResponse(
+            URI.create(BASE_URL + path),
+            1000,
+            HttpUtils.REQUEST_METHOD.DELETE,
+            headers,
+            ""
+        );
+    }
+
+    /**
+     * Construct http headers according to caller request and then make an authenticated call by placing the Auth0 user
+     * id in the headers so that {@link RequestingUser} can check the database for a matching user.
      */
     static HttpResponse<String> mockAuthenticatedRequest(String path, String body, AbstractUser requestingUser,
-                                                         HttpUtils.REQUEST_METHOD requestMethod, boolean mockHeaders) {
-        HashMap<String, String> headers = (mockHeaders) ? getMockHeaders(requestingUser) : null;
-        return authenticatedRequest(path, body, headers, requestMethod);
+                                                         HttpUtils.REQUEST_METHOD requestMethod) {
+        return makeRequest(path, body, getMockHeaders(requestingUser), requestMethod);
     }
 
     /**
      * Construct http headers according to caller request and then make an authenticated 'get' call.
      */
-    public static HttpResponse<String> mockAuthenticatedGet(String path, AbstractUser requestingUser, boolean mockHeaders) {
-        HashMap<String, String> headers = (mockHeaders) ? getMockHeaders(requestingUser) : null;
-        return authenticatedRequest(path, "", headers, HttpUtils.REQUEST_METHOD.GET);
+    public static HttpResponse<String> mockAuthenticatedGet(String path, AbstractUser requestingUser) {
+        return makeGetRequest(path, getMockHeaders(requestingUser));
+    }
+
+    /**
+     * Construct http headers according to caller request and then make an authenticated call by placing the Auth0 user
+     * id in the headers so that {@link RequestingUser} can check the database for a matching user.
+     */
+    static HttpResponse<String> mockAuthenticatedDelete(String path, AbstractUser requestingUser) {
+        return makeDeleteRequest(path, getMockHeaders(requestingUser));
     }
 
 

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -159,7 +159,7 @@ public class TestUtils {
     /**
      * Construct http headers according to caller request and then make an authenticated 'get' call.
      */
-    static HttpResponse<String> mockAuthenticatedGet(String path, AbstractUser requestingUser, boolean mockHeaders) {
+    public static HttpResponse<String> mockAuthenticatedGet(String path, AbstractUser requestingUser, boolean mockHeaders) {
         HashMap<String, String> headers = (mockHeaders) ? getMockHeaders(requestingUser) : null;
         return authenticatedRequest(path, "", headers, HttpUtils.REQUEST_METHOD.GET);
     }

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -3,7 +3,7 @@ package org.opentripplanner.middleware;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
-import org.opentripplanner.middleware.auth.Auth0UserProfile;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.models.AbstractUser;
 import org.opentripplanner.middleware.models.ApiUser;
 import org.opentripplanner.middleware.otp.OtpDispatcherResponse;
@@ -54,7 +54,7 @@ public class TestUtils {
     }
 
     /**
-     * Send request to provided URL placing the Auth0 user id in the headers so that {@link Auth0UserProfile} can check
+     * Send request to provided URL placing the Auth0 user id in the headers so that {@link RequestingUser} can check
      * the database for a matching user. Returns the response.
      */
     public static HttpResponse<String> mockAuthenticatedRequest(String path, AbstractUser requestingUser, HttpUtils.REQUEST_METHOD requestMethod) {
@@ -107,7 +107,7 @@ public class TestUtils {
     }
 
     /**
-     * Send request to provided URL placing the Auth0 user id in the headers so that {@link Auth0UserProfile} can check
+     * Send request to provided URL placing the Auth0 user id in the headers so that {@link RequestingUser} can check
      * the database for a matching user. Returns the response.
      */
     public static HttpResponse<String> mockAuthenticatedPost(String path, AbstractUser requestingUser, String body) {

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -137,6 +137,7 @@ public class TestUtils {
         }
         Service http = ignite().port(8080);
         http.get("/otp" + OTP_PLAN_ENDPOINT, TestUtils::mockOtpPlanResponse);
+        mockOtpServerSetUpIsDone = true;
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -134,6 +134,20 @@ public class TestUtils {
     }
 
     /**
+     * Send 'get' request to provided URL placing the Auth0 user id in the headers so that {@link RequestingUser} can
+     * check the database for a matching user.
+     */
+    static HttpResponse<String> authenticatedGet(String path, HashMap<String, String> headers) {
+        return HttpUtils.httpRequestRawResponse(
+            URI.create("http://localhost:4567/" + path),
+            1000,
+            HttpUtils.REQUEST_METHOD.GET,
+            headers,
+            ""
+        );
+    }
+
+    /**
      * Construct http headers according to caller request and then make an authenticated call.
      */
     static HttpResponse<String> mockAuthenticatedRequest(String path, String body, AbstractUser requestingUser,
@@ -141,6 +155,15 @@ public class TestUtils {
         HashMap<String, String> headers = (mockHeaders) ? getMockHeaders(requestingUser) : null;
         return authenticatedRequest(path, body, headers, requestMethod);
     }
+
+    /**
+     * Construct http headers according to caller request and then make an authenticated 'get' call.
+     */
+    static HttpResponse<String> mockAuthenticatedGet(String path, AbstractUser requestingUser, boolean mockHeaders) {
+        HashMap<String, String> headers = (mockHeaders) ? getMockHeaders(requestingUser) : null;
+        return authenticatedRequest(path, "", headers, HttpUtils.REQUEST_METHOD.GET);
+    }
+
 
     /**
      * Configure a mock OTP server for providing mock OTP responses. Note: this expects the config value

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -124,7 +124,7 @@ public class TestUtils {
         }
 
         // Otherwise, get a valid oauth token for the user
-        headers.put("Authorization", "Bearer " + Auth0Users.getAuth0Token(requestingUser.email, TEMP_AUTH0_USER_PASSWORD));
+        headers.put("Authorization", "Bearer " + Auth0Users.getAuth0AccessToken(requestingUser.email, TEMP_AUTH0_USER_PASSWORD));
         return headers;
     }
 

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -82,22 +82,6 @@ public class TestUtils {
     }
 
     /**
-     * Send request to provided URL placing the Auth0 user id in the headers so that {@link RequestingUser} can check
-     * the database for a matching user. Returns the response.
-     */
-    public static HttpResponse<String> mockAuthenticatedRequest(String path, AbstractUser requestingUser, HttpUtils.REQUEST_METHOD requestMethod) {
-        HashMap<String, String> headers = getMockHeaders(requestingUser);
-
-        return HttpUtils.httpRequestRawResponse(
-            URI.create("http://localhost:4567/" + path),
-            1000,
-            requestMethod,
-            headers,
-            ""
-        );
-    }
-
-    /**
      * Construct http header values based on user type and status of DISABLE_AUTH config parameter. If authorization is
      * disabled, use Auth0 user ID to authenticate else attempt to get a valid 0auth token from Auth0 and use this.
      */
@@ -133,20 +117,29 @@ public class TestUtils {
         return headers;
     }
 
+
     /**
      * Send request to provided URL placing the Auth0 user id in the headers so that {@link RequestingUser} can check
-     * the database for a matching user. Returns the response.
+     * the database for a matching user.
      */
-    public static HttpResponse<String> mockAuthenticatedPost(String path, AbstractUser requestingUser, String body) {
-        HashMap<String, String> headers = getMockHeaders(requestingUser);
-
+    static HttpResponse<String> authenticatedRequest(String path, String body, HashMap<String, String> headers,
+                                                     HttpUtils.REQUEST_METHOD requestMethod) {
         return HttpUtils.httpRequestRawResponse(
             URI.create("http://localhost:4567/" + path),
             1000,
-            HttpUtils.REQUEST_METHOD.POST,
+            requestMethod,
             headers,
             body
         );
+    }
+
+    /**
+     * Construct http headers according to caller request and then make an authenticated call.
+     */
+    static HttpResponse<String> mockAuthenticatedRequest(String path, String body, AbstractUser requestingUser,
+                                                         HttpUtils.REQUEST_METHOD requestMethod, boolean mockHeaders) {
+        HashMap<String, String> headers = (mockHeaders) ? getMockHeaders(requestingUser) : null;
+        return authenticatedRequest(path, body, headers, requestMethod);
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.middleware;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.eclipse.jetty.http.HttpStatus;
+import org.opentripplanner.middleware.auth.Auth0Users;
 import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.models.AbstractUser;
 import org.opentripplanner.middleware.models.ApiUser;
@@ -11,8 +11,6 @@ import org.opentripplanner.middleware.otp.OtpDispatcherResponse;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.utils.FileUtils;
 import org.opentripplanner.middleware.utils.HttpUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 import spark.Service;
@@ -25,13 +23,11 @@ import java.util.UUID;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthDisabled;
-import static org.opentripplanner.middleware.auth.Auth0Users.getAuth0Token;
 import static org.opentripplanner.middleware.otp.OtpDispatcher.OTP_PLAN_ENDPOINT;
 import static spark.Service.ignite;
 
 
 public class TestUtils {
-    private static final Logger LOG = LoggerFactory.getLogger(TestUtils.class);
     /**
      * Whether the end-to-end environment variable is enabled.
      */
@@ -111,13 +107,7 @@ public class TestUtils {
         }
 
         // Otherwise, get a valid oauth token for the user
-        String token = null;
-        try {
-            token = getAuth0Token(requestingUser.email, TEMP_AUTH0_USER_PASSWORD);
-        } catch (JsonProcessingException e) {
-            LOG.error("Cannot obtain Auth0 token for user {}", requestingUser.email, e);
-        }
-        headers.put("Authorization", "Bearer " + token);
+        headers.put("Authorization", "Bearer " + Auth0Users.getAuth0Token(requestingUser.email, TEMP_AUTH0_USER_PASSWORD));
         return headers;
     }
 

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -69,13 +69,6 @@ public class TestUtils {
      */
     public static HttpResponse<String> mockAuthenticatedRequest(String path, AbstractUser requestingUser, HttpUtils.REQUEST_METHOD requestMethod) {
         HashMap<String, String> headers = getMockHeaders(requestingUser);
-        // If requester is an API user, add API key value as x-api-key header to simulate request over API Gateway.
-        if (requestingUser instanceof ApiUser) {
-            ApiUser apiUser = (ApiUser) requestingUser;
-            if (!apiUser.apiKeys.isEmpty()) {
-                headers.put("x-api-key", apiUser.apiKeys.get(0).value);
-            }
-        }
 
         return HttpUtils.httpRequestRawResponse(
             URI.create("http://localhost:4567/" + path),
@@ -106,7 +99,6 @@ public class TestUtils {
             if (!apiUser.apiKeys.isEmpty()) {
                 headers.put("x-api-key", apiUser.apiKeys.get(0).value);
             }
-            return headers;
         }
 
         // If requester is an Otp user which was created by an Api user, return empty header because an Otp user created

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.middleware.OtpMiddlewareTest;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.persistence.Persistence;
-import org.opentripplanner.middleware.utils.HttpUtils;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
 import java.io.IOException;
@@ -19,7 +18,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedRequest;
+import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedGet;
 import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Connection.setAuthDisabled;
 
@@ -65,22 +64,22 @@ public class OtpUserControllerTest {
     public void invalidNumbersShouldProduceBadRequest(String badNumber, int statusCode) {
         // 1. Request verification SMS.
         // The invalid number should fail the call.
-        HttpResponse<String> response = mockAuthenticatedRequest(
+        HttpResponse<String> response = mockAuthenticatedGet(
             String.format("api/secure/user/%s/verify_sms/%s",
                 otpUser.id,
                 badNumber
             ),
             otpUser,
-            HttpUtils.REQUEST_METHOD.GET
+            true
         );
         assertEquals(statusCode, response.statusCode());
 
         // 2. Fetch the newly-created user.
         // The phone number should not be updated.
-        HttpResponse<String> otpUserWithPhoneRequest = mockAuthenticatedRequest(
+        HttpResponse<String> otpUserWithPhoneRequest = mockAuthenticatedGet(
             String.format("api/secure/user/%s", otpUser.id),
             otpUser,
-            HttpUtils.REQUEST_METHOD.GET
+            true
         );
         assertEquals(HttpStatus.OK_200, otpUserWithPhoneRequest.statusCode());
 

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
@@ -19,23 +19,19 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.middleware.TestUtils.mockAuthenticatedGet;
-import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthDisabled;
+import static org.opentripplanner.middleware.auth.Auth0Connection.restoreDefaultAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Connection.setAuthDisabled;
 
 public class OtpUserControllerTest {
     private static final String INITIAL_PHONE_NUMBER = "+15555550222"; // Fake US 555 number.
     private static OtpUser otpUser;
-    private static boolean originalIsAuthDisabled;
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
         // Load config.
         OtpMiddlewareTest.setUp();
-
-        // Save original isAuthDisabled state to restore it on tear down.
-        originalIsAuthDisabled = isAuthDisabled();
+        // Ensure auth is disabled.
         setAuthDisabled(true);
-
         // Create a persisted OTP user.
         otpUser = new OtpUser();
         otpUser.email = String.format("test-%s@example.com", UUID.randomUUID().toString());
@@ -52,7 +48,7 @@ public class OtpUserControllerTest {
         if (otpUser != null) otpUser.delete();
 
         // Restore original isAuthDisabled state.
-        setAuthDisabled(originalIsAuthDisabled);
+        restoreDefaultAuthDisabled();
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
@@ -69,8 +69,7 @@ public class OtpUserControllerTest {
                 otpUser.id,
                 badNumber
             ),
-            otpUser,
-            true
+            otpUser
         );
         assertEquals(statusCode, response.statusCode());
 
@@ -78,8 +77,7 @@ public class OtpUserControllerTest {
         // The phone number should not be updated.
         HttpResponse<String> otpUserWithPhoneRequest = mockAuthenticatedGet(
             String.format("api/secure/user/%s", otpUser.id),
-            otpUser,
-            true
+            otpUser
         );
         assertEquals(HttpStatus.OK_200, otpUserWithPhoneRequest.statusCode());
 

--- a/src/test/java/org/opentripplanner/middleware/persistence/PersistenceUtil.java
+++ b/src/test/java/org/opentripplanner/middleware/persistence/PersistenceUtil.java
@@ -36,6 +36,8 @@ public class PersistenceUtil {
         user.email = email;
         user.phoneNumber = phoneNumber;
         user.notificationChannel = "email";
+        user.hasConsentedToTerms = true;
+        user.storeTripHistory = true;
         Persistence.otpUsers.create(user);
         return user;
     }

--- a/src/test/java/org/opentripplanner/middleware/persistence/TripHistoryPersistenceTest.java
+++ b/src/test/java/org/opentripplanner/middleware/persistence/TripHistoryPersistenceTest.java
@@ -92,8 +92,6 @@ public class TripHistoryPersistenceTest extends OtpMiddlewareTest {
 
     @Test
     public void canGetFilteredTripRequestsWithFromAndToDate() {
-        OtpUser user = createUser(TEST_EMAIL);
-        List<TripRequest> tripRequests = createTripRequests(LIMIT, user.id);
         LocalDateTime fromStartOfDay = DateTimeUtils.nowAsLocalDate().atTime(LocalTime.MIN);
         LocalDateTime toEndOfDay = DateTimeUtils.nowAsLocalDate().atTime(LocalTime.MAX);
         Date fromDate = Date.from(fromStartOfDay
@@ -102,7 +100,7 @@ public class TripHistoryPersistenceTest extends OtpMiddlewareTest {
         Date toDate = Date.from(toEndOfDay
             .atZone(DateTimeUtils.getSystemZoneId())
             .toInstant());
-        Bson filter = filterByUserAndDateRange(user.id, fromDate, toDate);
+        Bson filter = filterByUserAndDateRange(otpUser.id, fromDate, toDate);
         ResponseList<TripRequest> result = Persistence.tripRequests.getResponseList(filter, 0, LIMIT);
         assertEquals(result.data.size(), tripRequests.size());
     }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR builds on https://github.com/ibi-group/otp-middleware/pull/82 by removing all auth based on an Api user's API key. Instead auth is handled by Auth0. To accomodate this, a new endpoint has been added to allow an Api user to obtain a bearer token from Auth0 by providing their username (email) and password. 

For clarity, the checks tieing an Otp user to an Api user based on an Api user's API key remains.

PR also includes an update to cover this issue: https://github.com/ibi-group/otp-middleware/issues/81. I could not strictly replicate the issue because Auth0 would reject creating an account with an existing email address. I could replicate if I create the admin user in just otp-middleware. I've added the suggested userId parameter, but if this isn't provided the conditional checks would still allow all trips to be returned for an Otp user. Therefore, I have updated the isUserAdmin to return true only if the requesting user is an admin (i.e. does not have mutiple user types).
