### PR TITLE
feat(OtpUser): add accessibility routing by default setting

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
@@ -20,6 +20,9 @@ public class OtpUser extends AbstractUser {
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(OtpUser.class);
 
+    /** Whether the user would like accessible routes by default. */
+    public boolean accessibilityRoutingByDefault;
+
     /** Whether the user has consented to terms of use. */
     public boolean hasConsentedToTerms;
 

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -1567,6 +1567,8 @@ definitions:
   OtpUser:
     type: "object"
     properties:
+      accessibilityRoutingByDefault:
+        type: "boolean"
       hasConsentedToTerms:
         type: "boolean"
       isPhoneNumberVerified:


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds a small boolean to the user object that allows users to enable accessibility routing by default.
