### PR TITLE
For proxied responses, we have been combining headers which we need to dedupe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
-            <version>2.7.2</version>
+            <version>2.9.4</version>
         </dependency>
 
         <!--

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -216,7 +216,6 @@ public class OtpRequestProcessor implements Endpoint {
         // spark.Response#header() will duplicate rather than update, so filter out duplicates.
         Arrays.stream(otpDispatcherResponse.headers)
             .filter(h -> !response.raw().containsHeader(h.getName()))
-            //.peek(h -> LOG.info("NEW {}={}", h.getName(), h.getValue()))
             .forEach(h -> response.header(h.getName(), h.getValue()));
 
         response.status(otpDispatcherResponse.statusCode);

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -210,11 +210,15 @@ public class OtpRequestProcessor implements Endpoint {
             } catch(NullPointerException e) {
                 LOG.warn("Failed to read variables from GraphQL Plan request. Still passing to OTP2: {}", e.getMessage());
             }
-
         }
 
-        // provide response to requester as received from OTP server
-        Arrays.stream(otpDispatcherResponse.headers).forEach(header -> response.header(header.getName(), header.getValue()));
+        // Add response headers to requester as it was received from OTP server, but beware that
+        // spark.Response#header() will duplicate rather than update, so filter out duplicates.
+        Arrays.stream(otpDispatcherResponse.headers)
+            .filter(h -> !response.raw().containsHeader(h.getName()))
+            //.peek(h -> LOG.info("NEW {}={}", h.getName(), h.getValue()))
+            .forEach(h -> response.header(h.getName(), h.getValue()));
+
         response.status(otpDispatcherResponse.statusCode);
         return otpDispatcherResponse.responseBody;
     }


### PR DESCRIPTION
Of the duplicates, "Access-Control-Allow-Origin" is the most problematic because browsers stop on that as an error.

### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

When we proxy a POST request through the middleware we have request headers from the middleware's Spark Framework and we update them with the request headers from the GraphQL endpoint being proxied to.  Unfortunately the `com.sparkjava.spark.Response#header()` method doesn't let you update a header, it creates duplicate headers. So I added a filter to prevent that.

Apparently the RFC for response headers is unclear (and thus undefined) on the legality of duplicate headers, but browsers specifically fail on duplicate `Access-Control-Allow-Origin` headers.