### PR TITLE
Fix start-of-trip handling

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/ManageTripTracking.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/ManageTripTracking.java
@@ -70,7 +70,7 @@ public class ManageTripTracking {
             // Provide response.
             return new TrackingResponse(
                 TRIP_TRACKING_UPDATE_FREQUENCY_SECONDS,
-                TravelerLocator.getInstruction(tripStatus, travelerPosition, true),
+                TravelerLocator.getInstruction(tripStatus, travelerPosition, create),
                 trackedJourney.id,
                 tripStatus.name()
             );

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -87,25 +87,12 @@ public class TravelerLocator {
      */
     @Nullable
     public static TripInstruction alignTravelerToTrip(TravelerPosition travelerPosition, boolean isStartOfTrip) {
-
-        if (isStartOfTrip) {
-            // If the traveler has just started the trip and is within a set distance of the first step.
-            Step firstStep = travelerPosition.expectedLeg.steps.get(0);
-            if (firstStep == null) {
-                return null;
-            }
-            double distance = getDistance(travelerPosition.currentPosition, new Coordinates(firstStep));
-            return (distance <= TRIP_INSTRUCTION_UPCOMING_RADIUS)
-                ? new TripInstruction(distance, firstStep)
-                : null;
-        }
-
         if (isApproachingDestination(travelerPosition)) {
             return new TripInstruction(getDistanceToDestination(travelerPosition), travelerPosition.expectedLeg.to.name);
         }
 
         Step nextStep = snapToStep(travelerPosition);
-        if (nextStep != null && !isPositionPastStep(travelerPosition, nextStep)) {
+        if (nextStep != null && (!isPositionPastStep(travelerPosition, nextStep) || isStartOfTrip)) {
             return new TripInstruction(
                 getDistance(travelerPosition.currentPosition, new Coordinates(nextStep)),
                 nextStep

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -30,8 +30,8 @@ import org.opentripplanner.middleware.utils.DateTimeUtils;
 import org.opentripplanner.middleware.utils.HttpResponseValues;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
-import java.io.IOException;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,9 +56,10 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
     private static final String TRACK_TRIP_PATH = ROUTE_PATH + "track";
     private static final String END_TRACKING_TRIP_PATH = ROUTE_PATH + "endtracking";
     private static final String FORCIBLY_END_TRACKING_TRIP_PATH = ROUTE_PATH + "forciblyendtracking";
+    private static HashMap<String, String> headers;
 
     @BeforeAll
-    public static void setUp() throws IOException {
+    public static void setUp() throws Exception {
         assumeTrue(IS_END_TO_END);
         setAuthDisabled(false);
         OtpTestUtils.mockOtpServer();
@@ -75,6 +76,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip = new MonitoredTrip();
         monitoredTrip.userId = soloOtpUser.id;
         Persistence.monitoredTrips.create(monitoredTrip);
+        headers = getMockHeaders(soloOtpUser);
     }
 
     @AfterAll
@@ -102,7 +104,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         var response = makeRequest(
             START_TRACKING_TRIP_PATH,
             JsonUtils.toJson(createStartTrackingPayload()),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
 
@@ -119,7 +121,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         response = makeRequest(
             UPDATE_TRACKING_TRIP_PATH,
             JsonUtils.toJson(createUpdateTrackingPayload(startTrackingResponse.journeyId)),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
 
@@ -138,7 +140,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         response = makeRequest(
             END_TRACKING_TRIP_PATH,
             JsonUtils.toJson(createEndTrackingPayload(startTrackingResponse.journeyId)),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
         var endTrackingResponse = JsonUtils.getPOJOFromJSON(response.responseBody, EndTrackingResponse.class);
@@ -155,7 +157,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         var response = makeRequest(
             START_TRACKING_TRIP_PATH,
             JsonUtils.toJson(createStartTrackingPayload()),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
 
@@ -166,7 +168,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         response = makeRequest(
             START_TRACKING_TRIP_PATH,
             JsonUtils.toJson(createStartTrackingPayload()),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
 
@@ -182,7 +184,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         var response = makeRequest(
             TRACK_TRIP_PATH,
             JsonUtils.toJson(createTrackPayload()),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
 
@@ -195,7 +197,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         response = makeRequest(
             TRACK_TRIP_PATH,
             JsonUtils.toJson(createTrackPayload()),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
 
@@ -213,7 +215,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         var response = makeRequest(
             START_TRACKING_TRIP_PATH,
             JsonUtils.toJson(createStartTrackingPayload()),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
 
@@ -224,7 +226,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         response = makeRequest(
             FORCIBLY_END_TRACKING_TRIP_PATH,
             JsonUtils.toJson(createForceEndTrackingPayload(monitoredTrip.id)),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
         var endTrackingResponse = JsonUtils.getPOJOFromJSON(response.responseBody, EndTrackingResponse.class);
@@ -239,7 +241,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         HttpResponseValues response = makeRequest(
             START_TRACKING_TRIP_PATH,
             JsonUtils.toJson(createStartTrackingPayload("unassociated-trip-id")),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
 
@@ -255,7 +257,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         HttpResponseValues response = makeRequest(
             UPDATE_TRACKING_TRIP_PATH,
             JsonUtils.toJson(createUpdateTrackingPayload("unknown-journey-id")),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
 
@@ -271,7 +273,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         var response = makeRequest(
             START_TRACKING_TRIP_PATH,
             JsonUtils.toJson(createStartTrackingPayload()),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
 
@@ -284,7 +286,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         response = makeRequest(
             END_TRACKING_TRIP_PATH,
             JsonUtils.toJson(createEndTrackingPayload(startTrackingResponse.journeyId)),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
         assertEquals(HttpStatus.OK_200, response.status);
@@ -292,7 +294,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         response = makeRequest(
             UPDATE_TRACKING_TRIP_PATH,
             JsonUtils.toJson(createUpdateTrackingPayload(startTrackingResponse.journeyId)),
-            getMockHeaders(soloOtpUser),
+            headers,
             HttpMethod.POST
         );
 

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -233,6 +233,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
 
         assertEquals(HttpStatus.OK_200, response.status);
         trackResponse = JsonUtils.getPOJOFromJSON(response.responseBody, TrackingResponse.class);
+        assertNotEquals(0, trackResponse.frequencySeconds);
         assertEquals(instruction, trackResponse.instruction, message);
         assertNotNull(trackResponse.journeyId);
         assertEquals(trackedJourney.id, trackResponse.journeyId);


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Found a copy/paste mistake that can lead to quirky behavior when starting tracking a trip. This PR fixes that and improves the tests for the tracking endpoints.
