### PR TITLE
fix(deps): Use log4j 2.16.0 with spark-swagger.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,12 @@
             <artifactId>spark-swagger</artifactId>
             <version>1.0.0.48</version>
         </dependency>
+        <!-- temporary override for spark-swagger log4j dependency -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.16.0</version>
+        </dependency>
 
         <!-- Auth0 Client library for using Management API  -->
         <dependency>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR temporarily addresses the log4j CVE-2021-44228 vulnerability from use of spark-swagger, until spark-swagger gets that patch. With the change, the correct version of log4j will be inserted in the final jar.
