### PR TITLE
Introduce endpoint for running OTP1 and 2 in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ The special E2E client settings should be defined in `env.yml`:
 | OTP_ADMIN_DASHBOARD_FROM_EMAIL | string | Optional | OTP Admin Dashboard <no-reply@email.com> | Config setting for linking to the OTP Admin Dashboard. |
 | OTP_ADMIN_DASHBOARD_NAME | string | Optional | OTP Admin Dashboard | Config setting for linking to the OTP Admin Dashboard. |
 | OTP_ADMIN_DASHBOARD_URL | string | Optional | https://admin.example.com | Config setting for linking to the OTP Admin Dashboard. |
-| OTP_API_ROOT | string | Required | http://otp-server.example.com/otp | The URL of an operational OTP server. |
+| OTP_API_ROOT | string | Required | http://otp-server.example.com/otp | The URL of an operational OTP1 server. |
+| OTP2_API_ROOT | string | Required | http://otp-server.example.com/otp | The URL of an operational OTP2 server. |
 | OTP_PLAN_ENDPOINT | string | Optional | /routers/default/plan | The path to the OTP server trip planning endpoint. |
 | OTP_TIMEZONE | string | Required | America/Los_Angeles | The timezone identifier that OTP is using to parse dates and times. OTP will use the timezone identifier that it finds in the first available agency to parse dates and times. |
 | OTP_UI_NAME | string | Optional | Trip Planner | Config setting for linking to the OTP UI (trip planner). |

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The special E2E client settings should be defined in `env.yml`:
 | OTP_ADMIN_DASHBOARD_NAME | string | Optional | OTP Admin Dashboard | Config setting for linking to the OTP Admin Dashboard. |
 | OTP_ADMIN_DASHBOARD_URL | string | Optional | https://admin.example.com | Config setting for linking to the OTP Admin Dashboard. |
 | OTP_API_ROOT | string | Required | http://otp-server.example.com/otp | The URL of an operational OTP1 server. |
-| OTP2_API_ROOT | string | Required | http://otp-server.example.com/otp | The URL of an operational OTP2 server. |
+| OTP2_API_ROOT | string | Optional | http://otp2-server.example.com/otp | The URL of an operational OTP2 server. |
 | OTP_PLAN_ENDPOINT | string | Optional | /routers/default/plan | The path to the OTP server trip planning endpoint. |
 | OTP_TIMEZONE | string | Required | America/Los_Angeles | The timezone identifier that OTP is using to parse dates and times. OTP will use the timezone identifier that it finds in the first available agency to parse dates and times. |
 | OTP_UI_NAME | string | Optional | Trip Planner | Config setting for linking to the OTP UI (trip planner). |

--- a/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
+++ b/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
@@ -16,6 +16,7 @@ import org.opentripplanner.middleware.controllers.api.OtpUserController;
 import org.opentripplanner.middleware.controllers.api.TripHistoryController;
 import org.opentripplanner.middleware.docs.PublicApiDocGenerator;
 import org.opentripplanner.middleware.models.MonitoredComponent;
+import org.opentripplanner.middleware.otp.OtpDispatcher.OtpVersion;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.tripmonitor.jobs.MonitorAllTripsJob;
 import org.opentripplanner.middleware.utils.ConfigUtils;
@@ -97,7 +98,8 @@ public class OtpMiddlewareMain {
                     new OtpUserController(API_PREFIX),
                     new LogController(API_PREFIX),
                     new ErrorEventsController(API_PREFIX),
-                    new OtpRequestProcessor()
+                    new OtpRequestProcessor("/", OtpVersion.OTP1),
+                    new OtpRequestProcessor("/otp2", OtpVersion.OTP2)
                     // TODO Add other models.
                 ))
                 // Spark-swagger auto-generates a swagger document at localhost:4567/doc.yaml.

--- a/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
+++ b/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
@@ -98,7 +98,7 @@ public class OtpMiddlewareMain {
                     new OtpUserController(API_PREFIX),
                     new LogController(API_PREFIX),
                     new ErrorEventsController(API_PREFIX),
-                    new OtpRequestProcessor("/", OtpVersion.OTP1),
+                    new OtpRequestProcessor("/otp", OtpVersion.OTP1),
                     new OtpRequestProcessor("/otp2", OtpVersion.OTP2)
                     // TODO Add other models.
                 ))

--- a/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
+++ b/src/main/java/org/opentripplanner/middleware/OtpMiddlewareMain.java
@@ -16,7 +16,7 @@ import org.opentripplanner.middleware.controllers.api.OtpUserController;
 import org.opentripplanner.middleware.controllers.api.TripHistoryController;
 import org.opentripplanner.middleware.docs.PublicApiDocGenerator;
 import org.opentripplanner.middleware.models.MonitoredComponent;
