### PR TITLE
CDP Support for GraphQL Plan Requests

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -227,8 +227,10 @@ public class OtpRequestProcessor implements Endpoint {
      * @return Returns false if there was an error.
      */
     private static boolean handlePlanTripResponse(Request request, OtpDispatcherResponse otpDispatcherResponse, OtpUser otpUser) {
+        return handlePlanTripResponse(request.queryParams("batchId"), request.queryParams("fromPlace"), request.queryParams("toPlace"), otpDispatcherResponse, otpUser);
+    }
+    private static boolean handlePlanTripResponse(String batchId, String fromPlace, String toPlace, OtpDispatcherResponse otpDispatcherResponse, OtpUser otpUser) {
         boolean result = true;
-        String batchId = request.queryParams("batchId");
         if (batchId == null) {
             batchId = BATCH_ID_NOT_PROVIDED;
         }
@@ -249,8 +251,8 @@ public class OtpRequestProcessor implements Endpoint {
                 TripRequest tripRequest = new TripRequest(
                     otpUser.id,
                     batchId,
-                    request.queryParams("fromPlace"),
-                    request.queryParams("toPlace"),
+                    fromPlace,
+                    toPlace,
                     otpResponse.requestParameters
                 );
                 // only save trip summary if the trip request was saved

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -189,7 +189,7 @@ public class OtpRequestProcessor implements Endpoint {
                 *
                 * Other requests will still be proxied, just not stored.
                 */
-                Map graphQlVariables = (Map) getPOJOFromJSON(requestBody, Map.class).get("variables");
+                HashMap graphQlVariables = (HashMap) getPOJOFromJSON(requestBody, Map.class).get("variables");
 
                 String fromPlace = (String) graphQlVariables.get("fromPlace");
                 String toPlace = (String) graphQlVariables.get("toPlace");
@@ -206,9 +206,9 @@ public class OtpRequestProcessor implements Endpoint {
                     return null;
                 }
             } catch(JsonProcessingException e) {
-                LOG.warn("Invalid GraphQL Request received. Still passing to OTP2: " + e.getMessage());
+                LOG.warn("Invalid GraphQL Request received. Still passing to OTP2: {}", e.getMessage());
             } catch(NullPointerException e) {
-                LOG.warn("Failed to read variables from GraphQL Plan request. Still passing to OTP2: " + e.getMessage());
+                LOG.warn("Failed to read variables from GraphQL Plan request. Still passing to OTP2: {}", e.getMessage());
             }
 
         }
@@ -267,10 +267,27 @@ public class OtpRequestProcessor implements Endpoint {
      *
      * @return Returns false if there was an error.
      */
-    private static boolean handlePlanTripResponse(Request request, OtpDispatcherResponse otpDispatcherResponse, OtpUser otpUser) {
-        return handlePlanTripResponse(request.queryParams("batchId"), request.queryParams("fromPlace"), request.queryParams("toPlace"), otpDispatcherResponse, otpUser);
+    private static boolean handlePlanTripResponse(
+            Request request,
+            OtpDispatcherResponse otpDispatcherResponse,
+            OtpUser otpUser
+    ) {
+        return handlePlanTripResponse(
+                request.queryParams("batchId"),
+                request.queryParams("fromPlace"),
+                request.queryParams("toPlace"),
+                otpDispatcherResponse,
+                otpUser
+        );
     }
-    private static boolean handlePlanTripResponse(String batchId, String fromPlace, String toPlace, OtpDispatcherResponse otpDispatcherResponse, OtpUser otpUser) {
+
+    private static boolean handlePlanTripResponse(
+            String batchId,
+            String fromPlace,
+            String toPlace,
+            OtpDispatcherResponse otpDispatcherResponse,
+            OtpUser otpUser
+    ) {
         boolean result = true;
         if (batchId == null) {
             batchId = BATCH_ID_NOT_PROVIDED;

--- a/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcher.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcher.java
@@ -27,6 +27,11 @@ public class OtpDispatcher {
      */
     public static final String OTP_PLAN_ENDPOINT = getConfigPropertyAsText("OTP_PLAN_ENDPOINT", "/routers/default/plan");
 
+    /**
+     * Location of the OTP GraphQL endpoint (e.g. /routers/default/index/graphql).
+     */
+    public static final String OTP_GRAPHQL_ENDPOINT = getConfigPropertyAsText("OTP_GRAPHQL_ENDPOINT", "/routers/default/index/graphql");
+
     private static final int OTP_SERVER_REQUEST_TIMEOUT_IN_SECONDS = 10;
 
     /**


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [x] The description lists all relevant PRs included in this release _(remove this if not merging to master)_

### Description

The current CDP only supports queries which are made via the `/plan` REST endpoint. To read graphQL queries we need to read those. This PR adds support for doing so. 

Introduces a new `OTP_GRAPHQL_ENDPOINT` config parameter which can probably be left at the default.
