### PR TITLE
Raise exception instead of returning null after failed JSON > POJO parse

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/bugsnag/BugsnagDispatcher.java
+++ b/src/main/java/org/opentripplanner/middleware/bugsnag/BugsnagDispatcher.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.middleware.bugsnag;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -135,7 +136,16 @@ public class BugsnagDispatcher {
             create ? EVENT_REQUEST_FILTER : null,
             true
         );
-        return JsonUtils.getPOJOFromHttpBody(response, BugsnagEventRequest.class);
+        try {
+            return JsonUtils.getPOJOFromHttpBody(response, BugsnagEventRequest.class);
+        } catch (JsonProcessingException e) {
+            BugsnagReporter.reportErrorToBugsnag(
+                "Failed to make Bugsnag event data request",
+                eventDataRequestUri,
+                e
+            );
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/bugsnag/jobs/BugsnagEventHandlingJob.java
+++ b/src/main/java/org/opentripplanner/middleware/bugsnag/jobs/BugsnagEventHandlingJob.java
@@ -67,6 +67,10 @@ public class BugsnagEventHandlingJob implements Runnable {
     private void refreshEventRequest(BugsnagEventRequest request) {
         // Refresh the event data request.
         BugsnagEventRequest refreshedRequest = request.refreshEventDataRequest();
+        if (refreshedRequest == null) {
+            LOG.error("Failed to refresh event request");
+            return;
+        }
         if (!refreshedRequest.status.equalsIgnoreCase("completed")) {
             // Request not completed by Bugsnag yet. Return and await the next cycle/refresh.
             // TODO: Update the request data in the database? What if the status has changed since the last fetch?

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiUserController.java
@@ -2,6 +2,7 @@ package org.opentripplanner.middleware.controllers.api;
 
 import com.auth0.json.auth.TokenHolder;
 import com.beerboy.ss.ApiEndpoint;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.auth.Auth0Connection;
 import org.opentripplanner.middleware.auth.Auth0Users;
@@ -109,7 +110,17 @@ public class ApiUserController extends AbstractUserController<ApiUser> {
                 String.format("Cannot obtain Auth0 token for user %s", username)
             );
         }
-        return JsonUtils.getPOJOFromJSON(auth0TokenResponse.responseBody, TokenHolder.class);
+        try {
+            return JsonUtils.getPOJOFromJSON(auth0TokenResponse.responseBody, TokenHolder.class);
+        } catch (JsonProcessingException e) {
+            logMessageAndHalt(
+                req,
+                500,
+                String.format("Encountered an error while trying to obtain Auth0 token for user %s", username),
+                e
+            );
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -143,7 +143,8 @@ public class OtpRequestProcessor implements Endpoint {
 
     /**
      * Process plan response from OTP. Store the response if consent is given. Handle the process and all exceptions
-     * seamlessly so as not to affect the response provided to the requester. Returns false if there was an error.
+     * seamlessly so as not to affect the response provided to the requester.
+     * @return Returns false if there was an error.
      */
     private static boolean handlePlanTripResponse(Request request, OtpDispatcherResponse otpDispatcherResponse, OtpUser otpUser) {
         boolean result = true;

--- a/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
@@ -190,7 +190,7 @@ public class ItineraryExistence extends Model {
             try {
                 plan = response.getResponse().plan;
             } catch (JsonProcessingException e) {
-                LOG.error("Encountered a parse exception for otpRequest {}", otpRequest, e);
+                LOG.error("Could not parse plan response for otpRequest {}", otpRequest, e);
             }
             // Handle response if valid itineraries exist.
             if (plan != null && plan.itineraries != null) {

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -2,6 +2,7 @@ package org.opentripplanner.middleware.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.mongodb.client.FindIterable;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -172,7 +173,11 @@ public class MonitoredTrip extends Model {
     public MonitoredTrip() {
     }
 
-    public MonitoredTrip(OtpDispatcherResponse otpDispatcherResponse) throws URISyntaxException {
+    /**
+     * Used only during testing
+     */
+    public MonitoredTrip(OtpDispatcherResponse otpDispatcherResponse) throws URISyntaxException,
+        JsonProcessingException {
         queryParams = otpDispatcherResponse.requestUri.getQuery();
         TripPlan plan = otpDispatcherResponse.getResponse().plan;
         itinerary = plan.itineraries.get(0);

--- a/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcherResponse.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcherResponse.java
@@ -80,8 +80,8 @@ public class OtpDispatcherResponse implements Serializable {
         String planResponse = null;
         try {
             planResponse = requestUri.getPath().endsWith(OTP_PLAN_ENDPOINT)
-                    ? ", response=" + getResponse()
-                    : "";
+                ? ", response=" + getResponse()
+                : "";
         } catch (JsonProcessingException e) {
             LOG.error("Encountered exception wile parsing OTP_PLAN_ENDPOINT response", e);
             planResponse = "PARSE_EXCEPTION";

--- a/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcherResponse.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcherResponse.java
@@ -83,7 +83,7 @@ public class OtpDispatcherResponse implements Serializable {
                 ? ", response=" + getResponse()
                 : "";
         } catch (JsonProcessingException e) {
-            LOG.error("Encountered exception wile parsing OTP_PLAN_ENDPOINT response", e);
+            LOG.error("Encountered exception while parsing OTP_PLAN_ENDPOINT response", e);
             planResponse = "PARSE_EXCEPTION";
         }
 

--- a/src/main/java/org/opentripplanner/middleware/utils/JsonUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/JsonUtils.java
@@ -61,17 +61,13 @@ public class JsonUtils {
     /**
      * Utility method to parse generic object from JSON String.
      */
-    public static <T> T getPOJOFromJSON(String json, Class<T> clazz) {
+    public static <T> T getPOJOFromJSON(String json, Class<T> clazz) throws JsonProcessingException {
         try {
             return mapper.readValue(json, clazz);
         } catch (JsonProcessingException e) {
-            BugsnagReporter.reportErrorToBugsnag(
-                String.format("Unable to get POJO from json for %s", clazz.getSimpleName()),
-                json,
-                e
-            );
+            LOG.error("Could not parse JSON `{}` into POJO for class {}", json, clazz, e);
+            throw e;
         }
-        return null;
     }
 
     /**
@@ -90,7 +86,8 @@ public class JsonUtils {
     /**
      * Utility method to parse generic object from HTTP response.
      */
-    public static <T> T getPOJOFromHttpBody(HttpResponseValues response, Class<T> clazz) {
+    public static <T> T getPOJOFromHttpBody(HttpResponseValues response, Class<T> clazz)
+        throws JsonProcessingException {
         return isResponseOk(response)
             ? getPOJOFromJSON(response.responseBody, clazz)
             : null;

--- a/src/test/java/org/opentripplanner/middleware/auth/Auth0ConnectionTest.java
+++ b/src/test/java/org/opentripplanner/middleware/auth/Auth0ConnectionTest.java
@@ -71,7 +71,7 @@ public class Auth0ConnectionTest extends OtpMiddlewareTestEnvironment {
 
     @ParameterizedTest
     @MethodSource("createIsCreatingSelfTestCases")
-    public void canCheckIsCreatingSelf(Auth0ConnectionTestCase testCase) {
+    public void canCheckIsCreatingSelf(Auth0ConnectionTestCase testCase) throws Exception {
         // Simulate a yet-to-be-saved OtpUser/ApiUser sending an authenticated request to persist itself
         // (e.g. during sign up).
         HttpResponseValues createUserResponse = mockAuthenticatedRequest(testCase.uri,
@@ -91,14 +91,10 @@ public class Auth0ConnectionTest extends OtpMiddlewareTestEnvironment {
             boolean creatingApiUser = testCase.uri.endsWith(API_USER_PATH);
             if (creatingOtpUser) {
                 OtpUser createdUser = JsonUtils.getPOJOFromJSON(createUserResponse.responseBody, OtpUser.class);
-                if (createdUser != null) {
-                    createdUser.delete(false);
-                }
+                createdUser.delete(false);
             } else if (creatingApiUser) {
                 ApiUser createdUser = JsonUtils.getPOJOFromJSON(createUserResponse.responseBody, ApiUser.class);
-                if (createdUser != null) {
-                    createdUser.delete(false);
-                }
+                createdUser.delete(false);
             }
         }
     }
@@ -116,7 +112,7 @@ public class Auth0ConnectionTest extends OtpMiddlewareTestEnvironment {
 
     @ParameterizedTest
     @MethodSource("createIsRequestingVerificationEmailTestCases")
-    public void canCheckIsRequestingVerificationEmail(Auth0ConnectionTestCase testCase) {
+    public void canCheckIsRequestingVerificationEmail(Auth0ConnectionTestCase testCase) throws Exception {
         // Simulate a yet-to-be-saved OtpUser/ApiUser sending an authenticated request to resend a verification email
         // (e.g. during sign up).
         HttpResponseValues sendVerificationEmailResponse = mockAuthenticatedGet(testCase.uri, dummyRequestingUser);

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/ApiKeyManagementTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/ApiKeyManagementTest.java
@@ -72,7 +72,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTestEnvironment {
      * Ensure that an {@link ApiUser} can create an API key for self.
      */
     @Test
-    public void canCreateApiKeyForSelf() {
+    public void canCreateApiKeyForSelf() throws Exception {
         HttpResponseValues response = createApiKeyRequest(apiUser.id, apiUser);
         assertEquals(HttpStatus.OK_200, response.status);
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.responseBody, ApiUser.class);
@@ -86,7 +86,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTestEnvironment {
      * Ensure that an {@link AdminUser} can create an API key for an {@link ApiUser}.
      */
     @Test
-    public void adminCanCreateApiKeyForApiUser() {
+    public void adminCanCreateApiKeyForApiUser() throws Exception {
         HttpResponseValues response = createApiKeyRequest(apiUser.id, adminUser);
         assertEquals(HttpStatus.OK_200, response.status);
         ApiUser userFromResponse = JsonUtils.getPOJOFromJSON(response.responseBody, ApiUser.class);
@@ -101,7 +101,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTestEnvironment {
      * limits).
      */
     @Test
-    public void cannotDeleteApiKeyForSelf() {
+    public void cannotDeleteApiKeyForSelf() throws Exception {
         ensureApiKeyExists();
         int initialKeyCount = apiUser.apiKeys.size();
         // delete key
@@ -118,7 +118,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTestEnvironment {
      * Ensure that an {@link AdminUser} can delete an API key for an {@link ApiUser}.
      */
     @Test
-    public void adminCanDeleteApiKeyForApiUser() {
+    public void adminCanDeleteApiKeyForApiUser() throws Exception {
         ensureApiKeyExists();
         // delete key
         String keyId = apiUser.apiKeys.get(0).keyId;
@@ -155,7 +155,7 @@ public class ApiKeyManagementTest extends OtpMiddlewareTestEnvironment {
     /**
      * Create API key for target user based on authorization of requesting user
      */
-    private HttpResponseValues createApiKeyRequest(String targetUserId, AbstractUser requestingUser) {
+    private HttpResponseValues createApiKeyRequest(String targetUserId, AbstractUser requestingUser) throws Exception {
         String path = String.format("api/secure/application/%s/apikey", targetUserId);
         return mockAuthenticatedRequest(path, "", requestingUser, HttpMethod.POST);
     }
@@ -163,7 +163,8 @@ public class ApiKeyManagementTest extends OtpMiddlewareTestEnvironment {
     /**
      * Delete API key for target user based on authorization of requesting user
      */
-    private static HttpResponseValues deleteApiKeyRequest(String targetUserId, String apiKeyId, AbstractUser requestingUser) {
+    private static HttpResponseValues deleteApiKeyRequest(String targetUserId, String apiKeyId, AbstractUser requestingUser)
+        throws Exception {
         String path = String.format("api/secure/application/%s/apikey/%s", targetUserId, apiKeyId);
         return mockAuthenticatedDelete(path, requestingUser);
     }

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/ApiUserFlowTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/ApiUserFlowTest.java
@@ -3,7 +3,6 @@ package org.opentripplanner.middleware.controllers.api;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.auth.TokenHolder;
 import com.auth0.json.mgmt.users.User;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
@@ -26,7 +25,6 @@ import org.opentripplanner.middleware.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.UUID;
 
@@ -154,7 +152,7 @@ public class ApiUserFlowTest extends OtpMiddlewareTestEnvironment {
      *   5. Delete user and verify that their associated objects are also deleted.
      */
     @Test
-    public void canSimulateApiUserFlow() throws URISyntaxException, JsonProcessingException {
+    public void canSimulateApiUserFlow() throws Exception {
 
         // Define the header values to be used in requests from this point forward.
         HashMap<String, String> apiUserHeaders = new HashMap<>();

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/GetMonitoredTripsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/GetMonitoredTripsTest.java
@@ -2,7 +2,6 @@ package org.opentripplanner.middleware.controllers.api;
 
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.mgmt.users.User;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
@@ -23,7 +22,6 @@ import org.opentripplanner.middleware.utils.HttpResponseValues;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -114,7 +112,7 @@ public class GetMonitoredTripsTest extends OtpMiddlewareTestEnvironment {
      * credentials.
      */
     @Test
-    public void canGetOwnMonitoredTrips() throws URISyntaxException, JsonProcessingException {
+    public void canGetOwnMonitoredTrips() throws Exception {
         // Create a trip for the solo and the multi OTP user.
         createMonitoredTripAsUser(soloOtpUser);
         createMonitoredTripAsUser(multiOtpUser);
@@ -143,7 +141,7 @@ public class GetMonitoredTripsTest extends OtpMiddlewareTestEnvironment {
     /**
      * Helper method to get trips for user.
      */
-    private ResponseList<MonitoredTrip> getMonitoredTripsForUser(String path, OtpUser otpUser) throws JsonProcessingException {
+    private ResponseList<MonitoredTrip> getMonitoredTripsForUser(String path, OtpUser otpUser) throws Exception {
         HttpResponseValues soloTripsResponse = mockAuthenticatedGet(path, otpUser);
         return JsonUtils.getResponseListFromJSON(soloTripsResponse.responseBody, MonitoredTrip.class);
     }
@@ -151,7 +149,7 @@ public class GetMonitoredTripsTest extends OtpMiddlewareTestEnvironment {
     /**
      * Creates a {@link MonitoredTrip} for the specified user.
      */
-    private static void createMonitoredTripAsUser(OtpUser otpUser) throws URISyntaxException {
+    private static void createMonitoredTripAsUser(OtpUser otpUser) throws Exception {
         MonitoredTrip monitoredTrip = new MonitoredTrip(OtpTestUtils.sendSamplePlanRequest());
         monitoredTrip.updateAllDaysOfWeek(true);
         monitoredTrip.userId = otpUser.id;

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
@@ -56,7 +56,7 @@ public class OtpUserControllerTest extends OtpMiddlewareTestEnvironment {
      */
     @ParameterizedTest
     @MethodSource("createBadPhoneNumbers")
-    public void invalidNumbersShouldProduceBadRequest(String badNumber, int statusCode) {
+    public void invalidNumbersShouldProduceBadRequest(String badNumber, int statusCode) throws Exception {
         // 1. Request verification SMS.
         // The invalid number should fail the call.
         HttpResponseValues response = mockAuthenticatedGet(

--- a/src/test/java/org/opentripplanner/middleware/persistence/TripHistoryPersistenceTest.java
+++ b/src/test/java/org/opentripplanner/middleware/persistence/TripHistoryPersistenceTest.java
@@ -12,7 +12,6 @@ import org.opentripplanner.middleware.models.TripSummary;
 import org.opentripplanner.middleware.testutils.OtpMiddlewareTestEnvironment;
 import org.opentripplanner.middleware.utils.DateTimeUtils;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Date;
@@ -42,7 +41,7 @@ public class TripHistoryPersistenceTest extends OtpMiddlewareTestEnvironment {
     private static List<TripRequest> tripRequests = null;
 
     @BeforeAll
-    public static void setup() throws IOException {
+    public static void setup() throws Exception {
         otpUser = createUser(TEST_EMAIL);
         tripRequest = createTripRequest(otpUser.id);
         tripRequests = createTripRequests(LIMIT, otpUser.id);

--- a/src/test/java/org/opentripplanner/middleware/testutils/ApiTestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/testutils/ApiTestUtils.java
@@ -44,7 +44,7 @@ public class ApiTestUtils {
      * Construct http header values based on user type and status of DISABLE_AUTH config parameter. If authorization is
      * disabled, use Auth0 user ID to authenticate else attempt to get a valid 0auth token from Auth0 and use this.
      */
-    public static HashMap<String, String> getMockHeaders(AbstractUser requestingUser) {
+    public static HashMap<String, String> getMockHeaders(AbstractUser requestingUser) throws Exception {
         HashMap<String, String> headers = new HashMap<>();
         String scope = null;
         // If auth is disabled, set the authorization header, x-api-key and scope accordingly, each which will be
@@ -90,7 +90,7 @@ public class ApiTestUtils {
      * Attempt to get Auth0 token from Auth0 tenant for the given username (email) and scope. If the response from Auth0
      * is ok, extract the access token from the token holder response and return to caller.
      */
-    private static String getTestAuth0AccessToken(String username, String scope) {
+    private static String getTestAuth0AccessToken(String username, String scope) throws Exception {
         HttpResponseValues response = Auth0Users.getAuth0TokenWithScope(username, TEMP_AUTH0_USER_PASSWORD, scope);
         if (response == null || response.status != HttpStatus.OK_200) {
             LOG.error("Cannot obtain Auth0 token for user {}. response: {} - {}",
@@ -151,14 +151,14 @@ public class ApiTestUtils {
      */
     public static HttpResponseValues mockAuthenticatedRequest(
         String path, String body, AbstractUser requestingUser, HttpMethod requestMethod
-    ) {
+    ) throws Exception {
         return makeRequest(path, body, getMockHeaders(requestingUser), requestMethod);
     }
 
     /**
      * Construct http headers according to caller request and then make an authenticated 'get' call.
      */
-    public static HttpResponseValues mockAuthenticatedGet(String path, AbstractUser requestingUser) {
+    public static HttpResponseValues mockAuthenticatedGet(String path, AbstractUser requestingUser) throws Exception {
         return makeGetRequest(path, getMockHeaders(requestingUser));
     }
 
@@ -166,7 +166,8 @@ public class ApiTestUtils {
      * Construct http headers according to caller request and then make an authenticated call by placing the Auth0 user
      * id in the headers so that {@link RequestingUser} can check the database for a matching user.
      */
-    public static HttpResponseValues mockAuthenticatedDelete(String path, AbstractUser requestingUser) {
+    public static HttpResponseValues mockAuthenticatedDelete(String path, AbstractUser requestingUser)
+        throws Exception {
         return makeDeleteRequest(path, getMockHeaders(requestingUser));
     }
 

--- a/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
@@ -174,7 +174,7 @@ public class OtpTestUtils {
         );
     }
 
-    public static List<OtpResponse> createMockOtpResponsesForTripExistence() {
+    public static List<OtpResponse> createMockOtpResponsesForTripExistence() throws Exception {
         // Set up monitored days and mock responses for itinerary existence check, ordered by day.
         LocalDate today = DateTimeUtils.nowAsLocalDate();
         List<String> monitoredTripDates = new ArrayList<>();
@@ -195,11 +195,11 @@ public class OtpTestUtils {
         );
     }
 
-    public static Itinerary createDefaultItinerary() {
+    public static Itinerary createDefaultItinerary() throws Exception {
         return OTP_DISPATCHER_PLAN_RESPONSE.clone().getResponse().plan.itineraries.get(0);
     }
 
-    public static JourneyState createDefaultJourneyState() {
+    public static JourneyState createDefaultJourneyState() throws Exception {
         JourneyState journeyState = new JourneyState();
         Itinerary defaultItinerary = createDefaultItinerary();
         journeyState.scheduledArrivalTimeEpochMillis = defaultItinerary.endTime.getTime();

--- a/src/test/java/org/opentripplanner/middleware/testutils/PersistenceTestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/testutils/PersistenceTestUtils.java
@@ -15,7 +15,6 @@ import org.opentripplanner.middleware.otp.OtpDispatcherResponse;
 import org.opentripplanner.middleware.otp.response.OtpResponse;
 import org.opentripplanner.middleware.tripmonitor.JourneyState;
 
-import java.net.URISyntaxException;
 import java.util.*;
 
 /**
@@ -78,7 +77,7 @@ public class PersistenceTestUtils {
     /**
      * Create trip summary from static plan response file and store in database.
      */
-    public static TripSummary createTripSummary(String tripRequestId) {
+    public static TripSummary createTripSummary(String tripRequestId) throws Exception {
         OtpResponse planResponse = OtpTestUtils.OTP_DISPATCHER_PLAN_RESPONSE.getResponse();
         TripSummary tripSummary = new TripSummary(planResponse.plan, planResponse.error, tripRequestId);
         Persistence.tripSummaries.create(tripSummary);
@@ -88,7 +87,7 @@ public class PersistenceTestUtils {
     /**
      * Create trip summary from static plan error response file and store in database.
      */
-    public static TripSummary createTripSummaryWithError(String tripRequestId) {
+    public static TripSummary createTripSummaryWithError(String tripRequestId) throws Exception {
         OtpResponse planErrorResponse = OtpTestUtils.OTP_DISPATCHER_PLAN_ERROR_RESPONSE.getResponse();
         TripSummary tripSummary = new TripSummary(null, planErrorResponse.error, tripRequestId);
         Persistence.tripSummaries.create(tripSummary);
@@ -129,7 +128,7 @@ public class PersistenceTestUtils {
         OtpDispatcherResponse otpDispatcherResponse,
         boolean persist,
         JourneyState journeyState
-    ) throws URISyntaxException {
+    ) throws Exception {
         MonitoredTrip monitoredTrip = new MonitoredTrip(otpDispatcherResponse);
         monitoredTrip.userId = userId;
         monitoredTrip.tripName = "test trip";

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
@@ -79,7 +78,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      * (and OTP_PLAN_ENDPOINT) to a valid OTP server.
      */
     @Test
-    public void canMonitorTrip() throws URISyntaxException, CloneNotSupportedException {
+    public void canMonitorTrip() throws Exception {
         // Do not run this test in a CI environment because it requires a live OTP server
         // FIXME: Add live otp server to e2e tests.
         assumeTrue(!ConfigUtils.isRunningCi && OtpMiddlewareTestEnvironment.IS_END_TO_END);
@@ -140,8 +139,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         }
     }
 
-    private static List<DelayNotificationTestCase> createDelayNotificationTestCases ()
-        throws URISyntaxException, CloneNotSupportedException {
+    private static List<DelayNotificationTestCase> createDelayNotificationTestCases () throws Exception {
         List<DelayNotificationTestCase> testCases = new ArrayList<>();
 
         // should not create departure/arrival notification for on-time trip
@@ -229,7 +227,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     /**
      * Convenience method for creating a CheckMonitoredTrip instance with the default journey state.
      */
-    private static CheckMonitoredTrip createCheckMonitoredTrip() throws URISyntaxException, CloneNotSupportedException {
+    private static CheckMonitoredTrip createCheckMonitoredTrip() throws Exception {
         return createCheckMonitoredTrip(OtpTestUtils.createDefaultJourneyState());
     }
 
@@ -238,9 +236,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      * created using the default OTP response. Also, creates a new matching itinerary that consists of the first
      * itinerary in the default OTP response.
      */
-    private static CheckMonitoredTrip createCheckMonitoredTrip(
-        JourneyState journeyState
-    ) throws URISyntaxException, CloneNotSupportedException {
+    private static CheckMonitoredTrip createCheckMonitoredTrip(JourneyState journeyState) throws Exception {
         MonitoredTrip monitoredTrip = PersistenceTestUtils.createMonitoredTrip(
             user.id,
             OtpTestUtils.OTP_DISPATCHER_PLAN_RESPONSE.clone(),
@@ -267,7 +263,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         );
     }
 
-    static List<ShouldSkipTripTestCase> createSkipTripTestCases() throws URISyntaxException {
+    static List<ShouldSkipTripTestCase> createSkipTripTestCases() throws Exception {
         List<ShouldSkipTripTestCase> testCases = new ArrayList<>();
 
         // - Return true for weekend trip when current time is on a weekday.
@@ -376,8 +372,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      * Tests whether an OTP request can be made and if the trip and matching itinerary gets updated properly
      */
     @Test
-    public void canMakeOTPRequestAndUpdateMatchingItineraryForPreviouslyUnmatchedItinerary()
-        throws URISyntaxException, CloneNotSupportedException {
+    public void canMakeOTPRequestAndUpdateMatchingItineraryForPreviouslyUnmatchedItinerary() throws Exception {
         // create a mock monitored trip and CheckMonitorTrip instance
         CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip();
         MonitoredTrip mockTrip = mockCheckMonitoredTrip.trip;
@@ -443,7 +438,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      * matching itinerary.
      */
     @Test
-    public void canMakeOTPRequestAndResolveUnmatchedItinerary() throws URISyntaxException, CloneNotSupportedException {
+    public void canMakeOTPRequestAndResolveUnmatchedItinerary() throws Exception {
         // create a mock monitored trip and CheckMonitorTrip instance
         CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip();
         MonitoredTrip mockTrip = mockCheckMonitoredTrip.trip;
@@ -521,8 +516,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      * matching itinerary for all days of the week.
      */
     @Test
-    public void canMakeOTPRequestAndResolveNoLongerPossibleTrip() throws URISyntaxException,
-        CloneNotSupportedException {
+    public void canMakeOTPRequestAndResolveNoLongerPossibleTrip() throws Exception {
         // create a mock monitored trip and CheckMonitorTrip instance
         CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip();
         MonitoredTrip mockTrip = mockCheckMonitoredTrip.trip;

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/ShouldSkipTripTestCase.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/ShouldSkipTripTestCase.java
@@ -9,7 +9,6 @@ import org.opentripplanner.middleware.testutils.OtpTestUtils;
 import org.opentripplanner.middleware.testutils.PersistenceTestUtils;
 import org.opentripplanner.middleware.tripmonitor.JourneyState;
 
-import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 
 class ShouldSkipTripTestCase {
@@ -49,9 +48,7 @@ class ShouldSkipTripTestCase {
         return message;
     }
 
-    public CheckMonitoredTrip generateCheckMonitoredTrip(
-        OtpUser user
-    ) throws URISyntaxException, CloneNotSupportedException {
+    public CheckMonitoredTrip generateCheckMonitoredTrip(OtpUser user) throws Exception {
         // create a mock OTP response for planning a trip on a weekday target datetime
         OtpResponse mockWeekdayResponse = OtpTestUtils.OTP_DISPATCHER_PLAN_RESPONSE.getResponse();
         Itinerary mockWeekdayItinerary = mockWeekdayResponse.plan.itineraries.get(0);

--- a/src/test/java/org/opentripplanner/middleware/utils/ItineraryUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/ItineraryUtilsTest.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -92,8 +91,9 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
     );
 
     /** Contains the verified itinerary set for a trip upon persisting. */
-    private static final Itinerary DEFAULT_ITINERARY =
-        OtpTestUtils.OTP_DISPATCHER_PLAN_RESPONSE.getResponse().plan.itineraries.get(0);
+    public static Itinerary getDefaultItinerary() throws Exception {
+        return OtpTestUtils.OTP_DISPATCHER_PLAN_RESPONSE.getResponse().plan.itineraries.get(0);
+    }
 
     @BeforeAll
     public static void setup() throws IOException {
@@ -110,7 +110,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
      */
     @ParameterizedTest
     @MethodSource("createCheckAllItinerariesExistTestCases")
-    public void canCheckAllItinerariesExist(boolean insertInvalidDay, String message) throws URISyntaxException {
+    public void canCheckAllItinerariesExist(boolean insertInvalidDay, String message) throws Exception {
         MonitoredTrip trip = makeTestTrip();
         List<OtpResponse> mockOtpResponses = getMockDatedOtpResponses(MONITORED_TRIP_DATES);
 
@@ -181,7 +181,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
      * Creates a set of mock OTP responses by making copies of #OTP_DISPATCHER_PLAN_RESPONSE,
      * each copy having the itinerary date set to one of the dates from the specified dates list.
      */
-    public static List<OtpResponse> getMockDatedOtpResponses(List<String> dates) {
+    public static List<OtpResponse> getMockDatedOtpResponses(List<String> dates) throws Exception {
         // Set mocks to a list of responses with itineraries, ordered by day.
         List<OtpResponse> mockOtpResponses = new ArrayList<>();
 
@@ -283,14 +283,14 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
         );
     }
 
-    private static List<ItineraryMatchTestCase> createItineraryComparisonTestCases() throws CloneNotSupportedException {
+    private static List<ItineraryMatchTestCase> createItineraryComparisonTestCases() throws Exception {
         List<ItineraryMatchTestCase> testCases = new ArrayList<>();
 
         // should match same data
         testCases.add(
             new ItineraryMatchTestCase(
                 "Should be equal with same data",
-                DEFAULT_ITINERARY.clone(),
+                getDefaultItinerary().clone(),
                 true
             )
         );
@@ -298,7 +298,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
         // should not be equal with a different amount of legs
         Leg extraBikeLeg = new Leg();
         extraBikeLeg.mode = "BICYCLE";
-        Itinerary itineraryWithMoreLegs = DEFAULT_ITINERARY.clone();
+        Itinerary itineraryWithMoreLegs = getDefaultItinerary().clone();
         itineraryWithMoreLegs.legs.add(extraBikeLeg);
         testCases.add(
             new ItineraryMatchTestCase(
@@ -309,7 +309,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
         );
 
         // should be equal with realtime data on transit leg (same day)
-        Itinerary itineraryWithRealtimeTransit = DEFAULT_ITINERARY.clone();
+        Itinerary itineraryWithRealtimeTransit = getDefaultItinerary().clone();
         Leg transitLeg = itineraryWithRealtimeTransit.legs.get(1);
         int secondsOfDelay = 120;
         transitLeg.startTime = new Date(transitLeg.startTime.getTime() + secondsOfDelay * 1000);
@@ -325,7 +325,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
         );
 
         // should be equal with scheduled data on transit leg (future date)
-        Itinerary itineraryOnFutureDate = DEFAULT_ITINERARY.clone();
+        Itinerary itineraryOnFutureDate = getDefaultItinerary().clone();
         Leg transitLeg2 = itineraryOnFutureDate.legs.get(1);
         transitLeg2.startTime = Date.from(transitLeg2.startTime.toInstant().plus(7, ChronoUnit.DAYS));
         transitLeg2.endTime = Date.from(transitLeg2.endTime.toInstant().plus(7, ChronoUnit.DAYS));
@@ -408,7 +408,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
             String name,
             Itinerary newItinerary,
             boolean shouldMatch
-        ) {
+        ) throws Exception {
             this(name, null, newItinerary, shouldMatch);
         }
 
@@ -417,12 +417,12 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
             Itinerary previousItinerary,
             Itinerary newItinerary,
             boolean shouldMatch
-        ) {
+        ) throws Exception {
             this.name = name;
             if (previousItinerary != null) {
                 this.previousItinerary = previousItinerary;
             } else {
-                this.previousItinerary = DEFAULT_ITINERARY;
+                this.previousItinerary = getDefaultItinerary();
             }
             this.newItinerary = newItinerary;
             this.shouldMatch = shouldMatch;


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Previously if a parse exception occurred, the code reported the exception to Bugsnag, but then returned `null`. Methods that called this method are mostly test methods, but some other non-test code that made this call would then not properly do a null check which could result in `NullPointerException`s. Therefore, this refactors the `JSONUtils#getPOJOFromJSON` method so that it throws a `JsonProcessingException`.

The affected methods that now need to catch this exception have been modified to better handle this exception and provide more relevant information to Bugsnag and avoid the possibility of NullPointerExceptions.