### PR TITLE
fix(TripTrackingData): Convert location timestamps to milliseconds.

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/TrackingLocation.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TrackingLocation.java
@@ -42,4 +42,9 @@ public class TrackingLocation {
     public TrackingLocation(Instant instant, double lat, double lon) {
         this(lat, lon, new Date(instant.toEpochMilli()));
     }
+
+    /** Used in testing **/
+    public TrackingLocation(Date timestamp, double lat, double lon) {
+        this(lat, lon, timestamp);
+    }
 }

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TripTrackingData.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TripTrackingData.java
@@ -103,7 +103,7 @@ public class TripTrackingData {
         return payload
             .getLocations()
             .stream()
-            .map(l -> new TrackingLocation(l.bearing, l.lat, l.lon, l.speed, Date.from(Instant.ofEpochMilli(l.timestamp.getTime() * 1000))))
+            .map(l -> new TrackingLocation(l.bearing, l.lat, l.lon, l.speed, Date.from(Instant.ofEpochSecond(l.timestamp.getTime()))))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TripTrackingData.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TripTrackingData.java
@@ -11,6 +11,7 @@ import org.opentripplanner.middleware.triptracker.payload.GeneralPayload;
 import spark.Request;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -100,8 +101,9 @@ public class TripTrackingData {
 
     /** HACK: Convert locations so that the time stamp is in milliseconds not seconds. */
     private static List<TrackingLocation> getTrackingLocationsMillis(GeneralPayload payload) {
-        return payload
-            .getLocations()
+        List<TrackingLocation> rawLocations = payload.getLocations();
+        if (rawLocations == null) rawLocations = new ArrayList<>();
+        return rawLocations
             .stream()
             .map(l -> new TrackingLocation(l.bearing, l.lat, l.lon, l.speed, Date.from(Instant.ofEpochSecond(l.timestamp.getTime()))))
             .collect(Collectors.toList());

--- a/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
@@ -294,4 +294,11 @@ public class DateTimeUtils {
     public static LocalDateTime getPreviousWholeHourFromNow() {
         return LocalDateTime.now().truncatedTo(ChronoUnit.HOURS).minusHours(1);
     }
+
+    /**
+     * Converts a date provided in seconds to a date in milliseconds.
+     */
+    public static Date convertDateFromSecondsToMillis(Date date) {
+        return Date.from(Instant.ofEpochSecond(date.getTime()));
+    }
 }

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -26,8 +26,10 @@ import org.opentripplanner.middleware.tripmonitor.JourneyState;
 import org.opentripplanner.middleware.triptracker.ManageTripTracking;
 import org.opentripplanner.middleware.triptracker.TrackingLocation;
 import org.opentripplanner.middleware.triptracker.TripStatus;
+import org.opentripplanner.middleware.triptracker.TripTrackingData;
 import org.opentripplanner.middleware.triptracker.payload.EndTrackingPayload;
 import org.opentripplanner.middleware.triptracker.payload.ForceEndTrackingPayload;
+import org.opentripplanner.middleware.triptracker.payload.GeneralPayload;
 import org.opentripplanner.middleware.triptracker.payload.StartTrackingPayload;
 import org.opentripplanner.middleware.triptracker.payload.TrackPayload;
 import org.opentripplanner.middleware.triptracker.payload.UpdatedTrackingPayload;
@@ -388,21 +390,17 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
     }
 
     private StartTrackingPayload createStartTrackingPayload(String monitorTripId) {
-        return createStartTrackingPayload(monitorTripId, 24.1111111111111, -79.2222222222222, new Date().getTime());
-    }
-
-    private StartTrackingPayload createStartTrackingPayload(String monitorTripId, double lat, double lon, long timestamp) {
         var payload = new StartTrackingPayload();
         payload.tripId = monitorTripId;
-        payload.location = new TrackingLocation(90, lat, lon, 29, new Date(timestamp));
+        payload.location = new TrackingLocation(90, 24.1111111111111, -79.2222222222222, 29, getDateAndConvertToSeconds());
         return payload;
     }
 
     private static List<TrackingLocation> createTrackingLocations() {
         return List.of(
-            new TrackingLocation(90, 24.1111111111111, -79.2222222222222, 29, new Date()),
-            new TrackingLocation(90, 28.5398938204469, -81.3772773742676, 30, new Date()),
-            new TrackingLocation(90, 29.5398938204469, -80.3772773742676, 31, new Date())
+            new TrackingLocation(90, 24.1111111111111, -79.2222222222222, 29, getDateAndConvertToSeconds()),
+            new TrackingLocation(90, 28.5398938204469, -81.3772773742676, 30, getDateAndConvertToSeconds()),
+            new TrackingLocation(90, 29.5398938204469, -80.3772773742676, 31, getDateAndConvertToSeconds())
         );
     }
 
@@ -421,7 +419,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
     }
 
     private TrackPayload createTrackPayload(Coordinates coords) {
-        return createTrackPayload(List.of(new TrackingLocation(Instant.now(), coords.lat, coords.lon)));
+        return createTrackPayload(List.of(new TrackingLocation(getDateAndConvertToSeconds(), coords.lat, coords.lon)));
     }
 
     private EndTrackingPayload createEndTrackingPayload(String journeyId) {
@@ -434,5 +432,13 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         var payload = new ForceEndTrackingPayload();
         payload.tripId = monitorTripId;
         return payload;
+    }
+
+    /**
+     * The mobile app sends timestamps in seconds which is then converted into milliseconds in {@link TripTrackingData}.
+     * To represent this in testing, provide the time in seconds from epoch.
+     */
+    private static Date getDateAndConvertToSeconds() {
+        return new Date(new Date().getTime() / 1000);
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

This PR converts location timestamps from seconds to milliseconds in the request data for the tracking endpoints.
