### PR TITLE
Twilio SMS consent

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -129,7 +129,7 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
         if (user instanceof OtpUser) {
             OtpUser otpUser = (OtpUser) user;
             OtpUser existingOtpUser = (OtpUser) preExistingUser;
-            if(!otpUser.storeTripHistory && existingOtpUser.storeTripHistory) {
+            if (!otpUser.storeTripHistory && existingOtpUser.storeTripHistory) {
                 // If an OTP user no longer wants their trip history stored, remove all history from MongoDB.
                 ConnectedDataManager.removeUsersTripHistory(otpUser.id);
                 // Kick-off a trip history upload job to recompile and upload trip data to S3 minus the user's trip
@@ -137,6 +137,10 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
                 TripHistoryUploadJob tripHistoryUploadJob = new TripHistoryUploadJob();
                 tripHistoryUploadJob.run();
             }
+
+            // Include select attributes from existingOtpUser marked @JsonIgnore and
+            // that are not set in otpUser.
+            otpUser.smsConsentDate = existingOtpUser.smsConsentDate;
         }
         return user;
     }

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpUserController.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
+import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -116,6 +117,7 @@ public class OtpUserController extends AbstractUserController<OtpUser> {
         if (verification.getStatus().equals("pending")) {
             otpUser.phoneNumber = phoneNumber;
             otpUser.isPhoneNumberVerified = false;
+            otpUser.smsConsentDate = new Date();
             otpUser.notificationChannel.add(OtpUser.Notification.SMS);
             Persistence.otpUsers.replace(otpUser.id, otpUser);
         }

--- a/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
@@ -53,6 +53,7 @@ public class OtpUser extends AbstractUser {
      * If the user starts the phone verification process, this field is populated
      * just before the verification code is sent.
      */
+    @JsonIgnore
     public Date smsConsentDate;
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/OtpUser.java
@@ -48,6 +48,14 @@ public class OtpUser extends AbstractUser {
     public String phoneNumber;
 
     /**
+     * The date when consent was given by user to receive SMS messages, as required by Twilio,
+     * see https://www.twilio.com/docs/verify/sms#consent-and-opt-in-policy.
+     * If the user starts the phone verification process, this field is populated
+     * just before the verification code is sent.
+     */
+    public Date smsConsentDate;
+
+    /**
      * The user's preferred locale, in language tag format
      * e.g. 'en-US', 'fr-FR', 'es-ES', 'zh-CN', etc.
      */

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -2562,6 +2562,9 @@ definitions:
           - "SMS"
       phoneNumber:
         type: "string"
+      smsConsentDate:
+        type: "string"
+        format: "date"
       preferredLocale:
         type: "string"
       pushDevices:

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
@@ -134,6 +134,6 @@ public class OtpUserControllerTest extends OtpMiddlewareTestEnvironment {
         );
 
         OtpUser updatedUser = Persistence.otpUsers.getById(otpUser.id);
-        Assertions.assertEquals(u.smsConsentDate, updatedUser.smsConsentDate);
+        Assertions.assertEquals(otpUser.smsConsentDate, updatedUser.smsConsentDate);
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/utils/NotificationUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/NotificationUtilsTest.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Date;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.testutils.PersistenceTestUtils.createUser;
@@ -94,12 +95,17 @@ public class NotificationUtilsTest extends OtpMiddlewareTestEnvironment {
      */
     @Test
     public void canSendTwilioVerificationText() {
+        Assertions.assertNull(user.smsConsentDate);
+        Date beforeVerificationDate = new Date();
         Verification verification = NotificationUtils.sendVerificationText(
             // Note: phone number is configured in setup method above.
             user.phoneNumber
         );
         LOG.info("Verification status: {}", verification.getStatus());
         Assertions.assertNotNull(verification.getSid());
+        Date afterVerificationDate = new Date();
+        Assertions.assertTrue(user.smsConsentDate.getTime() >= beforeVerificationDate.getTime());
+        Assertions.assertTrue(user.smsConsentDate.getTime() <= afterVerificationDate.getTime());
     }
 
     /**


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

As required by Twilio, this PR adds a field `smsConsentDate` for storing the date that an `OtpUser` gave consent to receive SMS verification and other notification messages. The consent date will be the moment the user submits their phone number for verification, not the moment the user submits a correct verification code.

Note that the new field `smsConsentDate` will not be passed in response to web requests, but will keep its previous value after incoming web requests update other fields for an `OtpUser`.
