### PR TITLE
Delete user from token

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -24,6 +24,7 @@ import spark.Response;
 
 import java.security.interfaces.RSAPublicKey;
 
+import static org.opentripplanner.middleware.controllers.api.AbstractUserController.TOKEN_PATH;
 import static org.opentripplanner.middleware.controllers.api.AbstractUserController.VERIFICATION_EMAIL_PATH;
 import static org.opentripplanner.middleware.controllers.api.ApiUserController.API_USER_PATH;
 import static org.opentripplanner.middleware.controllers.api.OtpUserController.OTP_USER_PATH;
@@ -100,7 +101,7 @@ public class Auth0Connection {
      * @return true if the request can operate without a user profile, false otherwise.
      */
     private static boolean expectsMissingProfile(Request req, RequestingUser profile) {
-        return isCreatingSelf(req, profile) || isRequestingVerificationEmail(req);
+        return isCreatingSelf(req, profile) || isRequestingVerificationEmail(req) || isDeletingSelf(req);
     }
 
     public static boolean isAuthHeaderPresent(Request req) {
@@ -313,6 +314,20 @@ public class Auth0Connection {
             String uri = req.uri();
             return uri.endsWith(API_USER_PATH + VERIFICATION_EMAIL_PATH) ||
                 uri.endsWith(OTP_USER_PATH + VERIFICATION_EMAIL_PATH);
+        }
+        return false;
+    }
+
+    /**
+     * @return true if the given request is for a user requesting to delete themselves.
+     */
+    static boolean isDeletingSelf(Request req) {
+        if (req.requestMethod().equalsIgnoreCase("DELETE")) {
+            // Should be a DELETE request against the fromtoken route for /user or /application.
+            // (does not apply to admins.)
+            String uri = req.uri();
+            return uri.endsWith(API_USER_PATH + TOKEN_PATH) ||
+                uri.endsWith(OTP_USER_PATH + TOKEN_PATH);
         }
         return false;
     }

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Connection.java
@@ -72,10 +72,10 @@ public class Auth0Connection {
             RequestingUser profile = new RequestingUser(jwt);
             if (!isValidUser(profile)) {
                 if (expectsMissingProfile(req, profile)) {
-                    // If creating or emailing self, no user account is required (it does not exist yet!). Note: creating an
-                    // admin user requires that the requester is an admin (checkUserIsAdmin must be passed), so this
-                    // is not a concern for that method/controller.
-                    LOG.info("New user is creating self. OK to proceed without existing user object for auth0UserId");
+                    // If creating, emailing, or deleting self, no user account is required (it does not exist yet!).
+                    // Note: creating an admin user requires that the requester is an admin
+                    // (checkUserIsAdmin must be passed), so this is not a concern for that method/controller.
+                    LOG.info("New user is creating/emailing/deleting self. OK to proceed without existing user object for auth0UserId");
                 } else {
                     // Otherwise, if no valid user is found, halt the request.
                     logMessageAndHalt(req, HttpStatus.NOT_FOUND_404, "No user found in database associated with the provided auth token.");
@@ -97,7 +97,8 @@ public class Auth0Connection {
 
     /**
      * Checks whether the given {@link Request} should expect missing {@link ApiUser} or {@link OtpUser} profiles,
-     * to handle situations such as during new user sign up where the ApiUser or OtpUser does not exist yet.
+     * to handle situations such as during new user sign up where the ApiUser or OtpUser does not exist yet,
+     * and when requesting the Auth0 account deletion before a user record is created in Mongo.
      * @return true if the request can operate without a user profile, false otherwise.
      */
     private static boolean expectsMissingProfile(Request req, RequestingUser profile) {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -86,10 +86,12 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
     private U getUserFromRequest(Request req, Response res) {
         RequestingUser profile = Auth0Connection.getUserFromRequest(req);
         if (profile == null) {
-            logMessageAndHalt(req,
-                    HttpStatus.NOT_FOUND_404,
-                    String.format(NO_USER_WITH_AUTH0_ID_MESSAGE, null),
-                    null);
+            logMessageAndHalt(
+                req,
+                HttpStatus.NOT_FOUND_404,
+                String.format(NO_USER_WITH_AUTH0_ID_MESSAGE, null),
+                null
+            );
         }
         U user = getUserProfile(profile);
 
@@ -98,10 +100,12 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
         // but have not completed the account setup form yet.
         // For those users, the user profile would be 404 not found (as opposed to 403 forbidden).
         if (user == null) {
-            logMessageAndHalt(req,
+            logMessageAndHalt(
+                req,
                 HttpStatus.NOT_FOUND_404,
                 String.format(NO_USER_WITH_AUTH0_ID_MESSAGE, profile.auth0UserId),
-                null);
+                null
+            );
         }
         return user;
     }
@@ -113,10 +117,12 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
     private boolean deleteUserFromRequest(Request req, Response res) {
         RequestingUser profile = Auth0Connection.getUserFromRequest(req);
         if (profile == null) {
-            logMessageAndHalt(req,
+            logMessageAndHalt(
+                req,
                 HttpStatus.NOT_FOUND_404,
                 String.format(NO_USER_WITH_AUTH0_ID_MESSAGE, null),
-                null);
+                null
+            );
             return false;
         }
         U user = getUserProfile(profile);
@@ -125,10 +131,12 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
             // If a user record was found in Mongo, cascade delete, including its Auth0 ID.
             boolean result = user.delete();
             if (!result) {
-                logMessageAndHalt(req,
+                logMessageAndHalt(
+                    req,
                     HttpStatus.INTERNAL_SERVER_ERROR_500,
                     String.format("An error occurred deleting user with id '%s'.", user.id),
-                    null);
+                    null
+                );
             }
             return result;
         } else {
@@ -137,10 +145,12 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
                 deleteAuth0User(profile.auth0UserId);
                 return true;
             } catch (Auth0Exception e) {
-                logMessageAndHalt(req,
+                logMessageAndHalt(
+                    req,
                     HttpStatus.INTERNAL_SERVER_ERROR_500,
                     String.format("Could not delete Auth0 user %s.", profile.auth0UserId),
-                    e);
+                    e
+                );
                 return false;
             }
         }

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -86,12 +86,7 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
     private U getUserFromRequest(Request req, Response res) {
         RequestingUser profile = Auth0Connection.getUserFromRequest(req);
         if (profile == null) {
-            logMessageAndHalt(
-                req,
-                HttpStatus.NOT_FOUND_404,
-                String.format(NO_USER_WITH_AUTH0_ID_MESSAGE, null),
-                null
-            );
+            logUserNotFoundAndHalt(req, null);
         }
         U user = getUserProfile(profile);
 
@@ -100,12 +95,7 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
         // but have not completed the account setup form yet.
         // For those users, the user profile would be 404 not found (as opposed to 403 forbidden).
         if (user == null) {
-            logMessageAndHalt(
-                req,
-                HttpStatus.NOT_FOUND_404,
-                String.format(NO_USER_WITH_AUTH0_ID_MESSAGE, profile.auth0UserId),
-                null
-            );
+            logUserNotFoundAndHalt(req, profile.auth0UserId);
         }
         return user;
     }
@@ -117,12 +107,7 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
     private boolean deleteUserFromRequest(Request req, Response res) {
         RequestingUser profile = Auth0Connection.getUserFromRequest(req);
         if (profile == null) {
-            logMessageAndHalt(
-                req,
-                HttpStatus.NOT_FOUND_404,
-                String.format(NO_USER_WITH_AUTH0_ID_MESSAGE, null),
-                null
-            );
+            logUserNotFoundAndHalt(req, null);
             return false;
         }
         U user = getUserProfile(profile);
@@ -154,6 +139,15 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
                 return false;
             }
         }
+    }
+
+    private void logUserNotFoundAndHalt(Request req, String id) {
+        logMessageAndHalt(
+            req,
+            HttpStatus.NOT_FOUND_404,
+            String.format(NO_USER_WITH_AUTH0_ID_MESSAGE, id),
+            null
+        );
     }
 
     private Job resendVerificationEmail(Request req, Response res) {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -31,7 +31,7 @@ import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 public abstract class AbstractUserController<U extends AbstractUser> extends ApiController<U> {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractUserController.class);
     static final String NO_USER_WITH_AUTH0_ID_MESSAGE = "No user with auth0UserID=%s found.";
-    private static final String TOKEN_PATH = "/fromtoken";
+    public static final String TOKEN_PATH = "/fromtoken";
     public static final String VERIFICATION_EMAIL_PATH = "/verification-email";
 
     /**
@@ -57,7 +57,7 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
                     .withResponses(stdResponses),
                 this::getUserFromRequest, JsonUtils::toJson
             )
-            .delete(path(fullTokenPath)
+            .delete(path(TOKEN_PATH)
                     .withDescription("Deletes an " + persistence.clazz.getSimpleName() + " entity using an Auth0 access token passed in an Authorization header.")
                     .withResponses(stdResponses),
                 this::deleteUserFromRequest, JsonUtils::toJson

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -56,9 +56,43 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
+          responseSchema:
+            $ref: "#/definitions/AdminUser"
           schema:
             $ref: "#/definitions/AdminUser"
+        "400":
+          description: "The request was not formed properly (e.g., some required parameters\
+            \ may be missing). See the details of the returned response to determine\
+            \ the exact issue."
+          examples: {}
+        "401":
+          description: "The server was not able to authenticate the request. This\
+            \ can happen if authentication headers are missing or malformed, or the\
+            \ authentication server cannot be reached."
+          examples: {}
+        "403":
+          description: "The requesting user is not allowed to perform the request."
+          examples: {}
+        "404":
+          description: "The requested item was not found."
+          examples: {}
+        "500":
+          description: "An error occurred while performing the request. Contact an\
+            \ API administrator for more information."
+          examples: {}
+    delete:
+      tags:
+      - "api/admin/user"
+      description: "Deletes an AdminUser entity using an Auth0 access token passed\
+        \ in an Authorization header."
+      parameters: []
+      responses:
+        "200":
+          description: "Successful operation"
+          examples: {}
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -89,9 +123,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
           responseSchema:
+            $ref: "#/definitions/Job"
+          schema:
             $ref: "#/definitions/Job"
   /api/admin/user:
     get:
@@ -121,9 +155,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -144,9 +178,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -186,9 +220,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -235,9 +269,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -275,9 +309,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -322,9 +356,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -368,9 +402,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -413,9 +447,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/TokenHolder"
           responseSchema:
+            $ref: "#/definitions/TokenHolder"
+          schema:
             $ref: "#/definitions/TokenHolder"
   /api/secure/application/fromtoken:
     get:
@@ -430,9 +464,43 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
+          responseSchema:
+            $ref: "#/definitions/ApiUser"
           schema:
             $ref: "#/definitions/ApiUser"
+        "400":
+          description: "The request was not formed properly (e.g., some required parameters\
+            \ may be missing). See the details of the returned response to determine\
+            \ the exact issue."
+          examples: {}
+        "401":
+          description: "The server was not able to authenticate the request. This\
+            \ can happen if authentication headers are missing or malformed, or the\
+            \ authentication server cannot be reached."
+          examples: {}
+        "403":
+          description: "The requesting user is not allowed to perform the request."
+          examples: {}
+        "404":
+          description: "The requested item was not found."
+          examples: {}
+        "500":
+          description: "An error occurred while performing the request. Contact an\
+            \ API administrator for more information."
+          examples: {}
+    delete:
+      tags:
+      - "api/secure/application"
+      description: "Deletes an ApiUser entity using an Auth0 access token passed in\
+        \ an Authorization header."
+      parameters: []
+      responses:
+        "200":
+          description: "Successful operation"
+          examples: {}
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -463,9 +531,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
           responseSchema:
+            $ref: "#/definitions/Job"
+          schema:
             $ref: "#/definitions/Job"
   /api/secure/application:
     get:
@@ -495,9 +563,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -518,9 +586,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -560,9 +628,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -609,9 +677,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -649,9 +717,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -686,9 +754,43 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
+          responseSchema:
+            $ref: "#/definitions/CDPUser"
           schema:
             $ref: "#/definitions/CDPUser"
+        "400":
+          description: "The request was not formed properly (e.g., some required parameters\
+            \ may be missing). See the details of the returned response to determine\
+            \ the exact issue."
+          examples: {}
+        "401":
+          description: "The server was not able to authenticate the request. This\
+            \ can happen if authentication headers are missing or malformed, or the\
+            \ authentication server cannot be reached."
+          examples: {}
+        "403":
+          description: "The requesting user is not allowed to perform the request."
+          examples: {}
+        "404":
+          description: "The requested item was not found."
+          examples: {}
+        "500":
+          description: "An error occurred while performing the request. Contact an\
+            \ API administrator for more information."
+          examples: {}
+    delete:
+      tags:
+      - "api/secure/cdp"
+      description: "Deletes an CDPUser entity using an Auth0 access token passed in\
+        \ an Authorization header."
+      parameters: []
+      responses:
+        "200":
+          description: "Successful operation"
+          examples: {}
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -719,9 +821,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
           responseSchema:
+            $ref: "#/definitions/Job"
+          schema:
             $ref: "#/definitions/Job"
   /api/secure/cdp:
     get:
@@ -751,9 +853,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -774,9 +876,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -816,9 +918,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -865,9 +967,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -905,9 +1007,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -948,9 +1050,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ItineraryExistence"
           responseSchema:
+            $ref: "#/definitions/ItineraryExistence"
+          schema:
             $ref: "#/definitions/ItineraryExistence"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1000,9 +1102,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1023,9 +1125,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
           responseSchema:
+            $ref: "#/definitions/MonitoredTrip"
+          schema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1065,9 +1167,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
           responseSchema:
+            $ref: "#/definitions/MonitoredTrip"
+          schema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1114,9 +1216,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
           responseSchema:
+            $ref: "#/definitions/MonitoredTrip"
+          schema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1155,9 +1257,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
           responseSchema:
+            $ref: "#/definitions/MonitoredTrip"
+          schema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1196,9 +1298,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/StartTrackingResponse"
           responseSchema:
+            $ref: "#/definitions/StartTrackingResponse"
+          schema:
             $ref: "#/definitions/StartTrackingResponse"
   /api/secure/monitoredtrip/updatetracking:
     post:
@@ -1217,9 +1319,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/UpdateTrackingResponse"
           responseSchema:
+            $ref: "#/definitions/UpdateTrackingResponse"
+          schema:
             $ref: "#/definitions/UpdateTrackingResponse"
   /api/secure/monitoredtrip/endtracking:
     post:
@@ -1238,9 +1340,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/EndTrackingResponse"
           responseSchema:
+            $ref: "#/definitions/EndTrackingResponse"
+          schema:
             $ref: "#/definitions/EndTrackingResponse"
   /api/secure/monitoredtrip/forciblyendtracking:
     post:
@@ -1259,9 +1361,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/EndTrackingResponse"
           responseSchema:
+            $ref: "#/definitions/EndTrackingResponse"
+          schema:
             $ref: "#/definitions/EndTrackingResponse"
   /api/secure/triprequests:
     get:
@@ -1307,9 +1409,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/TripRequest"
           responseSchema:
+            $ref: "#/definitions/TripRequest"
+          schema:
             $ref: "#/definitions/TripRequest"
   /api/secure/monitoredcomponent:
     get:
@@ -1339,9 +1441,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1362,9 +1464,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredComponent"
           responseSchema:
+            $ref: "#/definitions/MonitoredComponent"
+          schema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1404,9 +1506,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredComponent"
           responseSchema:
+            $ref: "#/definitions/MonitoredComponent"
+          schema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1453,9 +1555,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredComponent"
           responseSchema:
+            $ref: "#/definitions/MonitoredComponent"
+          schema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1494,9 +1596,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredComponent"
           responseSchema:
+            $ref: "#/definitions/MonitoredComponent"
+          schema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1537,9 +1639,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/VerificationResult"
           responseSchema:
+            $ref: "#/definitions/VerificationResult"
+          schema:
             $ref: "#/definitions/VerificationResult"
   /api/secure/user/{id}/verify_sms/{code}:
     post:
@@ -1560,9 +1662,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/VerificationResult"
           responseSchema:
+            $ref: "#/definitions/VerificationResult"
+          schema:
             $ref: "#/definitions/VerificationResult"
   /api/secure/user/fromtoken:
     get:
@@ -1577,9 +1679,43 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
+          responseSchema:
+            $ref: "#/definitions/OtpUser"
           schema:
             $ref: "#/definitions/OtpUser"
+        "400":
+          description: "The request was not formed properly (e.g., some required parameters\
+            \ may be missing). See the details of the returned response to determine\
+            \ the exact issue."
+          examples: {}
+        "401":
+          description: "The server was not able to authenticate the request. This\
+            \ can happen if authentication headers are missing or malformed, or the\
+            \ authentication server cannot be reached."
+          examples: {}
+        "403":
+          description: "The requesting user is not allowed to perform the request."
+          examples: {}
+        "404":
+          description: "The requested item was not found."
+          examples: {}
+        "500":
+          description: "An error occurred while performing the request. Contact an\
+            \ API administrator for more information."
+          examples: {}
+    delete:
+      tags:
+      - "api/secure/user"
+      description: "Deletes an OtpUser entity using an Auth0 access token passed in\
+        \ an Authorization header."
+      parameters: []
+      responses:
+        "200":
+          description: "Successful operation"
+          examples: {}
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1610,9 +1746,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
           responseSchema:
+            $ref: "#/definitions/Job"
+          schema:
             $ref: "#/definitions/Job"
   /api/secure/user:
     get:
@@ -1642,9 +1778,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1665,9 +1801,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1707,9 +1843,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1756,9 +1892,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1796,9 +1932,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1853,11 +1989,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/ApiUsageResult"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/ApiUsageResult"
@@ -1884,11 +2020,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/BugsnagEvent"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/BugsnagEvent"
@@ -1915,11 +2051,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/CDPFile"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/CDPFile"
@@ -1940,11 +2076,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/URL"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/URL"


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds a DELETE method to the `fromtoken` endpoint, so that UI callers can delete Auth0 accounts during the setup process (i.e. before the record in Mongo is created).
