### PR TITLE
Use Absolute Minutes For Early Arrivals [OTP-1190]

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/models/TripMonitorNotification.java
+++ b/src/main/java/org/opentripplanner/middleware/models/TripMonitorNotification.java
@@ -58,7 +58,7 @@ public class TripMonitorNotification extends Model {
             // Delays start at two minutes (plural form).
             String minutesString = String.format(
                 Message.TRIP_DELAY_MINUTES.get(locale),
-                delayInMinutes
+                absoluteMinutes
             );
             if (delayInMinutes > 0) {
                 delayHumanTime = String.format(Message.TRIP_DELAY_LATE.get(locale), minutesString);


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fix situations where negative minutes are shown when transit trips are ahead of schedule.
Also update and significantly simplify delay notification tests in `CheckMonitoredTripTest`.
