### PR TITLE
Check existence on all days when initially saving trip (OTP-1109)

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -64,9 +64,9 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
         preCreateOrUpdateChecks(monitoredTrip, req);
 
         try {
-            // Check itinerary existence and replace the provided trip's itinerary with a verified, non-realtime
-            // version of it.
-            boolean success = monitoredTrip.checkItineraryExistence(false, true);
+            // Check itinerary existence for all days and replace the provided trip's itinerary with a verified,
+            // non-realtime version of it.
+            boolean success = monitoredTrip.checkItineraryExistence(true, true);
             if (!success) {
                 logMessageAndHalt(
                     req,

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -66,7 +66,7 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
         try {
             // Check itinerary existence for all days and replace the provided trip's itinerary with a verified,
             // non-realtime version of it.
-            boolean success = monitoredTrip.checkItineraryExistence(true, true);
+            boolean success = monitoredTrip.checkItineraryExistence(true);
             if (!success) {
                 logMessageAndHalt(
                     req,
@@ -194,7 +194,7 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
         }
         try {
             trip.initializeFromItineraryAndQueryParams();
-            trip.checkItineraryExistence(true, false);
+            trip.checkItineraryExistence(false);
         } catch (URISyntaxException e) { // triggered by OtpQueryUtils#getQueryParams.
             logMessageAndHalt(
                 request,

--- a/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
@@ -127,20 +127,6 @@ public class ItineraryExistence extends Model {
     }
 
     /**
-     * Checks whether all checked days of the week are valid.
-     * @return true if all days are either valid (i.e., the day was checked) or null (i.e., the day was not checked).
-     */
-    public boolean allCheckedDaysAreValid() {
-        return (monday == null || itineraryExistsOn(monday)) &&
-            (tuesday == null || itineraryExistsOn(tuesday)) &&
-            (wednesday == null || itineraryExistsOn(wednesday)) &&
-            (thursday == null || itineraryExistsOn(thursday)) &&
-            (friday == null || itineraryExistsOn(friday)) &&
-            (saturday == null || itineraryExistsOn(saturday)) &&
-            (sunday == null || itineraryExistsOn(sunday));
-    }
-
-    /**
      * Checks whether all monitored days of the week for a trip are valid.
      * @return true if all monitored days are valid.
      */
@@ -186,7 +172,7 @@ public class ItineraryExistence extends Model {
     /**
      * Checks whether the itinerary of a trip matches any of the OTP itineraries from the trip query params.
      */
-    public void checkExistence() {
+    public void checkExistence(MonitoredTrip trip) {
         // TODO: Consider multi-threading?
         // Check existence of itinerary in the response for each OTP request.
         for (OtpRequest otpRequest : otpRequests) {
@@ -227,8 +213,7 @@ public class ItineraryExistence extends Model {
                 result.handleInvalidDate(otpRequest.dateTime);
             }
         }
-        // TODO: I think this should change too.
-        if (!this.allCheckedDaysAreValid()) {
+        if (!allMonitoredDaysAreValid(trip)) {
             this.message = String.format(
                 "The trip is not possible on the following days of the week you have selected: %s",
                 getInvalidDaysOfWeekMessage()

--- a/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
@@ -131,13 +131,13 @@ public class ItineraryExistence extends Model {
      * @return true if all days are either valid (i.e., the day was checked) or null (i.e., the day was not checked).
      */
     public boolean allCheckedDaysAreValid() {
-        return (monday == null || monday.isValid()) &&
-            (tuesday == null || tuesday.isValid()) &&
-            (wednesday == null || wednesday.isValid()) &&
-            (thursday == null || thursday.isValid()) &&
-            (friday == null || friday.isValid()) &&
-            (saturday == null || saturday.isValid()) &&
-            (sunday == null || sunday.isValid());
+        return (monday == null || itineraryExistsOn(monday)) &&
+            (tuesday == null || itineraryExistsOn(tuesday)) &&
+            (wednesday == null || itineraryExistsOn(wednesday)) &&
+            (thursday == null || itineraryExistsOn(thursday)) &&
+            (friday == null || itineraryExistsOn(friday)) &&
+            (saturday == null || itineraryExistsOn(saturday)) &&
+            (sunday == null || itineraryExistsOn(sunday));
     }
 
     /**
@@ -145,13 +145,13 @@ public class ItineraryExistence extends Model {
      * @return true if all monitored days are valid.
      */
     public boolean allMonitoredDaysAreValid(MonitoredTrip trip) {
-        return (!trip.monday || monday.isValid()) &&
-            (!trip.tuesday || tuesday.isValid()) &&
-            (!trip.wednesday || wednesday.isValid()) &&
-            (!trip.thursday || thursday.isValid()) &&
-            (!trip.friday || friday.isValid()) &&
-            (!trip.saturday || saturday.isValid()) &&
-            (!trip.sunday || sunday.isValid());
+        return (!trip.monday || itineraryExistsOn(monday)) &&
+            (!trip.tuesday || itineraryExistsOn(tuesday)) &&
+            (!trip.wednesday || itineraryExistsOn(wednesday)) &&
+            (!trip.thursday || itineraryExistsOn(thursday)) &&
+            (!trip.friday || itineraryExistsOn(friday)) &&
+            (!trip.saturday || itineraryExistsOn(saturday)) &&
+            (!trip.sunday || itineraryExistsOn(sunday));
     }
 
     /**
@@ -159,7 +159,7 @@ public class ItineraryExistence extends Model {
      */
     public Itinerary getItineraryForDayOfWeek(DayOfWeek dow) {
         ItineraryExistenceResult resultForDay = getResultForDayOfWeek(dow);
-        return resultForDay != null && resultForDay.isValid() && resultForDay.itineraries.size() > 0
+        return itineraryExistsOn(resultForDay) && !resultForDay.itineraries.isEmpty()
             ? resultForDay.itineraries.get(0)
             : null;
     }
@@ -242,13 +242,17 @@ public class ItineraryExistence extends Model {
      * returned.
      */
     public boolean isPossibleOnAtLeastOneMonitoredDayOfTheWeek(MonitoredTrip trip) {
-        return (trip.monday && monday != null && monday.isValid()) ||
-            (trip.tuesday && tuesday != null && tuesday.isValid()) ||
-            (trip.wednesday && wednesday != null && wednesday.isValid()) ||
-            (trip.thursday && thursday != null && thursday.isValid()) ||
-            (trip.friday && friday != null && friday.isValid()) ||
-            (trip.saturday && saturday != null && saturday.isValid()) ||
-            (trip.sunday && sunday != null && sunday.isValid());
+        return (trip.monday && itineraryExistsOn(monday)) ||
+            (trip.tuesday && itineraryExistsOn(tuesday)) ||
+            (trip.wednesday && itineraryExistsOn(wednesday)) ||
+            (trip.thursday && itineraryExistsOn(thursday)) ||
+            (trip.friday && itineraryExistsOn(friday)) ||
+            (trip.saturday && itineraryExistsOn(saturday)) ||
+            (trip.sunday && itineraryExistsOn(sunday));
+    }
+
+    public static boolean itineraryExistsOn(ItineraryExistenceResult dayResult) {
+        return dayResult != null && dayResult.isValid();
     }
 
     /**
@@ -260,7 +264,7 @@ public class ItineraryExistence extends Model {
          */
         @JsonProperty
         public boolean isValid() {
-            return invalidDates.size() == 0;
+            return invalidDates.isEmpty();
         }
 
         /**

--- a/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
@@ -141,6 +141,20 @@ public class ItineraryExistence extends Model {
     }
 
     /**
+     * Checks whether all monitored days of the week for a trip are valid.
+     * @return true if all monitored days are valid.
+     */
+    public boolean allMonitoredDaysAreValid(MonitoredTrip trip) {
+        return (!trip.monday || monday.isValid()) &&
+            (!trip.tuesday || tuesday.isValid()) &&
+            (!trip.wednesday || wednesday.isValid()) &&
+            (!trip.thursday || thursday.isValid()) &&
+            (!trip.friday || friday.isValid()) &&
+            (!trip.saturday || saturday.isValid()) &&
+            (!trip.sunday || sunday.isValid());
+    }
+
+    /**
      * @return The first {@link Itinerary} found for the given {@link DayOfWeek}.
      */
     public Itinerary getItineraryForDayOfWeek(DayOfWeek dow) {
@@ -213,6 +227,7 @@ public class ItineraryExistence extends Model {
                 result.handleInvalidDate(otpRequest.dateTime);
             }
         }
+        // TODO: I think this should change too.
         if (!this.allCheckedDaysAreValid()) {
             this.message = String.format(
                 "The trip is not possible on the following days of the week you have selected: %s",

--- a/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
@@ -127,8 +127,7 @@ public class ItineraryExistence extends Model {
     }
 
     /**
-     * Checks whether all monitored days of the week for a trip are valid.
-     * @return true if all monitored days are valid.
+     * @return true if all monitored days of the week for a trip are valid.
      */
     public boolean allMonitoredDaysAreValid(MonitoredTrip trip) {
         return (!trip.monday || itineraryExistsOn(monday)) &&

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -199,12 +199,13 @@ public class MonitoredTrip extends Model {
      *                     or just the days the trip is set to be monitored.
      * @return a summary of the itinerary existence results for each day of the week
      */
+    // TODO: remove arg checkAllDays
     public boolean checkItineraryExistence(boolean checkAllDays, boolean replaceItinerary) throws URISyntaxException {
         // Get queries to execute by date.
         List<OtpRequest> queriesByDate = getItineraryExistenceQueries(checkAllDays);
         this.itineraryExistence = new ItineraryExistence(queriesByDate, this.itinerary, this.arriveBy);
         this.itineraryExistence.checkExistence();
-        boolean itineraryExists = this.itineraryExistence.allCheckedDaysAreValid();
+        boolean itineraryExists = this.itineraryExistence.allMonitoredDaysAreValid(this);
         // If itinerary should be replaced, do so if all checked days are valid.
         return replaceItinerary && itineraryExists
             ? this.updateTripWithVerifiedItinerary()

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -201,7 +201,7 @@ public class MonitoredTrip extends Model {
         // Get queries to execute by date.
         List<OtpRequest> queriesByDate = getItineraryExistenceQueries();
         this.itineraryExistence = new ItineraryExistence(queriesByDate, this.itinerary, this.arriveBy);
-        this.itineraryExistence.checkExistence();
+        this.itineraryExistence.checkExistence(this);
         boolean itineraryExists = this.itineraryExistence.allMonitoredDaysAreValid(this);
         // If itinerary should be replaced, do so if all checked days are valid.
         return replaceItinerary && itineraryExists

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -195,14 +195,11 @@ public class MonitoredTrip extends Model {
 
     /**
      * Checks that, for each query provided, an itinerary exists.
-     * @param checkAllDays Determines whether all days of the week are checked,
-     *                     or just the days the trip is set to be monitored.
      * @return a summary of the itinerary existence results for each day of the week
      */
-    // TODO: remove arg checkAllDays
-    public boolean checkItineraryExistence(boolean checkAllDays, boolean replaceItinerary) throws URISyntaxException {
+    public boolean checkItineraryExistence(boolean replaceItinerary) throws URISyntaxException {
         // Get queries to execute by date.
-        List<OtpRequest> queriesByDate = getItineraryExistenceQueries(checkAllDays);
+        List<OtpRequest> queriesByDate = getItineraryExistenceQueries();
         this.itineraryExistence = new ItineraryExistence(queriesByDate, this.itinerary, this.arriveBy);
         this.itineraryExistence.checkExistence();
         boolean itineraryExists = this.itineraryExistence.allMonitoredDaysAreValid(this);
@@ -245,11 +242,11 @@ public class MonitoredTrip extends Model {
      */
     @JsonIgnore
     @BsonIgnore
-    public List<OtpRequest> getItineraryExistenceQueries(boolean checkAllDays)
+    public List<OtpRequest> getItineraryExistenceQueries()
         throws URISyntaxException {
         return ItineraryUtils.getOtpRequestsForDates(
             ItineraryUtils.excludeRealtime(parseQueryParams()),
-            ItineraryUtils.getDatesToCheckItineraryExistence(this, checkAllDays)
+            ItineraryUtils.getDatesToCheckItineraryExistence(this)
         );
     }
 

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -286,10 +286,8 @@ public class CheckMonitoredTrip implements Runnable {
         // possible for just that day, but could again be possible the next week. Therefore, this checks if the trip
         // was not possible on all monitored days of the previous week and if so, it updates the journeyState to say
         // that the trip is no longer possible.
-        boolean noMatchingItineraryFoundOnPreviousChecks = !trip.itineraryExistence.
-            isPossibleOnAtLeastOneMonitoredDayOfTheWeek(
-                trip
-            );
+        boolean noMatchingItineraryFoundOnPreviousChecks =
+            !trip.itineraryExistence.isPossibleOnAtLeastOneMonitoredDayOfTheWeek(trip);
         journeyState.tripStatus = noMatchingItineraryFoundOnPreviousChecks
             ? TripStatus.NO_LONGER_POSSIBLE
             : TripStatus.NEXT_TRIP_NOT_POSSIBLE;

--- a/src/main/java/org/opentripplanner/middleware/utils/ItineraryUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/ItineraryUtils.java
@@ -75,7 +75,7 @@ public class ItineraryUtils {
      * @param trip The trip from which to extract the monitored dates to check.
      * @return A list of date strings in YYYY-MM-DD format corresponding to each day of the week to monitor, sorted from earliest.
      */
-    public static List<ZonedDateTime> getDatesToCheckItineraryExistence(MonitoredTrip trip, boolean checkAllDays)
+    public static List<ZonedDateTime> getDatesToCheckItineraryExistence(MonitoredTrip trip)
         throws URISyntaxException {
         List<ZonedDateTime> datesToCheck = new ArrayList<>();
         Map<String, String> params = trip.parseQueryParams();
@@ -87,10 +87,7 @@ public class ItineraryUtils {
         ZonedDateTime startingDateTime = trip.tripZonedDateTime(startingDate);
         // Get the dates to check starting from the query date and continuing through the full date range window.
         for (int i = 0; i < ITINERARY_CHECK_WINDOW; i++) {
-            ZonedDateTime dateToCheck = startingDateTime.plusDays(i);
-            if (checkAllDays || trip.isActiveOnDate(dateToCheck)) {
-                datesToCheck.add(dateToCheck);
-            }
+            datesToCheck.add(startingDateTime.plusDays(i));
         }
 
         return datesToCheck;

--- a/src/test/java/org/opentripplanner/middleware/utils/ItineraryUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/ItineraryUtilsTest.java
@@ -135,7 +135,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
         Itinerary expectedItinerary = mockOtpResponses.get(0).plan.itineraries.get(0);
         trip.itinerary = expectedItinerary;
 
-        trip.checkItineraryExistence(true, false);
+        trip.checkItineraryExistence(false);
         ItineraryExistence existence = trip.itineraryExistence;
 
         boolean allDaysValid = !insertInvalidDay;
@@ -238,28 +238,12 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
      * Check the computation of the dates corresponding to the monitored days,
      * for which we want to check itinerary existence.
      */
-    @ParameterizedTest
-    @MethodSource("createGetDatesTestCases")
-    void canGetDatesToCheckItineraryExistence(List<ZonedDateTime> testDates, boolean checkAllDays) throws URISyntaxException {
+    @Test
+    void canGetDatesToCheckItineraryExistence() throws URISyntaxException {
         MonitoredTrip trip = makeTestTrip();
-        List<ZonedDateTime> datesToCheck = ItineraryUtils.getDatesToCheckItineraryExistence(trip, checkAllDays);
+        List<ZonedDateTime> testDates = datesToZonedDateTimes(MONITORED_TRIP_DATES);
+        List<ZonedDateTime> datesToCheck = ItineraryUtils.getDatesToCheckItineraryExistence(trip);
         Assertions.assertEquals(testDates, datesToCheck);
-    }
-
-    private static Stream<Arguments> createGetDatesTestCases() {
-        // Each list includes dates to be monitored in a 7-day window starting from the query date.
-        return Stream.of(
-            // Dates solely based on monitored days (see the trip variable in the corresponding test).
-            Arguments.of(datesToZonedDateTimes(
-                MONITORED_TRIP_DATES
-                ), false),
-
-            // If we forceAllDays to ItineraryUtils.getDatesToCheckItineraryExistence,
-            // it should return all dates in the 7-day window regardless of the ones set in the monitored trip.
-            Arguments.of(datesToZonedDateTimes(List.of(
-                QUERY_DATE /* Thursday */, "2020-08-14", "2020-08-15", "2020-08-16", "2020-08-17", "2020-08-18", "2020-08-19")
-            ), true)
-        );
     }
 
     /**


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Previously, itinerary existence was checked only for days for which a trip is set to be monitored. Upon editing, days not monitored days would be incorrectly marked as "not possible" (i.e. with a red background) even if they were shown as possible upon saving. This PR fixes that (see screenshots).

Before screenshot when editing a trip that is possible 7 days (Saturday and Sunday are shown not possible (red shade) in UI):
<img width="777" alt="image" src="https://github.com/ibi-group/otp-middleware/assets/56846598/e6710b9d-0e9d-4fff-ad44-a8fdf10ffd1c">

After screenshot when editing a trip that is possible 7 days (Saturday and Sunday are shown possible in UI):
<img width="777" alt="image" src="https://github.com/ibi-group/otp-middleware/assets/56846598/85e6b8cc-0a67-4d60-a336-03e07e99e78c">



