### PR TITLE
Persist trip status for last submitted location to Mongo [OTP-1158]

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/models/TrackedJourney.java
+++ b/src/main/java/org/opentripplanner/middleware/models/TrackedJourney.java
@@ -75,4 +75,8 @@ public class TrackedJourney extends Model {
     public int hashCode() {
         return Objects.hash(super.hashCode(), tripId, startTime);
     }
+
+    public TrackingLocation lastLocation() {
+        return locations.get(locations.size() - 1);
+    }
 }

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TrackingLocation.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TrackingLocation.java
@@ -18,6 +18,8 @@ public class TrackingLocation {
 
     public Date timestamp;
 
+    public TripStatus tripStatus;
+
     public TrackingLocation() {
         // Needed for deserializing objects.
     }

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -2742,6 +2742,15 @@ definitions:
       timestamp:
         type: "string"
         format: "date"
+      tripStatus:
+        type: "string"
+        enum:
+        - "ON_SCHEDULE"
+        - "BEHIND_SCHEDULE"
+        - "AHEAD_OF_SCHEDULE"
+        - "ENDED"
+        - "DEVIATED"
+        - "NO_STATUS"
   StartTrackingResponse:
     type: "object"
     properties:

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -106,11 +106,14 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         );
 
         var startTrackingResponse = JsonUtils.getPOJOFromJSON(response.responseBody, StartTrackingResponse.class);
-        trackedJourney = Persistence.trackedJourneys.getById(startTrackingResponse.journeyId);
         assertEquals(ManageTripTracking.TRIP_TRACKING_UPDATE_FREQUENCY_SECONDS, startTrackingResponse.frequencySeconds);
         assertEquals(TripInstruction.GET_ON_BUS.name(), startTrackingResponse.instruction);
         assertEquals(TripStatus.NO_STATUS.name(), startTrackingResponse.tripStatus);
         assertEquals(HttpStatus.OK_200, response.status);
+
+        trackedJourney = Persistence.trackedJourneys.getById(startTrackingResponse.journeyId);
+        assertEquals(1, trackedJourney.locations.size());
+        assertEquals(TripStatus.NO_STATUS, trackedJourney.locations.get(0).tripStatus);
 
         response = makeRequest(
             UPDATE_TRACKING_TRIP_PATH,
@@ -123,6 +126,10 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         assertEquals(TripInstruction.NO_INSTRUCTION.name(), updateTrackingResponse.instruction);
         assertEquals(TripStatus.NO_STATUS.name(), updateTrackingResponse.tripStatus);
         assertEquals(HttpStatus.OK_200, response.status);
+
+        trackedJourney = Persistence.trackedJourneys.getById(startTrackingResponse.journeyId);
+        assertEquals(2, trackedJourney.locations.size());
+        assertEquals(TripStatus.NO_STATUS, trackedJourney.locations.get(1).tripStatus);
 
         response = makeRequest(
             END_TRACKING_TRIP_PATH,

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -112,8 +112,9 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         assertEquals(HttpStatus.OK_200, response.status);
 
         trackedJourney = Persistence.trackedJourneys.getById(startTrackingResponse.journeyId);
+        // A single location is submitted when starting tracking.
         assertEquals(1, trackedJourney.locations.size());
-        assertEquals(TripStatus.NO_STATUS, trackedJourney.locations.get(0).tripStatus);
+        assertEquals(TripStatus.NO_STATUS, trackedJourney.lastLocation().tripStatus);
 
         response = makeRequest(
             UPDATE_TRACKING_TRIP_PATH,
@@ -128,8 +129,10 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         assertEquals(HttpStatus.OK_200, response.status);
 
         trackedJourney = Persistence.trackedJourneys.getById(startTrackingResponse.journeyId);
-        assertEquals(2, trackedJourney.locations.size());
-        assertEquals(TripStatus.NO_STATUS, trackedJourney.locations.get(1).tripStatus);
+        // The call to updatetracking sent 3 additional locations, so there are 4 locations stored at this point.
+        assertEquals(4, trackedJourney.locations.size());
+        assertEquals(trackedJourney.locations.get(3), trackedJourney.lastLocation());
+        assertEquals(TripStatus.NO_STATUS, trackedJourney.lastLocation().tripStatus);
 
         response = makeRequest(
             END_TRACKING_TRIP_PATH,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

For reporting purposes, this PR adds persisting of a trip status associated with the last location submitted when the `starttracking` or `updatetracking` endpoint is invoked.