### PR TITLE
refactor(templates): Change email link paths

### DIFF
--- a/src/main/resources/templates/MonitoredTripHtml.ftl
+++ b/src/main/resources/templates/MonitoredTripHtml.ftl
@@ -65,7 +65,7 @@
             </#list>
         </ul>
 
-        <p>View all of your saved trips in <a href="${OTP_UI_URL}${TRIPS_PATH}/${tripId}">${OTP_UI_NAME}</a>.</p>
+        <p>View all of your saved trips in <a href="${OTP_UI_URL}${TRIPS_PATH}">${OTP_UI_NAME}</a>.</p>
     </div>
 </#macro>
 

--- a/src/main/resources/templates/OtpUserContainer.ftl
+++ b/src/main/resources/templates/OtpUserContainer.ftl
@@ -16,7 +16,7 @@
 <div>
     <p>
         <small>
-            You're receiving this email because you're subscribed to notifications through ${OTP_UI_NAME}. You can manage that subscription <a href="${OTP_UI_URL}/#/account">here</a>.
+            You're receiving this email because you're subscribed to notifications through ${OTP_UI_NAME}. You can manage that subscription <a href="${OTP_UI_URL}${TRIPS_PATH}/${tripId}">here</a>.
         </small>
     </p>
 </div>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [x] The description lists all relevant PRs included in this release _(remove this if not merging to master)_

### Description

Addresses feedback from users that pointed out the "view all your saved trips" link goes to the specific trip id, while "manage trip subscription" link goes to the my trips page. This updates the links so that the destinations make a little more sense. 
