### PR TITLE
Delay switching matching itin to next day

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
@@ -98,7 +98,7 @@ public class ItineraryExistence extends Model {
     /**
      * Helper function to set the existence check for a particular day of the week.
      */
-    private void setResultForDayOfWeek(ItineraryExistenceResult result, DayOfWeek dayOfWeek) {
+    public void setResultForDayOfWeek(ItineraryExistenceResult result, DayOfWeek dayOfWeek) {
         switch (dayOfWeek) {
             case MONDAY:
                 monday = result;

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -120,7 +120,7 @@ public class CheckMonitoredTrip implements Runnable {
         previousJourneyState = trip.journeyState;
         journeyState = previousJourneyState.clone();
         previousMatchingItinerary = trip.journeyState.matchingItinerary;
-        this.otpResponseProvider = this::getOtpResponse;
+        otpResponseProvider = this::getOtpResponse;
     }
 
     public CheckMonitoredTrip(MonitoredTrip trip, Supplier<OtpResponse> otpResponseProvider) throws CloneNotSupportedException {
@@ -335,9 +335,6 @@ public class CheckMonitoredTrip implements Runnable {
             );
             return null;
         }
-
-        // FIXME in PR Review: Is the below if statement needed? (SonarLint thinks not.)
-        if (otpDispatcherResponse == null) return null;
 
         if (otpDispatcherResponse.statusCode >= 400) {
             BugsnagReporter.reportErrorToBugsnag(
@@ -697,8 +694,8 @@ public class CheckMonitoredTrip implements Runnable {
                     );
                     if (
                         lastDate.getYear() == targetZonedDateTime.getYear() &&
-                            lastDate.getMonthValue() == targetZonedDateTime.getMonthValue() &&
-                            lastDate.getDayOfMonth() == targetZonedDateTime.getDayOfMonth()
+                        lastDate.getMonthValue() == targetZonedDateTime.getMonthValue() &&
+                        lastDate.getDayOfMonth() == targetZonedDateTime.getDayOfMonth()
                     ) {
                         targetZonedDateTime = targetZonedDateTime.plusDays(1);
                     }
@@ -710,8 +707,8 @@ public class CheckMonitoredTrip implements Runnable {
                 // check for the current day and the target zoned date time should be advanced to the next day.
                 if (
                     previousMatchingItinerary == null &&
-                        trip.itinerary.endTime.before(DateTimeUtils.nowAsDate()) &&
-                        ItineraryUtils.occursOnSameServiceDay(trip.itinerary, targetZonedDateTime, trip.arriveBy)
+                    trip.itinerary.endTime.before(DateTimeUtils.nowAsDate()) &&
+                    ItineraryUtils.occursOnSameServiceDay(trip.itinerary, targetZonedDateTime, trip.arriveBy)
                 ) {
                     // Increment the target day for recurring trips.
                     targetZonedDateTime = targetZonedDateTime.plusDays(1);

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -645,9 +645,9 @@ public class CheckMonitoredTrip implements Runnable {
         }
 
         // Check if the previous matching itinerary was null or if it has already concluded
-        boolean prevMatchingItineraryConcluded = previousMatchingItinerary != null &&
+        boolean prevMatchingItineraryNotConcluded = previousMatchingItinerary != null &&
             previousMatchingItinerary.endTime.after(new Date(previousJourneyState.lastCheckedEpochMillis));
-        if (prevMatchingItineraryConcluded) {
+        if (prevMatchingItineraryNotConcluded) {
             // Skip checking the trip the rest of the time that it is active if the trip was deemed not possible for the
             // next possible time during a previous query to find candidate itinerary matches.
             if (previousJourneyState.tripStatus == TripStatus.NEXT_TRIP_NOT_POSSIBLE) {

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -214,17 +214,15 @@ public class CheckMonitoredTrip implements Runnable {
      * @return false to indicate that no further checks for delays/alerts/etc should occur, true otherwise.
      */
     public boolean checkOtpAndUpdateTripStatus() {
-        // If tracking is still ongoing, don't check OTP.
-        if (isTrackingOngoing() && trip.journeyState.matchingItinerary.hasEnded()) {
+        // If matching itinerary has concluded, and live tracking is ongoing or the trip is one-time, don't check OTP.
+        boolean oneTime = trip.isOneTime();
+        boolean trackingOngoing = isTrackingOngoing();
+        if ((oneTime || trackingOngoing) && trip.journeyState.matchingItinerary.hasEnded()) {
+            if (oneTime && !trackingOngoing) {
+                trip.journeyState.tripStatus = TripStatus.PAST_TRIP;
+            }
             return false;
         }
-
-        // For one-time trips in the past, update status accordingly and don't check OTP.
-        if (trip.isOneTime() && trip.itinerary.hasEnded()) {
-            trip.journeyState.tripStatus = TripStatus.PAST_TRIP;
-            return false;
-        }
-
         // Perform normal OTP checks otherwise.
         return makeOTPRequestAndUpdateMatchingItineraryInternal();
     }

--- a/src/main/java/org/opentripplanner/middleware/triptracker/ManageTripTracking.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/ManageTripTracking.java
@@ -212,7 +212,7 @@ public class ManageTripTracking {
     /**
      * Get the ongoing tracked journey for trip id.
      */
-    private static TrackedJourney getOngoingTrackedJourney(String tripId) {
+    public static TrackedJourney getOngoingTrackedJourney(String tripId) {
         return Persistence.trackedJourneys.getOneFiltered(
             Filters.and(
                 eq(TrackedJourney.TRIP_ID_FIELD_NAME, tripId),

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -30,7 +30,7 @@ class CheckMonitoredTripBasicTest {
     void testSkipMonitoredTripCheck(SkipMonitoringTestArgs args) throws Exception {
         MonitoredTrip trip = makeMonitoredTripFromNow(args.tripStartOffsetSecs, args.tripEndOffsetSecs);
         if (args.isRecurring) {
-            setMonitoredDaysForTest(trip);
+            setRecurringTodayAndTomorrow(trip);
         }
         if (args.pastState) {
             trip.journeyState.tripStatus = TripStatus.PAST_TRIP;
@@ -61,7 +61,7 @@ class CheckMonitoredTripBasicTest {
     }
 
     /** Add the day-of-week of the itinerary start time as the recurring day, and the next day too. */
-    static void setMonitoredDaysForTest(MonitoredTrip trip) {
+    static void setRecurringTodayAndTomorrow(MonitoredTrip trip) {
         DayOfWeek dayOfWeek = DayOfWeek.of(LocalDate.ofInstant(
             trip.itinerary.startTime.toInstant(),
             DateTimeUtils.getOtpZoneId()).get(ChronoField.DAY_OF_WEEK

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.middleware.tripmonitor.jobs;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.middleware.models.ItineraryExistence;
 import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.tripmonitor.TripStatus;
@@ -96,6 +97,12 @@ class CheckMonitoredTripBasicTest {
                 break;
             default:
                 break;
+        }
+        if (trip.itineraryExistence == null) {
+            ItineraryExistence existence = new ItineraryExistence();
+            existence.setResultForDayOfWeek(new ItineraryExistence.ItineraryExistenceResult(), dayOfWeek);
+            existence.setResultForDayOfWeek(new ItineraryExistence.ItineraryExistenceResult(), dayOfWeek.plus(1));
+            trip.itineraryExistence = existence;
         }
     }
 

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.middleware.tripmonitor.jobs;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.middleware.models.MonitoredTrip;
@@ -61,7 +60,7 @@ class CheckMonitoredTripBasicTest {
     }
 
     /** Add the day-of-week of the itinerary start time as the recurring day, and the next day too. */
-    private static void setMonitoredDaysForTest(MonitoredTrip trip) {
+    static void setMonitoredDaysForTest(MonitoredTrip trip) {
         DayOfWeek dayOfWeek = DayOfWeek.of(LocalDate.ofInstant(
             trip.itinerary.startTime.toInstant(),
             DateTimeUtils.getOtpZoneId()).get(ChronoField.DAY_OF_WEEK
@@ -100,16 +99,7 @@ class CheckMonitoredTripBasicTest {
         }
     }
 
-    @Test
-    void shouldReportOneTimeTripInPastAsCompleted() throws CloneNotSupportedException {
-        MonitoredTrip trip = makeMonitoredTripFromNow(-900, -300);
-        trip.journeyState.tripStatus = TripStatus.TRIP_ACTIVE;
-
-        new CheckMonitoredTrip(trip).checkOtpAndUpdateTripStatus();
-        assertEquals(TripStatus.PAST_TRIP, trip.journeyState.tripStatus);
-    }
-
-    private static MonitoredTrip makeMonitoredTripFromNow(int startOffsetSecs, int endOffsetSecs) {
+    static MonitoredTrip makeMonitoredTripFromNow(int startOffsetSecs, int endOffsetSecs) {
         Instant now = Instant.now();
         Date start = Date.from(now.plusSeconds(startOffsetSecs));
 

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -665,11 +665,14 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     }
 
     @Test
-    void shouldReportRecurringTripInstanceInPastWithTrackingAsActive() throws CloneNotSupportedException {
+    void shouldReportRecurringTripInstanceInPastWithTrackingAsActive() throws Exception {
         MonitoredTrip trip = createPastActiveTripWithTrackedJourney();
         setMonitoredDaysForTest(trip);
         String todayFormatted = trip.journeyState.targetDate;
-        new CheckMonitoredTrip(trip).checkOtpAndUpdateTripStatus();
+
+        CheckMonitoredTrip check = new CheckMonitoredTrip(trip);
+        check.shouldSkipMonitoredTripCheck(false);
+        check.checkOtpAndUpdateTripStatus();
         // Trip should remain active, and the target date should still be "today".
         assertEquals(TripStatus.TRIP_ACTIVE, trip.journeyState.tripStatus);
         assertEquals(todayFormatted, trip.journeyState.targetDate);

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTripBasicTest.makeMonitoredTripFromNow;
-import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTripBasicTest.setMonitoredDaysForTest;
+import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTripBasicTest.setRecurringTodayAndTomorrow;
 
 /**
  * This class contains tests for the {@link CheckMonitoredTrip} job.
@@ -650,7 +650,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     @Test
     void shouldReportRecurringTripInstanceInPastAsUpcoming() throws Exception {
         MonitoredTrip trip = createPastActiveTrip();
-        setMonitoredDaysForTest(trip);
+        setRecurringTodayAndTomorrow(trip);
 
         // Build fake OTP response, using an existing one as template
         OtpResponse otpResponse = OtpTestUtils.OTP_DISPATCHER_PLAN_RESPONSE.getResponse();
@@ -667,7 +667,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     @Test
     void shouldReportRecurringTripInstanceInPastWithTrackingAsActive() throws Exception {
         MonitoredTrip trip = createPastActiveTripWithTrackedJourney();
-        setMonitoredDaysForTest(trip);
+        setRecurringTodayAndTomorrow(trip);
         String todayFormatted = trip.journeyState.targetDate;
 
         CheckMonitoredTrip check = new CheckMonitoredTrip(trip);

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -42,8 +42,10 @@ import static com.mongodb.client.model.Filters.eq;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTripBasicTest.makeMonitoredTripFromNow;
 import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTripBasicTest.setMonitoredDaysForTest;
@@ -56,7 +58,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     private static OtpUser user;
 
     // this is initialized in the setup method after the OTP_TIMEZONE config value is known.
-    private static ZonedDateTime noonMonday8June2020 = DateTimeUtils.makeOtpZonedDateTime(new Date())
+    private static final ZonedDateTime noonMonday8June2020 = DateTimeUtils.makeOtpZonedDateTime(new Date())
         .withYear(2020)
         .withMonth(6)
         .withDayOfMonth(8)
@@ -88,7 +90,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      * (and OTP_PLAN_ENDPOINT) to a valid OTP server.
      */
     @Test
-    public void canMonitorTrip() throws Exception {
+    void canMonitorTrip() throws Exception {
         // Do not run this test in a CI environment because it requires a live OTP server
         // FIXME: Add live otp server to e2e tests.
         assumeTrue(!ConfigUtils.isRunningCi && OtpMiddlewareTestEnvironment.IS_END_TO_END);
@@ -377,7 +379,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // - Return true if trip has ended as of the last check 3 minutes ago
         ShouldSkipTripTestCase weekdayTripEndedTestCase = new ShouldSkipTripTestCase(
             "should return true if trip has ended as of the last check",
-            noonMonday8June2020.withHour(9).withMinute(00), // mock time: 9:00am
+            noonMonday8June2020.withHour(9).withMinute(0), // mock time: 9:00am
             true
         );
         weekdayTripEndedTestCase.lastCheckedTime = noonMonday8June2020.withHour(8).withMinute(59);
@@ -390,7 +392,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      * Tests whether an OTP request can be made and if the trip and matching itinerary gets updated properly
      */
     @Test
-    public void canMakeOTPRequestAndUpdateMatchingItineraryForPreviouslyUnmatchedItinerary() throws Exception {
+    void canMakeOTPRequestAndUpdateMatchingItineraryForPreviouslyUnmatchedItinerary() throws Exception {
         // create an OTP mock to return
         OtpResponse mockWeekdayResponse = OtpTestUtils.OTP_DISPATCHER_PLAN_RESPONSE.getResponse();
         // create a mock monitored trip and CheckMonitorTrip instance
@@ -430,7 +432,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         );
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
-        assertEquals(true, mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
+        assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
 
         // fetch updated trip from persistence
         MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(mockTrip.id);
@@ -443,8 +445,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         );
 
         // verify itinerary existence was updated to show trip is possible again
-        assertEquals(
-            true,
+        assertTrue(
             updatedTrip.itineraryExistence.monday.isValid(),
             "updated trip should be valid on Monday"
         );
@@ -455,7 +456,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      * matching itinerary.
      */
     @Test
-    public void canMakeOTPRequestAndResolveUnmatchedItinerary() throws Exception {
+    void canMakeOTPRequestAndResolveUnmatchedItinerary() throws Exception {
         // create an OTP mock to return
         OtpResponse mockWeekdayResponse = OtpTestUtils.OTP_DISPATCHER_PLAN_RESPONSE.getResponse();
         // create a mock monitored trip and CheckMonitorTrip instance
@@ -495,7 +496,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         );
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
-        assertEquals(false, mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
+        assertFalse(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
 
         // fetch updated trip from persistence
         MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(mockTrip.id);
@@ -508,8 +509,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         );
 
         // verify itinerary existence was updated to show trip is not possible today
-        assertEquals(
-            false,
+        assertFalse(
             updatedTrip.itineraryExistence.monday.isValid(),
             "updated Trip should not be valid on Monday"
         );
@@ -532,7 +532,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      * matching itinerary for all days of the week.
      */
     @Test
-    public void canMakeOTPRequestAndResolveNoLongerPossibleTrip() throws Exception {
+    void canMakeOTPRequestAndResolveNoLongerPossibleTrip() throws Exception {
         // create an OTP mock to return
         OtpResponse mockWeekdayResponse = OtpTestUtils.OTP_DISPATCHER_PLAN_RESPONSE.getResponse();
         // create a mock monitored trip and CheckMonitorTrip instance
@@ -574,7 +574,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         );
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
-        assertEquals(false, mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
+        assertFalse(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
 
         // fetch updated trip from persistence
         MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(mockTrip.id);
@@ -587,8 +587,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         );
 
         // verify itinerary existence was updated to show trip is not possible today
-        assertEquals(
-            false,
+        assertFalse(
             updatedTrip.itineraryExistence.monday.isValid(),
             "updated Trip should not be valid on Monday"
         );
@@ -609,6 +608,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     @Test
     void shouldReportOneTimeTripInPastAsCompleted() throws CloneNotSupportedException {
         MonitoredTrip trip = makeMonitoredTripFromNow(-900, -300);
+        trip.journeyState.matchingItinerary = trip.itinerary;
         trip.journeyState.tripStatus = TripStatus.TRIP_ACTIVE;
 
         new CheckMonitoredTrip(trip).checkOtpAndUpdateTripStatus();
@@ -617,12 +617,13 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
     @Test
     void shouldReportOneTimeTripInPastWithTrackingAsActive() throws CloneNotSupportedException {
-        MonitoredTrip trip = makeMonitoredTripFromNow(-900, -300);
-        trip.id =  UUID.randomUUID().toString();
-        trip.userId = user.id;
-        trip.journeyState.matchingItinerary = trip.itinerary;
-        trip.journeyState.tripStatus = TripStatus.TRIP_ACTIVE;
-        Persistence.monitoredTrips.create(trip);
+        MonitoredTrip trip = createPastActiveTripWithTrackedJourney();
+        new CheckMonitoredTrip(trip).checkOtpAndUpdateTripStatus();
+        assertEquals(TripStatus.TRIP_ACTIVE, trip.journeyState.tripStatus);
+    }
+
+    private static MonitoredTrip createPastActiveTripWithTrackedJourney() {
+        MonitoredTrip trip = createPastActiveTrip();
 
         TrackedJourney journey = new TrackedJourney();
         journey.id = UUID.randomUUID().toString();
@@ -631,27 +632,29 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // No end time or condition provided in this case as tracking is still ongoing.
         Persistence.trackedJourneys.create(journey);
 
-        new CheckMonitoredTrip(trip).checkOtpAndUpdateTripStatus();
-        assertEquals(TripStatus.TRIP_ACTIVE, trip.journeyState.tripStatus);
+        return trip;
     }
 
-    @Test
-    void shouldReportRecurringTripInstanceInPastAsUpcoming() throws Exception {
+    private static MonitoredTrip createPastActiveTrip() {
         MonitoredTrip trip = makeMonitoredTripFromNow(-900, -300);
-        setMonitoredDaysForTest(trip);
         String todayFormatted = getShiftedDay(trip.itinerary.startTime, 0);
         trip.id =  UUID.randomUUID().toString();
         trip.userId = user.id;
         trip.journeyState.matchingItinerary = trip.itinerary;
-        trip.journeyState.tripStatus = TripStatus.TRIP_ACTIVE;
         trip.journeyState.targetDate = todayFormatted;
+        trip.journeyState.tripStatus = TripStatus.TRIP_ACTIVE;
         Persistence.monitoredTrips.create(trip);
+        return trip;
+    }
+
+    @Test
+    void shouldReportRecurringTripInstanceInPastAsUpcoming() throws Exception {
+        MonitoredTrip trip = createPastActiveTrip();
+        setMonitoredDaysForTest(trip);
 
         // Build fake OTP response, using an existing one as template
         OtpResponse otpResponse = OtpTestUtils.OTP_DISPATCHER_PLAN_RESPONSE.getResponse();
         Itinerary adjustedItinerary = trip.itinerary.clone();
-        //adjustedItinerary.startTime = Date.from(adjustedItinerary.startTime.toInstant().plus(1, ChronoUnit.DAYS));
-        //adjustedItinerary.endTime = Date.from(adjustedItinerary.endTime.toInstant().plus(1, ChronoUnit.DAYS));
         otpResponse.plan.itineraries = List.of(adjustedItinerary);
 
         CheckMonitoredTrip check = new CheckMonitoredTrip(trip, () -> otpResponse);
@@ -659,6 +662,17 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         check.checkOtpAndUpdateTripStatus();
         assertEquals(TripStatus.TRIP_UPCOMING, trip.journeyState.tripStatus);
         assertEquals(getShiftedDay(trip.itinerary.startTime, 1), trip.journeyState.targetDate);
+    }
+
+    @Test
+    void shouldReportRecurringTripInstanceInPastWithTrackingAsActive() throws CloneNotSupportedException {
+        MonitoredTrip trip = createPastActiveTripWithTrackedJourney();
+        setMonitoredDaysForTest(trip);
+        String todayFormatted = trip.journeyState.targetDate;
+        new CheckMonitoredTrip(trip).checkOtpAndUpdateTripStatus();
+        // Trip should remain active, and the target date should still be "today".
+        assertEquals(TripStatus.TRIP_ACTIVE, trip.journeyState.tripStatus);
+        assertEquals(todayFormatted, trip.journeyState.targetDate);
     }
 
     static String getShiftedDay(Date startTime, int dayShift) {

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
@@ -41,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTripBasicTest.makeMonitoredTripFromNow;
 
 /**
  * This class contains tests for the {@link CheckMonitoredTrip} job.
@@ -598,5 +598,14 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             mockCheckMonitoredTrip.notifications.iterator().next().body,
             "The notification should have the appropriate message when the trip is no longer possible"
         );
+    }
+
+    @Test
+    void shouldReportOneTimeTripInPastAsCompleted() throws CloneNotSupportedException {
+        MonitoredTrip trip = makeMonitoredTripFromNow(-900, -300);
+        trip.journeyState.tripStatus = TripStatus.TRIP_ACTIVE;
+
+        new CheckMonitoredTrip(trip).checkOtpAndUpdateTripStatus();
+        assertEquals(TripStatus.PAST_TRIP, trip.journeyState.tripStatus);
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR will prevent the change of a trip monitoring status from `TRIP_ACTIVE` to `TRIP_UPCOMING` or `TRIP_PAST` if live tracking is ongoing. This is so that if one is using live tracking and is "behind schedule", that status doesn't suddenly change to "ahead of schedule" when the theoretical trip end time passes.
