### PR TITLE
 OTP-983 Test Short Time Format

### DIFF
--- a/src/test/java/org/opentripplanner/middleware/models/TripMonitorNotificationTest.java
+++ b/src/test/java/org/opentripplanner/middleware/models/TripMonitorNotificationTest.java
@@ -9,7 +9,8 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Locale;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class TripMonitorNotificationTest {
@@ -19,7 +20,9 @@ class TripMonitorNotificationTest {
     void canCreateInitialReminder() {
         MonitoredTrip trip = makeSampleTrip();
         TripMonitorNotification notification = TripMonitorNotification.createInitialReminderNotification(trip, EN_US_LOCALE);
-        assertEquals("Reminder for Sample Trip at 5:44 PM.", notification.body);
+        assertNotNull(notification);
+        // JDK 20 uses narrow no-break space U+202F for time format; earlier JDKs just use a space.
+        assertThat(notification.body, matchesPattern("Reminder for Sample Trip at 5:44[\\u202f ]PM\\."));
     }
 
     @Test
@@ -32,7 +35,11 @@ class TripMonitorNotificationTest {
             EN_US_LOCALE
         );
         assertNotNull(notification);
-        assertEquals("⏱ Your trip is now predicted to arrive 10 minutes late (at 5:44 PM).", notification.body);
+        // JDK 20 uses narrow no-break space U+202F for time format; earlier JDKs just use a space.
+        assertThat(
+            notification.body,
+            matchesPattern("⏱ Your trip is now predicted to arrive 10 minutes late \\(at 5:44[\\u202f ]PM\\)\\.")
+        );
     }
 
     private static MonitoredTrip makeSampleTrip() {

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/DelayNotificationTestCase.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/DelayNotificationTestCase.java
@@ -12,10 +12,10 @@ class DelayNotificationTestCase {
     public NotificationType delayType;
 
     /**
-     * The expected body of the notification message. If this is not set, it is assumed in the test case that a
-     * notification should not be generated.
+     * A regex pattern to match the expected body of the notification message. If this is not set, it is assumed
+     * in the test case that a notification should not be generated.
      */
-    public String expectedNotificationMessage;
+    public String expectedNotificationPattern;
 
     /**
      * Message for test case
@@ -31,12 +31,12 @@ class DelayNotificationTestCase {
     public DelayNotificationTestCase(
         CheckMonitoredTrip checkMonitoredTrip,
         NotificationType delayType,
-        String expectedNotificationMessage,
+        String expectedNotificationPattern,
         String message
     ) {
         this.checkMonitoredTrip = checkMonitoredTrip;
         this.delayType = delayType;
-        this.expectedNotificationMessage = expectedNotificationMessage;
+        this.expectedNotificationPattern = expectedNotificationPattern;
         this.message = message;
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
@@ -9,29 +9,32 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
 
 class DateTimeUtilsTest {
     @ParameterizedTest
     @MethodSource("createDateFormatCases")
-    void supportsDateFormatsInSeveralLocales(String localeTag, String result) {
+    void supportsDateFormatsInSeveralLocales(String localeTag, String pattern) {
         ZonedDateTime zonedTime = ZonedDateTime.of(2023, 2, 12, 17, 44, 0, 0, DateTimeUtils.getOtpZoneId());
-        assertEquals(result, DateTimeUtils.formatShortDate(
-            Date.from(zonedTime.toInstant()),
-            Locale.forLanguageTag(localeTag))
+        assertThat(
+            DateTimeUtils.formatShortDate(Date.from(zonedTime.toInstant()), Locale.forLanguageTag(localeTag)),
+            matchesPattern(pattern)
         );
     }
 
     private static Stream<Arguments> createDateFormatCases() {
+        // JDK 20 uses narrow no-break space U+202F before "PM" for time format; earlier JDKs just use a space.
+        // Also, JDK 20 uses 24-hour format for Chinese (as does Format.JS library); earlier JDKs use "下午".
         return Stream.of(
-            Arguments.of("en-US", "5:44 PM"),
+            Arguments.of("en-US", "5:44[\\u202f ]PM"),
             Arguments.of("fr", "17:44"),
             Arguments.of("es", "17:44"),
             Arguments.of("ko", "오후 5:44"),
             Arguments.of("vi", "17:44"),
-            Arguments.of("zh", "下午5:44"), // Note: The Format.JS library shows 24-hour format for Chinese.
+            Arguments.of("zh", "(17|下午5):44"),
             Arguments.of("ru", "17:44"),
-            Arguments.of("tl", "5:44 PM")
+            Arguments.of("tl", "5:44[\\u202f ]PM")
         );
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Java’s “short” time format has changed to conform with the Unicode "CLDR 42.0" spec. The space character in a string like “5:30 PM” is no longer a simple ASCII space but a “narrow non-breaking space.” ASCII space is U+20 and nnbsp is U+202F under Unicode. Here's where the change was introduced:

https://bugs.openjdk.org/browse/JDK-8304925

Unit tests comparing our time formats failed under JDK 20.

### Solution

Using a regular expression pattern so we can detect either the nnbsp or the ASCII space, unit tests can  work for all JDKs. Here's an example regular expression to match against:
```
"[\\u202f ]PM" 
```
Another “short” format change in JDK 20 is that Chinese is now using 24hr format (making it consistent with the Javascript Format.JS used in the UI). So a regular expression for 5:44 PM would look like this:
```
 "(17|下午5):44"
```