-import org.opentripplanner.middleware.otp.OtpDispatcher.OtpVersion;
+import org.opentripplanner.middleware.otp.OtpVersion;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.tripmonitor.jobs.MonitorAllTripsJob;
 import org.opentripplanner.middleware.utils.ConfigUtils;

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -12,7 +12,7 @@ import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.models.TripRequest;
 import org.opentripplanner.middleware.models.TripSummary;
 import org.opentripplanner.middleware.otp.OtpDispatcher;
-import org.opentripplanner.middleware.otp.OtpDispatcher.OtpVersion;
+import org.opentripplanner.middleware.otp.OtpVersion;
 import org.opentripplanner.middleware.otp.OtpDispatcherResponse;
 import org.opentripplanner.middleware.otp.response.OtpResponse;
 import org.opentripplanner.middleware.persistence.Persistence;

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -77,10 +77,10 @@ public class OtpRequestProcessor implements Endpoint {
             .withDescription("If a third-party application is making a trip plan request on behalf of an end user (OtpUser), the user id must be specified.")
             .build();
         restApi.endpoint(
-            EndpointDescriptor.endpointPath(basePath).withDescription("Proxy interface for OTP endpoints. " + OTP_DOC_LINK),
+            EndpointDescriptor.endpointPath(basePath).withDescription("Proxy interface for " + otpVersion.toString() + " endpoints. " + OTP_DOC_LINK),
             HttpUtils.NO_FILTER
         ).get(path("/*")
-                .withDescription("Forwards any GET request to OTP. " + OTP_DOC_LINK)
+                .withDescription("Forwards any GET request to " + otpVersion.toString() + ". " + OTP_DOC_LINK)
                 .withQueryParam(USER_ID)
                 .withProduces(List.of(MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML)),
                 this::proxy

--- a/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.opentripplanner.middleware.otp.OtpDispatcher;
-import org.opentripplanner.middleware.otp.OtpDispatcher.OtpVersion;
+import org.opentripplanner.middleware.otp.OtpVersion;
 import org.opentripplanner.middleware.otp.OtpDispatcherResponse;
 import org.opentripplanner.middleware.otp.OtpRequest;
 import org.opentripplanner.middleware.otp.response.Itinerary;

--- a/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.opentripplanner.middleware.otp.OtpDispatcher;
+import org.opentripplanner.middleware.otp.OtpDispatcher.OtpVersion;
 import org.opentripplanner.middleware.otp.OtpDispatcherResponse;
 import org.opentripplanner.middleware.otp.OtpRequest;
 import org.opentripplanner.middleware.otp.response.Itinerary;
@@ -185,7 +186,7 @@ public class ItineraryExistence extends Model {
                 setResultForDayOfWeek(result, dayOfWeek);
             }
             // Send off each plan query to OTP.
-            OtpDispatcherResponse response = OtpDispatcher.sendOtpPlanRequest(otpRequest);
+            OtpDispatcherResponse response = OtpDispatcher.sendOtpPlanRequest(OtpVersion.OTP1, otpRequest);
             TripPlan plan = null;
             try {
                 plan = response.getResponse().plan;

--- a/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcher.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcher.java
@@ -20,12 +20,15 @@ import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigProperty
 public class OtpDispatcher {
 
     public enum OtpVersion {
-        OTP1("OTP_API_ROOT"), OTP2("OTP2_API_ROOT");
+        OTP1("OTP_API_ROOT", "OTP 1"),
+        OTP2("OTP2_API_ROOT", "OTP 2");
 
         private final String uri;
+        private final String name;
 
-        OtpVersion(String configName) {
+        OtpVersion(String configName, String name) {
             uri = getConfigPropertyAsText(configName);
+            this.name = name;
         }
         /**
          * URI location of the OpenTripPlanner API (e.g., https://otp-server.com/otp). Requests sent to this URI should
@@ -34,6 +37,7 @@ public class OtpDispatcher {
         public String uri() {
             return uri;
         }
+        public String toString() { return name; }
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(OtpDispatcher.class);

--- a/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcher.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcher.java
@@ -19,27 +19,6 @@ import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigProperty
  */
 public class OtpDispatcher {
 
-    public enum OtpVersion {
-        OTP1("OTP_API_ROOT", "OTP 1"),
-        OTP2("OTP2_API_ROOT", "OTP 2");
-
-        private final String uri;
-        private final String name;
-
-        OtpVersion(String configName, String name) {
-            uri = getConfigPropertyAsText(configName);
-            this.name = name;
-        }
-        /**
-         * URI location of the OpenTripPlanner API (e.g., https://otp-server.com/otp). Requests sent to this URI should
-         * return OTP version info.
-         */
-        public String uri() {
-            return uri;
-        }
-        public String toString() { return name; }
-    }
-
     private static final Logger LOG = LoggerFactory.getLogger(OtpDispatcher.class);
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/otp/OtpVersion.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/OtpVersion.java
@@ -1,0 +1,28 @@
+package org.opentripplanner.middleware.otp;
+
+import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
+
+/**
+ * Represents an OTP version and associated configuration including its name for pretty printing
+ * and URI.
+ */
+public enum OtpVersion {
+    OTP1("OTP_API_ROOT", "OTP 1"),
+    OTP2("OTP2_API_ROOT", "OTP 2");
+
+    private final String uri;
+    private final String name;
+
+    OtpVersion(String configName, String name) {
+        uri = getConfigPropertyAsText(configName);
+        this.name = name;
+    }
+    /**
+     * URI location of the OpenTripPlanner API (e.g., https://otp-server.com/otp). Requests sent to this URI should
+     * return OTP version info.
+     */
+    public String uri() {
+        return uri;
+    }
+    public String toString() { return name; }
+}

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -6,7 +6,7 @@ import org.opentripplanner.middleware.models.ItineraryExistence;
 import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.models.TripMonitorNotification;
-import org.opentripplanner.middleware.otp.OtpDispatcher.OtpVersion;
+import org.opentripplanner.middleware.otp.OtpVersion;
 import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.tripmonitor.TripStatus;
 import org.opentripplanner.middleware.otp.OtpDispatcher;

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -6,6 +6,7 @@ import org.opentripplanner.middleware.models.ItineraryExistence;
 import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.models.TripMonitorNotification;
+import org.opentripplanner.middleware.otp.OtpDispatcher.OtpVersion;
 import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.tripmonitor.TripStatus;
 import org.opentripplanner.middleware.otp.OtpDispatcher;
@@ -160,7 +161,7 @@ public class CheckMonitoredTrip implements Runnable {
             // parameter with the appropriate date.
             Map<String, String> params = trip.parseQueryParams();
             params.put(ItineraryUtils.DATE_PARAM, targetZonedDateTime.format(DateTimeUtils.DEFAULT_DATE_FORMATTER));
-            otpDispatcherResponse = OtpDispatcher.sendOtpPlanRequest(ItineraryUtils.toQueryString(params));
+            otpDispatcherResponse = OtpDispatcher.sendOtpPlanRequest(OtpVersion.OTP1, ItineraryUtils.toQueryString(params));
         } catch (Exception e) {
             BugsnagReporter.reportErrorToBugsnag(
                 "Encountered an error while making a request ot the OTP server.",

--- a/src/main/resources/env.schema.json
+++ b/src/main/resources/env.schema.json
@@ -158,7 +158,12 @@
     "OTP_API_ROOT": {
       "type": "string",
       "examples": ["http://otp-server.example.com/otp"],
-      "description": "The URL of an operational OTP server."
+      "description": "The URL of an operational OTP1 server."
+    },
+    "OTP2_API_ROOT": {
+      "type": "string",
+      "examples": ["http://otp2-server.example.com/otp"],
+      "description": "The URL of an operational OTP2 server."
     },
     "OTP_PLAN_ENDPOINT": {
       "type": "string",

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -34,6 +34,9 @@ tags:
 - name: "otp"
   description: "Proxy interface for OTP endpoints. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
     \ API documentation</a> for OTP's supported API resources."
+- name: "otp2"
+  description: "Proxy interface for OTP endpoints. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
+    \ API documentation</a> for OTP's supported API resources."
 schemes:
 - "https"
 paths:
@@ -920,10 +923,10 @@ paths:
       responses:
         "200":
           description: "successful operation"
-  /otp/otp2*:
+  /otp2/*:
     get:
       tags:
-      - "otp"
+      - "otp2"
       description: "Forwards any GET request to OTP. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
         \ API documentation</a> for OTP's supported API resources."
       produces:

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -32,10 +32,10 @@ tags:
 - name: "api/admin/bugsnag/eventsummary"
   description: "Interface for reporting and retrieving application errors using Bugsnag."
 - name: "otp"
-  description: "Proxy interface for OTP endpoints. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
+  description: "Proxy interface for OTP 1 endpoints. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
     \ API documentation</a> for OTP's supported API resources."
 - name: "otp2"
-  description: "Proxy interface for OTP endpoints. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
+  description: "Proxy interface for OTP 2 endpoints. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
     \ API documentation</a> for OTP's supported API resources."
 schemes:
 - "https"
@@ -908,7 +908,7 @@ paths:
     get:
       tags:
       - "otp"
-      description: "Forwards any GET request to OTP. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
+      description: "Forwards any GET request to OTP 1. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
         \ API documentation</a> for OTP's supported API resources."
       produces:
       - "application/json"
@@ -927,7 +927,7 @@ paths:
     get:
       tags:
       - "otp2"
-      description: "Forwards any GET request to OTP. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
+      description: "Forwards any GET request to OTP 2. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
         \ API documentation</a> for OTP's supported API resources."
       produces:
       - "application/json"

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -920,6 +920,25 @@ paths:
       responses:
         "200":
           description: "successful operation"
+  /otp/otp2*:
+    get:
+      tags:
+      - "otp"
+      description: "Forwards any GET request to OTP. Refer to <a href='http://otp-docs.ibi-transit.com/api/index.html'>OTP's\
+        \ API documentation</a> for OTP's supported API resources."
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "userId"
+        in: "query"
+        description: "If a third-party application is making a trip plan request on\
+          \ behalf of an end user (OtpUser), the user id must be specified."
+        required: false
+        type: "string"
+      responses:
+        "200":
+          description: "successful operation"
 definitions:
   AdminUser:
     type: "object"

--- a/src/test/java/org/opentripplanner/middleware/bugsnag/BugsnagTest.java
+++ b/src/test/java/org/opentripplanner/middleware/bugsnag/BugsnagTest.java
@@ -29,6 +29,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.middleware.bugsnag.BugsnagDispatcher.TEST_BUGSNAG_DOMAIN;
 import static org.opentripplanner.middleware.bugsnag.BugsnagDispatcher.TEST_BUGSNAG_PORT;
 import static org.opentripplanner.middleware.bugsnag.BugsnagJobs.getHoursRoundedToWholeDaySinceDate;
@@ -193,8 +194,9 @@ public class BugsnagTest extends OtpMiddlewareTestEnvironment {
                 )
             );
         assertNotNull(bugsnagEventRequest1);
-        // Rounding hour to nearest whole day bumps this by a day from the original 2 to 3 days.
-        assertEquals(3, bugsnagEventRequest1.daysInPast);
+        // Rounding hour to nearest whole day bumps this by a day from the original 2 to 3 days if after midday. The
+        // result will change depending on what time of day the test is run.
+        assertTrue(bugsnagEventRequest1.daysInPast == 2 || bugsnagEventRequest1.daysInPast == 3);
         assertEquals("PREPARING", bugsnagEventRequest1.status);
     }
 

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/ApiUserFlowTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/ApiUserFlowTest.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.auth.Auth0Connection.isAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Users.createAuth0UserForEmail;
 import static org.opentripplanner.middleware.controllers.api.ApiUserController.DEFAULT_USAGE_PLAN_ID;
-import static org.opentripplanner.middleware.controllers.api.OtpRequestProcessor.OTP_PROXY_ENDPOINT;
 import static org.opentripplanner.middleware.otp.OtpDispatcher.OTP_PLAN_ENDPOINT;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.TEMP_AUTH0_USER_PASSWORD;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.makeDeleteRequest;
@@ -74,6 +73,7 @@ public class ApiUserFlowTest extends OtpMiddlewareTestEnvironment {
     private static OtpUser otpUserStandalone;
     private static final String OTP_USER_PATH = "api/secure/user";
     private static final String MONITORED_TRIP_PATH = "api/secure/monitoredtrip";
+    private static final String OTP_PROXY_ENDPOINT = "/otp";
 
     /**
      * Whether tests for this class should run. End to End must be enabled and Auth must NOT be disabled. This should be

--- a/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
@@ -2,7 +2,7 @@ package org.opentripplanner.middleware.testutils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opentripplanner.middleware.otp.OtpDispatcher;
-import org.opentripplanner.middleware.otp.OtpDispatcher.OtpVersion;
+import org.opentripplanner.middleware.otp.OtpVersion;
 import org.opentripplanner.middleware.otp.OtpDispatcherResponse;
 import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.otp.response.OtpResponse;

--- a/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
@@ -2,6 +2,7 @@ package org.opentripplanner.middleware.testutils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opentripplanner.middleware.otp.OtpDispatcher;
+import org.opentripplanner.middleware.otp.OtpDispatcher.OtpVersion;
 import org.opentripplanner.middleware.otp.OtpDispatcherResponse;
 import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.otp.response.OtpResponse;
@@ -168,6 +169,7 @@ public class OtpTestUtils {
         // Submit a query to the OTP server.
         // From P&R to Downtown Orlando
         return OtpDispatcher.sendOtpPlanRequest(
+            OtpVersion.OTP1,
             "28.45119,-81.36818",
             "28.54834,-81.37745",
             "08:35"


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds the ability to run OTP1 and OTP2 in parallel by parametrizing all calls in `OtpRequestProcessor` and related classes.

## Questions

- Do all instances have two versions?
- Should this be backwards-compatible?
