### PR TITLE
Retrieve push devices when returning user profile

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
@@ -80,7 +80,11 @@ public class OtpUserController extends AbstractUserController<OtpUser> {
 
     @Override
     protected OtpUser getUserProfile(RequestingUser profile) {
-        return profile.otpUser;
+        OtpUser otpUser = profile.otpUser;
+        if (otpUser != null) {
+            NotificationUtils.updatePushDevices(otpUser);
+        }
+        return otpUser;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -410,11 +410,8 @@ public class CheckMonitoredTrip implements Runnable {
             return;
         }
         // Update push notification devices count, which may change asynchronously
-        int numPushDevices = NotificationUtils.getPushInfo(otpUser.email);
-        if (numPushDevices != otpUser.pushDevices) {
-            otpUser.pushDevices = numPushDevices;
-            Persistence.otpUsers.replace(otpUser.id, otpUser);
-      	}
+        NotificationUtils.updatePushDevices(otpUser);
+
         if (notifications.size() == 0) {
             // FIXME: Change log level
             LOG.info("No notifications queued for trip. Skipping notify.");

--- a/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
@@ -325,6 +325,11 @@ public class NotificationUtils {
         return 0;
     }
 
+    /**
+     * Poll the push middleware for the number of devices registered to receive push notifications
+     * for the specified user, and update the corresponding field in memory and Mongo.
+     * @param otpUser The {@link OtpUser} for which to check and update push devices.
+     */
     public static void updatePushDevices(OtpUser otpUser) {
         int numPushDevices = getPushInfo(otpUser.email);
         if (numPushDevices != otpUser.pushDevices) {

--- a/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
@@ -14,6 +14,7 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.opentripplanner.middleware.bugsnag.BugsnagReporter;
 import org.opentripplanner.middleware.models.AdminUser;
 import org.opentripplanner.middleware.models.OtpUser;
+import org.opentripplanner.middleware.persistence.Persistence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -322,6 +323,14 @@ public class NotificationUtils {
             LOG.error("No info on push notification devices", e);
         }
         return 0;
+    }
+
+    public static void updatePushDevices(OtpUser otpUser) {
+        int numPushDevices = getPushInfo(otpUser.email);
+        if (numPushDevices != otpUser.pushDevices) {
+            otpUser.pushDevices = numPushDevices;
+            Persistence.otpUsers.replace(otpUser.id, otpUser);
+      	}
     }
 
     static class NotificationInfo {


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR makes OTP-middleware retrieve the number of push devices when user info is requested. This is useful for new users that have opened the mobile app but have yet to start saving trips.
