### PR TITLE
Prevent overwriting trip/user internal fields

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -139,8 +139,14 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
             }
 
             // Include select attributes from existingOtpUser marked @JsonIgnore and
-            // that are not set in otpUser.
+            // that are not set in otpUser, and other attributes that should not be modifiable
+            // using web requests.
             otpUser.smsConsentDate = existingOtpUser.smsConsentDate;
+            otpUser.email = existingOtpUser.email;
+            otpUser.auth0UserId = existingOtpUser.auth0UserId;
+            otpUser.isDataToolsUser = existingOtpUser.isDataToolsUser;
+            otpUser.pushDevices = existingOtpUser.pushDevices;
+
         }
         return user;
     }

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -144,18 +144,22 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
         MonitoredTripLocks.lockTripForUpdating(monitoredTrip, req);
 
         try {
-            preCreateOrUpdateChecks(monitoredTrip, req);
-
             // Forbid the editing of certain values that are analyzed and set during the CheckMonitoredTrip job.
-            // For now, accomplish this by setting whatever the previous itinerary and journey state were in the preExisting
-            // trip.
+            // These include the itinerary, journeyState, and fields initially computed via processTripQueryParams
+            // that we don't need to recalculate.
+            // Note: There is no need to re-check for monitorability because the itinerary field cannot be changed.
             monitoredTrip.itinerary = preExisting.itinerary;
             monitoredTrip.journeyState = preExisting.journeyState;
+            monitoredTrip.itineraryExistence = preExisting.itineraryExistence;
+            monitoredTrip.tripTime = preExisting.tripTime;
+            monitoredTrip.queryParams = preExisting.queryParams;
+            monitoredTrip.userId = preExisting.userId;
+            monitoredTrip.from = preExisting.from;
+            monitoredTrip.to = preExisting.to;
+            monitoredTrip.arriveBy = preExisting.arriveBy;
 
-            checkTripCanBeMonitored(monitoredTrip, req);
-            processTripQueryParams(monitoredTrip, req);
-
-            // TODO: Update itinerary existence record when updating a trip.
+            // TODO: Update itinerary existence record when updating a trip?
+            //   (Currently, we let web requests change the monitored days regardless of existence.)
 
             // perform the database update here before releasing the lock to be sure that the record is updated in the
             // database before a CheckMonitoredTripJob analyzes the data

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -71,7 +71,6 @@ public class MonitoredTrip extends Model {
     /**
      * whether the trip is an arriveBy trip
      */
-    @JsonIgnore
     public boolean arriveBy;
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -60,7 +60,6 @@ public class MonitoredTrip extends Model {
      * separately) to the date and time within the query parameters. The reasoning is so that it doesn't have to be
      * extracted every time the trip requires checking.
      */
-    @JsonIgnore
     public String tripTime;
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -60,6 +60,7 @@ public class MonitoredTrip extends Model {
      * separately) to the date and time within the query parameters. The reasoning is so that it doesn't have to be
      * extracted every time the trip requires checking.
      */
+    @JsonIgnore
     public String tripTime;
 
     /**
@@ -71,6 +72,7 @@ public class MonitoredTrip extends Model {
     /**
      * whether the trip is an arriveBy trip
      */
+    @JsonIgnore
     public boolean arriveBy;
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/GetMonitoredTripsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/GetMonitoredTripsTest.java
@@ -25,6 +25,7 @@ import org.opentripplanner.middleware.utils.JsonUtils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.auth.Auth0Connection.restoreDefaultAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Connection.setAuthDisabled;
@@ -130,6 +131,10 @@ public class GetMonitoredTripsTest extends OtpMiddlewareTestEnvironment {
         ResponseList<MonitoredTrip> soloTrips = getMonitoredTripsForUser(MONITORED_TRIP_PATH, soloOtpUser);
         // Expect only 1 trip for solo Otp user.
         assertEquals(1, soloTrips.data.size());
+
+        // Certain fields such as tripTime should be null when obtained from parsing JSON responses
+        // because of the @JsonIgnore annotation.
+        assertNull(soloTrips.data.get(0).tripTime);
 
         // Get trips for multi Otp user/admin user.
         ResponseList<MonitoredTrip> multiTrips = getMonitoredTripsForUser(MONITORED_TRIP_PATH, multiOtpUser);

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/GetMonitoredTripsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/GetMonitoredTripsTest.java
@@ -152,12 +152,13 @@ public class GetMonitoredTripsTest extends OtpMiddlewareTestEnvironment {
         // Create a trip for the solo OTP user.
         createMonitoredTripAsUser(soloOtpUser);
 
-        // Get trips for solo Otp user.
-        ResponseList<MonitoredTrip> soloTrips = getMonitoredTripsForUser(MONITORED_TRIP_PATH, soloOtpUser);
-        // Expect only 1 trip for solo Otp user.
-        assertEquals(1, soloTrips.data.size());
+        BasicDBObject filter = new BasicDBObject();
+        filter.put("userId", soloOtpUser.id);
 
-        MonitoredTrip originalTrip = soloTrips.data.get(0);
+        // Expect only 1 trip for solo Otp user.
+        assertEquals(1, Persistence.monitoredTrips.getCountFiltered(filter));
+
+        MonitoredTrip originalTrip = Persistence.monitoredTrips.getOneFiltered(filter);
         assertNotNull(originalTrip.itinerary);
         assertNotNull(originalTrip.itineraryExistence);
         // Can't really assert journeyState because itinerary checks will not be run for these tests.

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/GetMonitoredTripsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/GetMonitoredTripsTest.java
@@ -138,6 +138,9 @@ public class GetMonitoredTripsTest extends OtpMiddlewareTestEnvironment {
         );
         // Just the trip for Otp user 2 will be returned.
         assertEquals(1, tripsFiltered.data.size());
+
+        Persistence.monitoredTrips.removeById(soloTrips.data.get(0).id);
+        Persistence.monitoredTrips.removeById(multiTrips.data.get(0).id);
     }
 
     @Test
@@ -177,6 +180,8 @@ public class GetMonitoredTripsTest extends OtpMiddlewareTestEnvironment {
         assertEquals(updatedTrip.userId, originalTrip.userId);
         assertEquals(updatedTrip.from.name, originalTrip.from.name);
         assertEquals(updatedTrip.to.name, originalTrip.to.name);
+
+        Persistence.monitoredTrips.removeById(originalTrip.id);
     }
 
     /**


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Web requests that missed certain fields in `MonitoredTrip` could mess up the stored state of those trips,
resulting in, for instance, errors in the trip monitoring checks and loss of push notifications.

This PR addresses that issue by preventing a number of internal fields in `MonitoredTrip` and `OtpUser` from being modified via web requests.
