### PR TITLE
Prevent assigning trip to other user

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -85,19 +85,29 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
         return monitoredTrip;
     }
 
+    /**
+     * Performs the operations/checks common to the preCreate and preUpdate hooks.
+     */
     private void preCreateOrUpdateChecks(MonitoredTrip monitoredTrip, Request req) {
         checkTripCanBeMonitored(monitoredTrip, req);
         checkTripBelongsToManagedUser(monitoredTrip, req);
         processTripQueryParams(monitoredTrip, req);
     }
 
+    /**
+     * Checks that the monitored trip to be written belongs to the requesting user
+     * or to an OtpUser managed by the requesting ApiUser.
+     *
+     * For update (PUT) requests, this check is in addition to MonitoredTrip#canBeManagedBy
+     * that checks that the requesting user can modify the existing, persisted trip.
+     */
     private void checkTripBelongsToManagedUser(MonitoredTrip monitoredTrip, Request req) {
         RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
         if (!requestingUser.canManageEntity(monitoredTrip)) {
             logMessageAndHalt(
                 req,
                 HttpStatus.FORBIDDEN_403,
-                "Api."
+                "Requesting user not authorized to assign the specified trip to the specified user."
             );
         }
     }

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.mongodb.client.model.Filters;
 import org.bson.conversions.Bson;
 import org.eclipse.jetty.http.HttpStatus;
+import org.opentripplanner.middleware.auth.Auth0Connection;
+import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.models.ItineraryExistence;
 import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.persistence.Persistence;
