### PR TITLE
Do not update matching itin inside shouldSkipMonitoredTripCheck

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/models/JourneyState.java
+++ b/src/main/java/org/opentripplanner/middleware/models/JourneyState.java
@@ -76,11 +76,14 @@ public class JourneyState extends Model {
      * Update journey state based on results from {@link CheckMonitoredTrip}.
      * TODO: This may need some tweaking depending on whether a check was successfully completed or not.
      *   E.g., should a previous journey state be overwritten by a failed check?
+     * @param updateMatchingItinerary true to update the matchingItinerary, otherwise just updates the other fields.
      */
-    public void update(CheckMonitoredTrip checkMonitoredTripJob) {
+    public void update(CheckMonitoredTrip checkMonitoredTripJob, boolean updateMatchingItinerary) {
         targetDate = checkMonitoredTripJob.targetDate;
         lastCheckedMillis = DateTimeUtils.currentTimeMillis();
-        matchingItinerary = checkMonitoredTripJob.matchingItinerary;
+        if (updateMatchingItinerary) {
+            matchingItinerary = checkMonitoredTripJob.matchingItinerary;
+        }
         lastDepartureDelay = checkMonitoredTripJob.departureDelay;
         lastArrivalDelay = checkMonitoredTripJob.arrivalDelay;
         // Update notification time if notification successfully sent.

--- a/src/main/java/org/opentripplanner/middleware/tripMonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripMonitor/jobs/CheckMonitoredTrip.java
@@ -119,8 +119,8 @@ public class CheckMonitoredTrip implements Runnable {
         // Send notifications to user. This should happen before updating the journey state so that we can check the
         // last notification sent.
         sendNotifications();
-        // Update journey state.
-        journeyState.update(this);
+        // Update journey state, including matching itinerary.
+        journeyState.update(this, true);
     }
 
     private void runCheckLogic() {
@@ -335,8 +335,10 @@ public class CheckMonitoredTrip implements Runnable {
                 if (!calculateNextItinerary()) return true;
             }
             LOG.info("Next itinerary happening on {}.", targetDate);
-            // save journey state with updated matching itinerary and target date
-            journeyState.update(this);
+            // Save journey state time checks, but do not update with updated matching itinerary and target date.
+            // The matching itinerary will be updated at the end of method runLogic.
+            // FIXME: Can/should this call be removed altogether?
+            journeyState.update(this, false);
         } else {
             matchingItinerary = journeyState.matchingItinerary;
             targetDate = journeyState.targetDate;

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
@@ -45,7 +45,7 @@ public class OtpUserControllerTest {
     public static void tearDown() {
         // Delete the users if they were not already deleted during the test script.
         otpUser = Persistence.otpUsers.getById(otpUser.id);
-        if (otpUser != null) otpUser.delete();
+        if (otpUser != null) otpUser.delete(false);
 
         // Restore original isAuthDisabled state.
         restoreDefaultAuthDisabled();

--- a/src/test/java/org/opentripplanner/middleware/tripMonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripMonitor/jobs/CheckMonitoredTripTest.java
@@ -117,7 +117,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTest {
         checkMonitoredTrip.run();
         // Assert that there is one notification generated during check.
         // TODO: Improve assertions to use snapshots.
-        Assertions.assertEquals(checkMonitoredTrip.notifications.size(), 0);
+        Assertions.assertEquals(1, checkMonitoredTrip.notifications.size());
         // Clear the created trip.
         deleteMonitoredTripAndJourney(monitoredTrip);
     }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

This PR fixes #108 by removing an extra persistence write for a matching itinerary during `shouldSkipMonitoredTripCheck`. The previous matching itinerary (or null if the itinerary is being checked for the first time) is needed to compare alerts with the latest matching itinerary, otherwise that check will compare the same itinerary and will never find new alerts.

This brings the question whether `shouldSkipMonitoredTripCheck` should update the `JourneyState` for the trip at all, let me know what your thoughts are.
