### PR TITLE
Monitored trip route color

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/otp/response/Leg.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/response/Leg.java
@@ -51,6 +51,8 @@ public class Leg implements Cloneable {
     public List<EncodedPolyline> interStopGeometry = null;
     public String routeShortName;
     public String routeLongName;
+    public String routeColor;
+    public String routeTextColor;
     public List<LocalizedAlert> alerts = null;
     public String headsign;
 

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -2212,6 +2212,10 @@ definitions:
         type: "string"
       routeLongName:
         type: "string"
+      routeColor:
+        type: "string"
+      routeTextColor:
+        type: "string"
       alerts:
         type: "array"
         items:


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Companion for https://github.com/opentripplanner/otp-react-redux/pull/805.

This PR adds support for OTP `routeColors` and `routeTextColor` in monitored trips, so that supporting UI can render the routes accordingly.
