### PR TITLE
Localized trip times in notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ The special E2E client settings should be defined in `env.yml`:
 | MONITORED_COMPONENTS | array | Optional | n/a | An array of monitored components. |
 | NOTIFICATION_FROM_EMAIL | string | Optional | noreply@email.com | The from email address used in notification emails |
 | NOTIFICATION_FROM_PHONE | string | Optional | +15551234 | The from phone number used in notification SMSs. The phone number must be surrounded with quotes to be correctly parsed as a String. |
-| NOTIFICATION_TIME_FORMAT | string | Optional | HH:mm | The time format used in notification emails and SMSs. |
 | OTP_ADMIN_DASHBOARD_FROM_EMAIL | string | Optional | OTP Admin Dashboard <no-reply@email.com> | Config setting for linking to the OTP Admin Dashboard. |
 | OTP_ADMIN_DASHBOARD_NAME | string | Optional | OTP Admin Dashboard | Config setting for linking to the OTP Admin Dashboard. |
 | OTP_ADMIN_DASHBOARD_URL | string | Optional | https://admin.example.com | Config setting for linking to the OTP Admin Dashboard. |

--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -66,8 +66,6 @@ TWILIO_ACCOUNT_SID: your-account-sid
 TWILIO_AUTH_TOKEN: your-auth-token
 # Get Sparkpost key at: https://app.sparkpost.com/account/api-keys
 SPARKPOST_KEY: your-api-key
-# Notification message settings
-NOTIFICATION_TIME_FORMAT: HH:mm
 
 # Optional parameter for the hour (local time, 24-hr format) at which a service day starts.
 # To make the service day change at 2am, enter 2. The default is 3am.

--- a/src/main/java/org/opentripplanner/middleware/models/TripMonitorNotification.java
+++ b/src/main/java/org/opentripplanner/middleware/models/TripMonitorNotification.java
@@ -7,8 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.FormatStyle;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Locale;
@@ -119,11 +117,7 @@ public class TripMonitorNotification extends Model {
             NotificationType.INITIAL_REMINDER,
             String.format("Reminder for %s at %s.",
                 trip.tripName,
-                DateTimeFormatter
-                    .ofLocalizedTime(FormatStyle.SHORT)
-                    .withLocale(locale)
-                    .withZone(DateTimeUtils.getOtpZoneId())
-                    .format(trip.itinerary.startTime.toInstant())
+                DateTimeUtils.formatShortDate(trip.itinerary.startTime, locale)
             )
         );
     }

