### PR TITLE
fix(ConnectedDataManager): Skip trip upload if bucket is not set.

### DIFF
--- a/src/test/java/org/opentripplanner/middleware/connecteddataplatform/ConnectedDataPlatformTest.java
+++ b/src/test/java/org/opentripplanner/middleware/connecteddataplatform/ConnectedDataPlatformTest.java
@@ -417,4 +417,11 @@ public class ConnectedDataPlatformTest extends OtpMiddlewareTestEnvironment {
         Coordinates randomized = LatLongUtils.getRandomizedCoordinates(coordinates);
         assertNotEquals(coordinates, randomized);
     }
+
+    @Test
+    void shouldProcessTripHistory() {
+        assertTrue(ConnectedDataManager.shouldProcessTripHistory("some-bucket-name"));
+        assertFalse(ConnectedDataManager.shouldProcessTripHistory(null));
+        assertFalse(ConnectedDataManager.shouldProcessTripHistory(""));
+    }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes #165. Basically, if configuration parameter `CONNECTED_DATA_PLATFORM_S3_BUCKET_NAME` is not set,
no jobs for uploading trip data are scheduled.
