### PR TITLE
SMS phone verification using user's locale

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
@@ -102,7 +102,7 @@ public class OtpUserController extends AbstractUserController<OtpUser> {
             );
         }
 
-        Verification verification = NotificationUtils.sendVerificationText(phoneNumber);
+        Verification verification = NotificationUtils.sendVerificationText(phoneNumber, otpUser.preferredLocale);
         if (verification == null) {
             logMessageAndHalt(req, HttpStatus.INTERNAL_SERVER_ERROR_500, "Unknown error sending verification text");
         }

--- a/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
@@ -148,6 +148,9 @@ public class NotificationUtils {
      * See https://www.twilio.com/docs/verify/supported-languages#verify-default-template
      */
     public static String getTwilioLocale(String locale) {
+        if (locale == null) {
+            return "en";
+        }
         // The Twilio's supported locales are just the first two letters of the user's locale,
         // unless it is zh-HK, pt-BR, or en-GB.
         switch (locale) {
@@ -156,7 +159,7 @@ public class NotificationUtils {
             case "zh-HK":
                 return locale;
             default:
-                return locale == null || locale.length() < 2 ? "en" : locale.substring(0, 2);
+                return locale.length() < 2 ? "en" : locale.substring(0, 2);
         }
     }
 

--- a/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
@@ -144,10 +144,27 @@ public class NotificationUtils {
     }
 
     /**
+     * Get a supported Twilio locale for a given locale in IETF's BPC 47 format.
+     * See https://www.twilio.com/docs/verify/supported-languages#verify-default-template
+     */
+    public static String getTwilioLocale(String locale) {
+        // The Twilio's supported locales are just the first two letters of the user's locale,
+        // unless it is zh-HK, pt-BR, or en-GB.
+        switch (locale) {
+            case "en-GB":
+            case "pt-BR":
+            case "zh-HK":
+                return locale;
+            default:
+                return locale == null || locale.length() < 2 ? "en" : locale.substring(0, 2);
+        }
+    }
+
+    /**
      * Send verification text to phone number (i.e., a code that the recipient will use to verify ownership of the
      * number via the OTP web app).
      */
-    public static Verification sendVerificationText(String phoneNumber) {
+    public static Verification sendVerificationText(String phoneNumber, String locale) {
         if (TWILIO_ACCOUNT_SID == null || TWILIO_AUTH_TOKEN == null) {
             LOG.error("SMS notifications not configured correctly.");
             return null;
@@ -155,6 +172,7 @@ public class NotificationUtils {
         try {
             Twilio.init(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
             VerificationCreator smsVerifier = Verification.creator(TWILIO_VERIFICATION_SERVICE_SID, phoneNumber, "sms");
+            smsVerifier.setLocale(getTwilioLocale(locale));
             Verification verification = smsVerifier.create();
             LOG.info("SMS verification ({}) sent successfully", verification.getSid());
             return verification;

--- a/src/test/java/org/opentripplanner/middleware/utils/NotificationUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/NotificationUtilsTest.java
@@ -2,6 +2,9 @@ package org.opentripplanner.middleware.utils;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.opentripplanner.middleware.utils.NotificationUtils.getTwilioLocale;
 
@@ -13,13 +16,18 @@ import static org.opentripplanner.middleware.utils.NotificationUtils.getTwilioLo
 class NotificationUtilsTest {
     @Test
     void canGetTwilioLocale() {
-        Assertions.assertEquals("en", getTwilioLocale("en"));
-        Assertions.assertEquals("en", getTwilioLocale("en-US"));
         Assertions.assertEquals("en-GB", getTwilioLocale("en-GB"));
         Assertions.assertEquals("fr", getTwilioLocale("fr-FR"));
         Assertions.assertEquals("zh", getTwilioLocale("zh"));
         Assertions.assertEquals("zh-HK", getTwilioLocale("zh-HK"));
         Assertions.assertEquals("pt", getTwilioLocale("pt"));
         Assertions.assertEquals("pt-BR", getTwilioLocale("pt-BR"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "e", "en", "en-US"})
+    @NullSource
+    void twilioLocaleDefaultsToEnglish(String locale) {
+        Assertions.assertEquals("en", getTwilioLocale(locale));
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/utils/NotificationUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/NotificationUtilsTest.java
@@ -1,0 +1,25 @@
+package org.opentripplanner.middleware.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.opentripplanner.middleware.utils.NotificationUtils.getTwilioLocale;
+
+/**
+ * Contains tests for the various notification utilities.
+ * Tests in this file do not require specific environment variables
+ * and do not contain end-to-end notification actions.
+ */
+class NotificationUtilsTest {
+    @Test
+    void canGetTwilioLocale() {
+        Assertions.assertEquals("en", getTwilioLocale("en"));
+        Assertions.assertEquals("en", getTwilioLocale("en-US"));
+        Assertions.assertEquals("en-GB", getTwilioLocale("en-GB"));
+        Assertions.assertEquals("fr", getTwilioLocale("fr-FR"));
+        Assertions.assertEquals("zh", getTwilioLocale("zh"));
+        Assertions.assertEquals("zh-HK", getTwilioLocale("zh-HK"));
+        Assertions.assertEquals("pt", getTwilioLocale("pt"));
+        Assertions.assertEquals("pt-BR", getTwilioLocale("pt-BR"));
+    }
+}

--- a/src/test/java/org/opentripplanner/middleware/utils/NotificationUtilsTestCI.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/NotificationUtilsTestCI.java
@@ -24,8 +24,8 @@ import static org.opentripplanner.middleware.utils.NotificationUtils.OTP_ADMIN_D
  * Note: these tests require the environment variables RUN_E2E=true and valid values for TEST_TO_EMAIL, TEST_TO_PHONE,
  * and TEST_TO_PUSH. Furthermore, TEST_TO_PHONE must be a verified phone number in a valid Twilio account.
  */
-public class NotificationUtilsTest extends OtpMiddlewareTestEnvironment {
-    private static final Logger LOG = LoggerFactory.getLogger(NotificationUtilsTest.class);
+public class NotificationUtilsTestCI extends OtpMiddlewareTestEnvironment {
+    private static final Logger LOG = LoggerFactory.getLogger(NotificationUtilsTestCI.class);
     private static OtpUser user;
 
     /**
@@ -96,7 +96,8 @@ public class NotificationUtilsTest extends OtpMiddlewareTestEnvironment {
     public void canSendTwilioVerificationText() {
         Verification verification = NotificationUtils.sendVerificationText(
             // Note: phone number is configured in setup method above.
-            user.phoneNumber
+            user.phoneNumber,
+            "en"
         );
         LOG.info("Verification status: {}", verification.getStatus());
         Assertions.assertNotNull(verification.getSid());


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR makes use of the user's `preferredLocale` for sending the phone verification SMS via Twilio.

To test:
1. Log in in OTP-RR
2. Required: Change the UI language using the language drop-down selector. (If you must keep the current one, change the language to something else, then after step 6, change it back to what it was.)
3. Go to "My account > Settings"
4. If you already have a phone number set and can access only one phone number, manually delete `phoneNumber` and `isPhoneNumberVerified` from your `OtpUser` record in Mongo.
5. Enter a new phone number under the SMS notification option and click "Send Verification"
6. Wait for the verification SMS, upon receiving, note the language of the text in the SMS.
