### PR TITLE
Update Bugsnag library to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
         <!-- Required to communicate with Bugsnag's API -->
         <dependency>
             <groupId>com.bugsnag</groupId>
-            <version>3.4.4</version>
+            <version>3.6.2</version>
             <artifactId>bugsnag</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/org/opentripplanner/middleware/bugsnag/BugsnagReporter.java
+++ b/src/main/java/org/opentripplanner/middleware/bugsnag/BugsnagReporter.java
@@ -60,7 +60,7 @@ public class BugsnagReporter {
         // Finally, construct report and send to bugsnag.
         Report report = bugsnag.buildReport(throwable);
         report.setContext(message);
-        report.setAppInfo("entity", badEntity != null ? badEntity.toString() : "N/A");
+        report.addToTab("debugging", "bad entity", badEntity != null ? badEntity.toString() : "N/A");
         report.setSeverity(Severity.ERROR);
         return bugsnag.notify(report);
     }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This updates the Bugsnag library to the latest version. As a part of updating, the deprecated method call of `setEntity` has been replaced with `addToTab` which should create a new tab with new keys and the corresponding value that should be visible within the error details in the Bugsnag dashboard.

#### Old Bugsnag error detail

<img width="654" alt="Screen Shot 2021-06-23 at 8 51 11 AM" src="https://user-images.githubusercontent.com/3112493/123128749-40f7c400-d400-11eb-8d10-8693d624a0d3.png">

#### New Bugsnag error detail

<img width="417" alt="Screen Shot 2021-06-23 at 11 06 13 AM" src="https://user-images.githubusercontent.com/3112493/123146772-1d8a4480-d413-11eb-9987-89a3b90e50bb.png">