--- a/src/main/java/org/opentripplanner/middleware/models/TripMonitorNotification.java
+++ b/src/main/java/org/opentripplanner/middleware/models/TripMonitorNotification.java
@@ -6,7 +6,6 @@ import org.opentripplanner.middleware.utils.DateTimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Locale;
@@ -65,7 +64,8 @@ public class TripMonitorNotification extends Model {
     public static TripMonitorNotification createDelayNotification(
         long delayInMinutes,
         Date targetDatetime,
-        NotificationType delayType
+        NotificationType delayType,
+        Locale locale
     ) {
         if (delayType != NotificationType.ARRIVAL_DELAY && delayType != NotificationType.DEPARTURE_DELAY) {
             LOG.error("Delay notification not permitted for type {}", delayType);
@@ -86,9 +86,7 @@ public class TripMonitorNotification extends Model {
                 "Your trip is now predicted to %s %s (at %s).",
                 delayType == NotificationType.ARRIVAL_DELAY ? "arrive" : "depart",
                 delayHumanTime,
-                ZonedDateTime
-                    .ofInstant(targetDatetime.toInstant(), DateTimeUtils.getOtpZoneId())
-                    .format(DateTimeUtils.NOTIFICATION_TIME_FORMATTER)
+                DateTimeUtils.formatShortDate(targetDatetime, locale)
             )
         );
     }

--- a/src/main/java/org/opentripplanner/middleware/models/TripMonitorNotification.java
+++ b/src/main/java/org/opentripplanner/middleware/models/TripMonitorNotification.java
@@ -7,8 +7,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -110,12 +113,18 @@ public class TripMonitorNotification extends Model {
      * Creates an initial reminder of the itinerary monitoring.
      */
     public static TripMonitorNotification createInitialReminderNotification(
-        MonitoredTrip trip
+        MonitoredTrip trip, Locale locale
     ) {
-        // TODO: i18n.
         return new TripMonitorNotification(
             NotificationType.INITIAL_REMINDER,
-            String.format("Reminder for %s at %s.", trip.tripName, trip.tripTime)
+            String.format("Reminder for %s at %s.",
+                trip.tripName,
+                DateTimeFormatter
+                    .ofLocalizedTime(FormatStyle.SHORT)
+                    .withLocale(locale)
+                    .withZone(DateTimeUtils.getOtpZoneId())
+                    .format(trip.itinerary.startTime.toInstant())
+            )
         );
     }
 

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -143,8 +143,9 @@ public class CheckMonitoredTrip implements Runnable {
 
         if (!trip.isInactive() && isFirstTimeCheckWithinLeadMonitoringTime && userWantsInitialReminder) {
             OtpUser otpUser = Persistence.otpUsers.getById(trip.userId);
+            Locale locale = Locale.forLanguageTag(otpUser.preferredLocale == null ? "en-US" : otpUser.preferredLocale);
             enqueueNotification(
-                TripMonitorNotification.createInitialReminderNotification(trip, Locale.forLanguageTag(otpUser.preferredLocale))
+                TripMonitorNotification.createInitialReminderNotification(trip, locale)
             );
         }
     }

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -141,8 +142,9 @@ public class CheckMonitoredTrip implements Runnable {
         boolean userWantsInitialReminder = !trip.snoozed && trip.notifyAtLeadingInterval;
 
         if (!trip.isInactive() && isFirstTimeCheckWithinLeadMonitoringTime && userWantsInitialReminder) {
+            OtpUser otpUser = Persistence.otpUsers.getById(trip.userId);
             enqueueNotification(
-                TripMonitorNotification.createInitialReminderNotification(trip)
+                TripMonitorNotification.createInitialReminderNotification(trip, Locale.forLanguageTag(otpUser.preferredLocale))
             );
         }
     }

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -381,6 +381,8 @@ public class CheckMonitoredTrip implements Runnable {
 
         // check if threshold met
         if (deviationAbsoluteMinutes >= deviationThreshold) {
+            OtpUser otpUser = Persistence.otpUsers.getById(trip.userId);
+            Locale locale = Locale.forLanguageTag(otpUser.preferredLocale == null ? "en-US" : otpUser.preferredLocale);
             // threshold met, set new baseline time
             if (delayType == NotificationType.DEPARTURE_DELAY) {
                 journeyState.baselineDepartureTimeEpochMillis = matchingItineraryTargetTime.getTime();
@@ -396,7 +398,8 @@ public class CheckMonitoredTrip implements Runnable {
             return TripMonitorNotification.createDelayNotification(
                 delayMinutes,
                 matchingItineraryTargetTime,
-                delayType
+                delayType,
+                locale
             );
         }
         return null;

--- a/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
@@ -15,10 +15,12 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.FormatStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -95,6 +97,17 @@ public class DateTimeUtils {
             .toFormatter()
             .withZone(zoneId);
         return localDate.format(expectedDateFormat);
+    }
+
+    /**
+     * Helper to format a date in short format (e.g. "5:40 PM" - no seconds) in the specified locale.
+     */
+    public static String formatShortDate(Date date, Locale locale) {
+        return DateTimeFormatter
+            .ofLocalizedTime(FormatStyle.SHORT)
+            .withLocale(locale)
+            .withZone(DateTimeUtils.getOtpZoneId())
+            .format(date.toInstant());
     }
 
     public static Date nowAsDate() {

--- a/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
@@ -43,9 +43,6 @@ public class DateTimeUtils {
     public static final DateTimeFormatter DEFAULT_DATE_FORMATTER = DateTimeFormatter.ofPattern(
         DEFAULT_DATE_FORMAT_PATTERN
     );
-    public static final DateTimeFormatter NOTIFICATION_TIME_FORMATTER = DateTimeFormatter.ofPattern(
-        ConfigUtils.getConfigPropertyAsText("NOTIFICATION_TIME_FORMAT", "HH:mm")
-    );
 
     /**
      * These are internal variables that can be used to mock dates and times in tests

--- a/src/main/resources/env.schema.json
+++ b/src/main/resources/env.schema.json
@@ -152,11 +152,6 @@
       "examples": ["+15551234"],
       "description": "The from phone number used in notification SMSs. The phone number must be surrounded with quotes to be correctly parsed as a String."
     },
-    "NOTIFICATION_TIME_FORMAT": {
-      "type": "string",
-      "examples": ["HH:mm"],
-      "description": "The time format used in notification emails and SMSs."
-    },
     "OTP_ADMIN_DASHBOARD_FROM_EMAIL": {
       "type": "string",
       "examples": ["OTP Admin Dashboard <no-reply@email.com>"],

--- a/src/test/java/org/opentripplanner/middleware/models/TripMonitorNotificationTest.java
+++ b/src/test/java/org/opentripplanner/middleware/models/TripMonitorNotificationTest.java
@@ -55,8 +55,5 @@ class TripMonitorNotificationTest {
 
         TripMonitorNotification notification = TripMonitorNotification.createInitialReminderNotification(trip, Locale.forLanguageTag("en-US"));
         assertEquals("Reminder for Trip time test at 5:44 PM.", notification.body);
-
-        TripMonitorNotification notification2 = TripMonitorNotification.createInitialReminderNotification(trip, Locale.forLanguageTag("fr"));
-        assertEquals("Reminder for Trip time test at 17:44.", notification2.body);
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/models/TripMonitorNotificationTest.java
+++ b/src/test/java/org/opentripplanner/middleware/models/TripMonitorNotificationTest.java
@@ -64,7 +64,7 @@ class TripMonitorNotificationTest {
         MonitoredTrip trip = new MonitoredTrip();
         trip.tripName = "Sample Trip";
 
-        // tripTime is for the OTP query, is included for reference only, and should not be used.
+        // tripTime is for the OTP query, is included for reference only, and should not be used for notifications.
         trip.tripTime = "13:31";
 
         // Set a start time for the itinerary, in the ambient/default OTP zone.

--- a/src/test/java/org/opentripplanner/middleware/models/TripMonitorNotificationTest.java
+++ b/src/test/java/org/opentripplanner/middleware/models/TripMonitorNotificationTest.java
@@ -4,10 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.tripmonitor.jobs.NotificationType;
+import org.opentripplanner.middleware.utils.DateTimeUtils;
 
+import java.time.ZonedDateTime;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -30,5 +35,28 @@ class TripMonitorNotificationTest {
         for (int i = 1; i < sortedNotifications.size(); i++) {
             assertNotEquals(reminder, sortedNotifications.get(i));
         }
+    }
+
+    @Test
+    void canUseItineraryStartTimeInInitialReminder() {
+        MonitoredTrip trip = new MonitoredTrip();
+        trip.tripName = "Trip time test";
+
+        // tripTime is for the OTP query and is included for reference only.
+        trip.tripTime = "13:31";
+
+        // Set a start time for the itinerary, in the ambient/default OTP zone.
+        ZonedDateTime startTime = ZonedDateTime.of(2023, 2, 12, 17, 44, 0, 0, DateTimeUtils.getOtpZoneId());
+
+        Itinerary itinerary = new Itinerary();
+        itinerary.startTime = Date.from(startTime.toInstant());
+
+        trip.itinerary = itinerary;
+
+        TripMonitorNotification notification = TripMonitorNotification.createInitialReminderNotification(trip, Locale.forLanguageTag("en-US"));
+        assertEquals("Reminder for Trip time test at 5:44 PM.", notification.body);
+
+        TripMonitorNotification notification2 = TripMonitorNotification.createInitialReminderNotification(trip, Locale.forLanguageTag("fr"));
+        assertEquals("Reminder for Trip time test at 17:44.", notification2.body);
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/models/TripMonitorNotificationTest.java
+++ b/src/test/java/org/opentripplanner/middleware/models/TripMonitorNotificationTest.java
@@ -38,11 +38,11 @@ class TripMonitorNotificationTest {
     }
 
     @Test
-    void canUseItineraryStartTimeInInitialReminder() {
+    void canCreateInitialReminder() {
         MonitoredTrip trip = new MonitoredTrip();
-        trip.tripName = "Trip time test";
+        trip.tripName = "Sample Trip";
 
-        // tripTime is for the OTP query and is included for reference only.
+        // tripTime is for the OTP query, is included for reference only, and should not be used.
         trip.tripTime = "13:31";
 
         // Set a start time for the itinerary, in the ambient/default OTP zone.
@@ -54,6 +54,28 @@ class TripMonitorNotificationTest {
         trip.itinerary = itinerary;
 
         TripMonitorNotification notification = TripMonitorNotification.createInitialReminderNotification(trip, Locale.forLanguageTag("en-US"));
-        assertEquals("Reminder for Trip time test at 5:44 PM.", notification.body);
+        assertEquals("Reminder for Sample Trip at 5:44 PM.", notification.body);
+    }
+
+    @Test
+    void canCreateDelayedTripNotification() {
+        MonitoredTrip trip = new MonitoredTrip();
+        trip.tripName = "Sample Trip";
+
+        // Set a start time for the itinerary, in the ambient/default OTP zone.
+        ZonedDateTime startTime = ZonedDateTime.of(2023, 2, 12, 17, 44, 0, 0, DateTimeUtils.getOtpZoneId());
+
+        Itinerary itinerary = new Itinerary();
+        itinerary.startTime = Date.from(startTime.toInstant());
+
+        trip.itinerary = itinerary;
+
+        TripMonitorNotification notification = TripMonitorNotification.createDelayNotification(
+            10,
+            itinerary.startTime,
+            NotificationType.ARRIVAL_DELAY,
+            Locale.forLanguageTag("en-US")
+        );
+        assertEquals("Your trip is now predicted to arrive 10 minutes late (at 5:44 PM).", notification.body);
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -163,13 +163,13 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         testCases.add(new DelayNotificationTestCase(
             twentyMinutesLateTimeTrip,
             NotificationType.DEPARTURE_DELAY,
-            "Your trip is now predicted to depart 20 minutes late (at 09:00).",
+            "Your trip is now predicted to depart 20 minutes late (at 9:00 AM).",
             "should create a departure notification for 20 minute late trip"
         ));
         testCases.add(new DelayNotificationTestCase(
             twentyMinutesLateTimeTrip,
             NotificationType.ARRIVAL_DELAY,
-            "Your trip is now predicted to arrive 20 minutes late (at 09:18).",
+            "Your trip is now predicted to arrive 20 minutes late (at 9:18 AM).",
             "should create a arrival notification for 20 minute late trip"
         ));
 
@@ -211,13 +211,13 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         testCases.add(new DelayNotificationTestCase(
             onTimeTripWithUpdatedThreshold,
             NotificationType.DEPARTURE_DELAY,
-            "Your trip is now predicted to depart about on time (at 08:40).",
+            "Your trip is now predicted to depart about on time (at 8:40 AM).",
             "should create a departure notification for on-time trip w/ 20 minute late threshold and 18 minute late baseline"
         ));
         testCases.add(new DelayNotificationTestCase(
             onTimeTripWithUpdatedThreshold,
             NotificationType.ARRIVAL_DELAY,
-            "Your trip is now predicted to arrive about on time (at 08:58).",
+            "Your trip is now predicted to arrive about on time (at 8:58 AM).",
             "should create a arrival notification for on-time trip w/ 20 minute late threshold and 18 minute late baseline"
         ));
 

--- a/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
@@ -1,0 +1,37 @@
+package org.opentripplanner.middleware.utils;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DateTimeUtilsTest {
+    @ParameterizedTest
+    @MethodSource("createDateFormatCases")
+    void supportsDateFormatsInSeveralLocales(String localeTag, String result) {
+        ZonedDateTime zonedTime = ZonedDateTime.of(2023, 2, 12, 17, 44, 0, 0, DateTimeUtils.getOtpZoneId());
+        assertEquals(result, DateTimeUtils.formatShortDate(
+            Date.from(zonedTime.toInstant()),
+            Locale.forLanguageTag(localeTag))
+        );
+    }
+
+    private static Stream<Arguments> createDateFormatCases() {
+        return Stream.of(
+            Arguments.of("en-US", "5:44 PM"),
+            Arguments.of("fr", "17:44"),
+            Arguments.of("es", "17:44"),
+            Arguments.of("ko", "오후 5:44"),
+            Arguments.of("vi", "17:44"),
+            Arguments.of("zh", "下午5:44"), // Note: formatjs shows 24-hour format for Chinese.
+            Arguments.of("ru", "17:44"),
+            Arguments.of("tl", "5:44 PM")
+        );
+    }
+}

--- a/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
@@ -29,7 +29,7 @@ class DateTimeUtilsTest {
             Arguments.of("es", "17:44"),
             Arguments.of("ko", "오후 5:44"),
             Arguments.of("vi", "17:44"),
-            Arguments.of("zh", "下午5:44"), // Note: formatjs shows 24-hour format for Chinese.
+            Arguments.of("zh", "下午5:44"), // Note: The Format.JS library shows 24-hour format for Chinese.
             Arguments.of("ru", "17:44"),
             Arguments.of("tl", "5:44 PM")
         );


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

This PR fixes the initial reminder to use the itinerary start time (and not `trip.tripTime`) 
and updates trip notification contents with localized times (e.g. "5:44 PM" vs. "17:44").
There are no other changes to trip notification contents.