@@ -58,9 +60,8 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
     MonitoredTrip preCreateHook(MonitoredTrip monitoredTrip, Request req) {
         // Ensure user has not reached their limit for number of trips.
         verifyBelowMaxNumTrips(monitoredTrip.userId, req);
-        checkTripCanBeMonitored(monitoredTrip, req);
-        processTripQueryParams(monitoredTrip, req);
-        
+        preCreateOrUpdateChecks(monitoredTrip, req);
+
         try {
             // Check itinerary existence and replace the provided trip's itinerary with a verified, non-realtime
             // version of it.
@@ -84,6 +85,23 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
         return monitoredTrip;
     }
 
+    private void preCreateOrUpdateChecks(MonitoredTrip monitoredTrip, Request req) {
+        checkTripCanBeMonitored(monitoredTrip, req);
+        checkTripBelongsToManagedUser(monitoredTrip, req);
+        processTripQueryParams(monitoredTrip, req);
+    }
+
+    private void checkTripBelongsToManagedUser(MonitoredTrip monitoredTrip, Request req) {
+        RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
+        if (!requestingUser.canManageEntity(monitoredTrip)) {
+            logMessageAndHalt(
+                req,
+                HttpStatus.FORBIDDEN_403,
+                "Api."
+            );
+        }
+    }
+
     /**
      * Processes the {@link MonitoredTrip} query parameters, so the trip's fields match the query parameters.
      * If an error occurs regarding the query params, returns a HTTP 400 status.
@@ -103,8 +121,7 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
 
     @Override
     MonitoredTrip preUpdateHook(MonitoredTrip monitoredTrip, MonitoredTrip preExisting, Request req) {
-        checkTripCanBeMonitored(monitoredTrip, req);
-        processTripQueryParams(monitoredTrip, req);
+        preCreateOrUpdateChecks(monitoredTrip, req);
 
         // TODO: Update itinerary existence record when updating a trip.
 

--- a/src/main/java/org/opentripplanner/middleware/utils/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/HttpUtils.java
@@ -22,7 +22,7 @@ import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 public class HttpUtils {
     private static final Logger LOG = LoggerFactory.getLogger(HttpUtils.class);
-    public enum REQUEST_METHOD {GET, POST, DELETE}
+    public enum REQUEST_METHOD {GET, POST, PUT, DELETE} // FIXME: use sn existing library enum?
 
     /**
      * A constant for a list of MIME types containing application/json only.
@@ -61,7 +61,7 @@ public class HttpUtils {
     }
 
     /**
-     * Makes an http get/post request and returns the response. The request is based on the provided params.
+     * Makes an http request and returns the response. The request is based on the provided params.
      */
     public static HttpResponse<String> httpRequestRawResponse(URI uri, int connectionTimeout, REQUEST_METHOD method,
                                                               Map<String, String> headers, String bodyContent) {
@@ -73,18 +73,24 @@ public class HttpUtils {
             .timeout(Duration.ofSeconds(connectionTimeout))
             .GET();
 
-        if (method.equals(REQUEST_METHOD.GET)) {
-            httpRequestBuilder.GET();
-        }
-
-        if (method.equals(REQUEST_METHOD.DELETE)) {
-            httpRequestBuilder.DELETE();
-        }
-
-        if (method.equals(REQUEST_METHOD.POST)) {
-            httpRequestBuilder.POST(HttpRequest
-                .BodyPublishers
-                .ofString(bodyContent));
+        switch(method) {
+            case GET:
+                httpRequestBuilder.GET();
+                break;
+            case DELETE:
+                httpRequestBuilder.DELETE();
+                break;
+            case POST:
+                httpRequestBuilder.POST(HttpRequest
+                    .BodyPublishers
+                    .ofString(bodyContent));
+                break;
+            case PUT:
+                httpRequestBuilder.PUT(HttpRequest
+                    .BodyPublishers
+                    .ofString(bodyContent));
+                break;
+            default:
         }
 
         if (headers != null && !headers.isEmpty()) {

--- a/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
+++ b/src/test/java/org/opentripplanner/middleware/ApiUserFlowTest.java
@@ -215,15 +215,19 @@ public class ApiUserFlowTest {
         );
 
         // As API user, try to assign this trip to another user the API user doesn't manage.
-        monitoredTrip.userId = otpUserStandalone.id;
+        // (This trip should not be persisted.)
+        MonitoredTrip monitoredTripToNonManagedUser = JsonUtils.getPOJOFromJSON(
+            createTripResponseAsApiUser.body(),
+            MonitoredTrip.class
+        );
+        monitoredTripToNonManagedUser.userId = otpUserStandalone.id;
         HttpResponse<String> putTripResponseAsApiUser = makeRequest(
-            MONITORED_TRIP_PATH + "/" + monitoredTrip.id,
-            JsonUtils.toJson(monitoredTrip),
+            MONITORED_TRIP_PATH + "/" + monitoredTripToNonManagedUser.id,
+            JsonUtils.toJson(monitoredTripToNonManagedUser),
             apiUserHeaders,
             HttpUtils.REQUEST_METHOD.PUT
         );
         assertEquals(HttpStatus.FORBIDDEN_403, putTripResponseAsApiUser.statusCode());
-        monitoredTrip.userId = otpUser.id;
 
         // Request all monitored trips for an Otp user authenticating as an Api user. This will work and return all trips
         // matching the user id provided.

--- a/src/test/java/org/opentripplanner/middleware/Auth0ConnectionTest.java
+++ b/src/test/java/org/opentripplanner/middleware/Auth0ConnectionTest.java
@@ -16,7 +16,6 @@ import org.opentripplanner.middleware.utils.JsonUtils;
 
 import java.io.IOException;
 import java.net.http.HttpResponse;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.eclipse.jetty.http.HttpStatus.NOT_FOUND_404;
@@ -53,7 +52,7 @@ public class Auth0ConnectionTest {
         setAuthDisabled(false);
 
         dummyRequestingUser = new OtpUser();
-        dummyRequestingUser.email = String.format("test-%s@example.com", UUID.randomUUID().toString());
+        dummyRequestingUser.email = TestUtils.generateEmailAddress("test-auth0conn");
 
         // Should use Auth0User.createNewAuth0User but this generates a random password preventing the mock headers
         // from being able to use TEMP_AUTH0_USER_PASSWORD.

--- a/src/test/java/org/opentripplanner/middleware/GetMonitoredTripsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/GetMonitoredTripsTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.middleware;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.mgmt.users.User;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -13,7 +12,6 @@ import org.opentripplanner.middleware.controllers.response.ResponseList;
 import org.opentripplanner.middleware.models.AdminUser;
 import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.models.OtpUser;
-import org.opentripplanner.middleware.models.TripRequest;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.persistence.PersistenceUtil;
 import org.opentripplanner.middleware.utils.HttpUtils;
@@ -24,7 +22,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -72,8 +69,8 @@ public class GetMonitoredTripsTest {
         setAuthDisabled(false);
         // Mock the OTP server TODO: Run a live OTP instance?
         TestUtils.mockOtpServer();
-        String multiUserEmail = String.format("test-%s@example.com", UUID.randomUUID().toString());
-        soloOtpUser = PersistenceUtil.createUser(String.format("test-%s@example.com", UUID.randomUUID().toString()));
+        String multiUserEmail = TestUtils.generateEmailAddress("test-multiotpuser");
+        soloOtpUser = PersistenceUtil.createUser(TestUtils.generateEmailAddress("test-solootpuser"));
         multiOtpUser = PersistenceUtil.createUser(multiUserEmail);
         multiAdminUser = PersistenceUtil.createAdminUser(multiUserEmail);
         try {

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -303,6 +303,10 @@ public class TestUtils {
         );
     }
 
+    /**
+     * Generates a test email address with the specified prefix (to help trace which code created a user),
+     * followed by random UUID string.
+     */
     public static String generateEmailAddress(String prefix) {
         return String.format("%s-%s@example.com", prefix, UUID.randomUUID().toString());
     }

--- a/src/test/java/org/opentripplanner/middleware/TestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/TestUtils.java
@@ -302,4 +302,8 @@ public class TestUtils {
             "08:35"
         );
     }
+
+    public static String generateEmailAddress(String prefix) {
+        return String.format("%s-%s@example.com", prefix, UUID.randomUUID().toString());
+    }
 }

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
@@ -7,13 +7,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.middleware.OtpMiddlewareTest;
+import org.opentripplanner.middleware.TestUtils;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
 import java.io.IOException;
 import java.net.http.HttpResponse;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,7 +34,7 @@ public class OtpUserControllerTest {
         setAuthDisabled(true);
         // Create a persisted OTP user.
         otpUser = new OtpUser();
-        otpUser.email = String.format("test-%s@example.com", UUID.randomUUID().toString());
+        otpUser.email = TestUtils.generateEmailAddress("test-otpusercont");
         otpUser.hasConsentedToTerms = true;
         otpUser.phoneNumber = INITIAL_PHONE_NUMBER;
         otpUser.isPhoneNumberVerified = true;


### PR DESCRIPTION
This PR prevents an API user from assigning a trip of an OTP user they manage to an OTP user they don't manage.
It adds a test in `ApiUserFlowTest` and corresponding code in `MonitoredTripController` that make the test pass.

The PR also places the code that generates test emails using UUIDs inside `TestUtils`.
