### PR TITLE
fix(HttpUtils): Use UTF-8 when forwarding request bodies to OTP

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/utils/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/HttpUtils.java
@@ -21,6 +21,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
@@ -102,13 +103,13 @@ public class HttpUtils {
                 break;
             case PUT:
                 HttpPut putRequest = new HttpPut(uri);
-                putRequest.setEntity(new StringEntity(bodyContent, "UTF-8"));
+                putRequest.setEntity(new StringEntity(bodyContent, StandardCharsets.UTF_8));
                 putRequest.setConfig(timeoutConfig);
                 httpUriRequest = putRequest;
                 break;
             case POST:
                 HttpPost postRequest = new HttpPost(uri);
-                postRequest.setEntity(new StringEntity(bodyContent, "UTF-8"));
+                postRequest.setEntity(new StringEntity(bodyContent, StandardCharsets.UTF_8));
                 postRequest.setConfig(timeoutConfig);
                 httpUriRequest = postRequest;
                 break;

--- a/src/main/java/org/opentripplanner/middleware/utils/HttpUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/HttpUtils.java
@@ -19,7 +19,6 @@ import spark.Request;
 
 import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.http.HttpTimeoutException;
 import java.time.LocalDate;
@@ -102,26 +101,16 @@ public class HttpUtils {
                 httpUriRequest = deleteRequest;
                 break;
             case PUT:
-                try {
-                    HttpPut putRequest = new HttpPut(uri);
-                    putRequest.setEntity(new StringEntity(bodyContent));
-                    putRequest.setConfig(timeoutConfig);
-                    httpUriRequest = putRequest;
-                } catch (UnsupportedEncodingException e) {
-                    LOG.error("Unsupported encoding type", e);
-                    return null;
-                }
+                HttpPut putRequest = new HttpPut(uri);
+                putRequest.setEntity(new StringEntity(bodyContent, "UTF-8"));
+                putRequest.setConfig(timeoutConfig);
+                httpUriRequest = putRequest;
                 break;
             case POST:
-                try {
-                    HttpPost postRequest = new HttpPost(uri);
-                    postRequest.setEntity(new StringEntity(bodyContent));
-                    postRequest.setConfig(timeoutConfig);
-                    httpUriRequest = postRequest;
-                } catch (UnsupportedEncodingException e) {
-                    LOG.error("Unsupported encoding type", e);
-                    return null;
-                }
+                HttpPost postRequest = new HttpPost(uri);
+                postRequest.setEntity(new StringEntity(bodyContent, "UTF-8"));
+                postRequest.setConfig(timeoutConfig);
+                httpUriRequest = postRequest;
                 break;
             case HEAD:
             case OPTIONS:


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Looking for advice on unit tests for these changes if practical.

This PR fixes the OTP request maker so that the body content uses UTF-8 encoding to support all international content.
