### PR TITLE
Allow monitoring non-transit trips (OTP-1103)

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/otp/response/Itinerary.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/response/Itinerary.java
@@ -96,7 +96,6 @@ public class Itinerary implements Cloneable {
     public Set<InvalidItineraryReason> checkItineraryCanBeMonitored() {
         // Check the itinerary for various conditions needed for monitoring.
         Set<InvalidItineraryReason> reasons = new HashSet<>();
-        if (!hasTransit()) reasons.add(InvalidItineraryReason.MISSING_TRANSIT);
         if (hasRentalOrRideHail()) reasons.add(InvalidItineraryReason.HAS_RENTAL_OR_RIDE_HAIL);
         // TODO: Add additional checks here.
         return reasons;

--- a/src/main/java/org/opentripplanner/middleware/utils/InvalidItineraryReason.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/InvalidItineraryReason.java
@@ -5,7 +5,6 @@ package org.opentripplanner.middleware.utils;
  * trip monitoring.
  */
 public enum InvalidItineraryReason {
-    MISSING_TRANSIT("the trip is missing a transit leg"),
     HAS_RENTAL_OR_RIDE_HAIL("the trip contains a rental or ride hail leg");
 
     private final String message;

--- a/src/test/java/org/opentripplanner/middleware/models/ItineraryTest.java
+++ b/src/test/java/org/opentripplanner/middleware/models/ItineraryTest.java
@@ -114,10 +114,9 @@ public class ItineraryTest {
 
     private static Stream<Arguments> createCannotBeMonitoredTestCases() {
         return Stream.of(
-            Arguments.of(itineraryWithoutTransitWithoutRentals, false,
-                Set.of(InvalidItineraryReason.MISSING_TRANSIT)),
+            Arguments.of(itineraryWithoutTransitWithoutRentals, true, Collections.EMPTY_SET),
             Arguments.of(itineraryWithRentalBikeWithoutTransit, false,
-                Set.of(InvalidItineraryReason.MISSING_TRANSIT, InvalidItineraryReason.HAS_RENTAL_OR_RIDE_HAIL)),
+                Set.of(InvalidItineraryReason.HAS_RENTAL_OR_RIDE_HAIL)),
             Arguments.of(itineraryWithTransitAndRentalBike, false,
                 Set.of(InvalidItineraryReason.HAS_RENTAL_OR_RIDE_HAIL)),
             Arguments.of(itineraryWithTransitNoRentals, true, Collections.EMPTY_SET)


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR allows monitoring of non-transit trips (walk-only, bike-only, etc), so that users can subscribe for notifications on such trips.
Trips that include rentals and ride-hail are still excluded from monitoring under this PR.
