### PR TITLE
fix(NotificationUtils): Encode user email to retrieve push devices.

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
@@ -329,7 +329,11 @@ public class NotificationUtils {
         try {
             Map<String, String> headers = Map.of("Accept", "application/json");
             var httpResponse = HttpUtils.httpRequestRawResponse(
-                URI.create(getPushDevicesUrl(PUSH_API_URL + "/devices/get?api_key=" + PUSH_API_KEY + "&user=", toUser)),
+                URI.create(getPushDevicesUrl(String.format(
+                    "%s/devices/get?api_key=%s&user=",
+                    PUSH_API_URL,
+                    PUSH_API_KEY
+                ), toUser)),
                 1000,
                 HttpMethod.GET,
                 headers,

--- a/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
@@ -20,8 +20,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
 
 /**
@@ -327,7 +329,7 @@ public class NotificationUtils {
         try {
             Map<String, String> headers = Map.of("Accept", "application/json");
             var httpResponse = HttpUtils.httpRequestRawResponse(
-                URI.create(PUSH_API_URL + "/devices/get?api_key=" + PUSH_API_KEY + "&user=" + toUser),
+                URI.create(getPushDevicesUrl(PUSH_API_URL + "/devices/get?api_key=" + PUSH_API_KEY + "&user=", toUser)),
                 1000,
                 HttpMethod.GET,
                 headers,
@@ -344,6 +346,10 @@ public class NotificationUtils {
             LOG.error("No info on push notification devices", e);
         }
         return 0;
+    }
+
+    static String getPushDevicesUrl(String baseUrl, String toUser) {
+        return baseUrl + URLEncoder.encode(toUser, UTF_8);
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/utils/NotificationUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/NotificationUtilsTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.opentripplanner.middleware.utils.NotificationUtils.getPushDevicesUrl;
 import static org.opentripplanner.middleware.utils.NotificationUtils.getTwilioLocale;
 
 /**
@@ -29,5 +30,15 @@ class NotificationUtilsTest {
     @NullSource
     void twilioLocaleDefaultsToEnglish(String locale) {
         Assertions.assertEquals("en", getTwilioLocale(locale));
+    }
+
+    @Test
+    void testGetPushDevicesUrl() {
+        String email = "first.last+suffix@example.com";
+        String base = "https://get.example.com/devices/?user=";
+        Assertions.assertEquals(
+            "https://get.example.com/devices/?user=first.last%2Bsuffix%40example.com",
+            getPushDevicesUrl(base, email)
+        );
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Changes from this PR include correctly encoding a user's email address before retrieving the number of push devices.

