### PR TITLE
OTP-888 Swagger including mobility profiles.

### DIFF
--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -56,9 +56,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -89,9 +89,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/Job"
           schema:
+            $ref: "#/definitions/Job"
+          responseSchema:
             $ref: "#/definitions/Job"
   /api/admin/user:
     get:
@@ -121,9 +121,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -144,9 +144,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -186,9 +186,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -235,9 +235,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -275,9 +275,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -322,9 +322,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -368,9 +368,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -413,9 +413,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/TokenHolder"
           schema:
+            $ref: "#/definitions/TokenHolder"
+          responseSchema:
             $ref: "#/definitions/TokenHolder"
   /api/secure/application/fromtoken:
     get:
@@ -430,9 +430,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -463,9 +463,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/Job"
           schema:
+            $ref: "#/definitions/Job"
+          responseSchema:
             $ref: "#/definitions/Job"
   /api/secure/application:
     get:
@@ -495,9 +495,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -518,9 +518,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -560,9 +560,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -609,9 +609,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -649,9 +649,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -686,9 +686,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -719,9 +719,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/Job"
           schema:
+            $ref: "#/definitions/Job"
+          responseSchema:
             $ref: "#/definitions/Job"
   /api/secure/cdp:
     get:
@@ -751,9 +751,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -774,9 +774,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -816,9 +816,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -865,9 +865,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -905,9 +905,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -948,9 +948,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ItineraryExistence"
           schema:
+            $ref: "#/definitions/ItineraryExistence"
+          responseSchema:
             $ref: "#/definitions/ItineraryExistence"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1000,9 +1000,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1023,9 +1023,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredTrip"
           schema:
+            $ref: "#/definitions/MonitoredTrip"
+          responseSchema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1065,9 +1065,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredTrip"
           schema:
+            $ref: "#/definitions/MonitoredTrip"
+          responseSchema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1114,9 +1114,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredTrip"
           schema:
+            $ref: "#/definitions/MonitoredTrip"
+          responseSchema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1155,9 +1155,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredTrip"
           schema:
+            $ref: "#/definitions/MonitoredTrip"
+          responseSchema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1223,9 +1223,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/TripRequest"
           schema:
+            $ref: "#/definitions/TripRequest"
+          responseSchema:
             $ref: "#/definitions/TripRequest"
   /api/secure/monitoredcomponent:
     get:
@@ -1255,9 +1255,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1278,9 +1278,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredComponent"
           schema:
+            $ref: "#/definitions/MonitoredComponent"
+          responseSchema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1320,9 +1320,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredComponent"
           schema:
+            $ref: "#/definitions/MonitoredComponent"
+          responseSchema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1369,9 +1369,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredComponent"
           schema:
+            $ref: "#/definitions/MonitoredComponent"
+          responseSchema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1410,9 +1410,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredComponent"
           schema:
+            $ref: "#/definitions/MonitoredComponent"
+          responseSchema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1453,9 +1453,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/VerificationResult"
           schema:
+            $ref: "#/definitions/VerificationResult"
+          responseSchema:
             $ref: "#/definitions/VerificationResult"
   /api/secure/user/{id}/verify_sms/{code}:
     post:
@@ -1476,9 +1476,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/VerificationResult"
           schema:
+            $ref: "#/definitions/VerificationResult"
+          responseSchema:
             $ref: "#/definitions/VerificationResult"
   /api/secure/user/fromtoken:
     get:
@@ -1493,9 +1493,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1526,9 +1526,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/Job"
           schema:
+            $ref: "#/definitions/Job"
+          responseSchema:
             $ref: "#/definitions/Job"
   /api/secure/user:
     get:
@@ -1558,9 +1558,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1581,9 +1581,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1623,9 +1623,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1672,9 +1672,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1712,9 +1712,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1769,11 +1769,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/ApiUsageResult"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/ApiUsageResult"
@@ -1800,11 +1800,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/BugsnagEvent"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/BugsnagEvent"
@@ -1831,11 +1831,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/CDPFile"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/CDPFile"
@@ -1856,11 +1856,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/URL"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/URL"
@@ -2550,8 +2550,18 @@ definitions:
         type: "boolean"
       hasConsentedToTerms:
         type: "boolean"
+      isMobilityLimited:
+        type: "boolean"
       isPhoneNumberVerified:
         type: "boolean"
+      mobilityDevices:
+        type: "array"
+        items:
+          type: "string"
+      mobilityMode:
+        type: "string"
+      visionLimitation:
+        type: "string"
       notificationChannel:
         type: "array"
         items:


### PR DESCRIPTION
### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_

### Description
Add mobility profile support. New fields in `OtpUser` (in this code and in Mongo and Swagger). Following the logic, naming, and strings in the Georgia Tech document, a somewhat unwieldy new `OtpUserController#calculateMobilityMode()` that takes specified string values and calculates a "mobility mode" keyword or compound keyword.

This PR should include the https://github.com/ibi-group/otp-middleware/commit/08d96959576cb3e902e837d368e5a23d05b37a82 commits.