### PR TITLE
Remove mock OTP server from itin existence tests

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/docs/PublicApiDocGenerator.java
+++ b/src/main/java/org/opentripplanner/middleware/docs/PublicApiDocGenerator.java
@@ -120,7 +120,7 @@ public class PublicApiDocGenerator {
         // Remove unwanted fields that spark-swagger created, add fields that were missed.
         removeTypeFields(ItineraryExistence.ItineraryExistenceResult.class.getSimpleName(), "itineraries");
         addTypeField(ItineraryExistence.ItineraryExistenceResult.class.getSimpleName(), "valid", "boolean");
-        removeTypeFields(ItineraryExistence.class.getSimpleName(), "otpRequests", "referenceItinerary", "tripIsArriveBy");
+        removeTypeFields(ItineraryExistence.class.getSimpleName(), "otpRequests", "referenceItinerary", "tripIsArriveBy", "otpResponseProvider");
 
         // Cleanup the final document.
         generateMissingTypes();

--- a/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
@@ -65,16 +65,10 @@ public class ItineraryExistence extends Model {
      */
     public Date timestamp = new Date();
 
-    private Function<OtpRequest, OtpResponse> otpResponseProvider = ItineraryExistence::getOtpResponse;
+    private transient Function<OtpRequest, OtpResponse> otpResponseProvider = ItineraryExistence::getOtpResponse;
 
     // Required for persistence.
     public ItineraryExistence() {}
-
-    public ItineraryExistence(List<OtpRequest> otpRequests, Itinerary referenceItinerary, boolean tripIsArriveBy) {
-        this.otpRequests = otpRequests;
-        this.referenceItinerary = referenceItinerary;
-        this.tripIsArriveBy = tripIsArriveBy;
-    }
 
     public ItineraryExistence(
         List<OtpRequest> otpRequests,
@@ -82,8 +76,10 @@ public class ItineraryExistence extends Model {
         boolean tripIsArriveBy,
         Function<OtpRequest, OtpResponse> otpResponseProvider
     ) {
-        this(otpRequests, referenceItinerary, tripIsArriveBy);
-        this.otpResponseProvider = otpResponseProvider;
+        this.otpRequests = otpRequests;
+        this.referenceItinerary = referenceItinerary;
+        this.tripIsArriveBy = tripIsArriveBy;
+        if (otpResponseProvider != null) this.otpResponseProvider = otpResponseProvider;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
@@ -2,13 +2,11 @@ package org.opentripplanner.middleware.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.opentripplanner.middleware.otp.OtpDispatcher;
-import org.opentripplanner.middleware.otp.OtpVersion;
-import org.opentripplanner.middleware.otp.OtpDispatcherResponse;
 import org.opentripplanner.middleware.otp.OtpRequest;
 import org.opentripplanner.middleware.otp.response.Itinerary;
+import org.opentripplanner.middleware.otp.response.OtpResponse;
 import org.opentripplanner.middleware.otp.response.TripPlan;
 import org.opentripplanner.middleware.utils.DateTimeUtils;
 import org.opentripplanner.middleware.utils.ItineraryUtils;
@@ -184,14 +182,11 @@ public class ItineraryExistence extends Model {
                 result = new ItineraryExistenceResult();
                 setResultForDayOfWeek(result, dayOfWeek);
             }
+
             // Send off each plan query to OTP.
-            OtpDispatcherResponse response = OtpDispatcher.sendOtpPlanRequest(OtpVersion.OTP1, otpRequest);
-            TripPlan plan = null;
-            try {
-                plan = response.getResponse().plan;
-            } catch (JsonProcessingException e) {
-                LOG.error("Could not parse plan response for otpRequest {}", otpRequest, e);
-            }
+            OtpResponse response = OtpDispatcher.sendOtpRequestWithErrorHandling(otpRequest);
+            TripPlan plan = response.plan;
+
             // Handle response if valid itineraries exist.
             if (plan != null && plan.itineraries != null) {
                 for (Itinerary itineraryCandidate : plan.itineraries) {

--- a/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
+++ b/src/main/java/org/opentripplanner/middleware/models/ItineraryExistence.java
@@ -10,8 +10,6 @@ import org.opentripplanner.middleware.otp.response.OtpResponse;
 import org.opentripplanner.middleware.otp.response.TripPlan;
 import org.opentripplanner.middleware.utils.DateTimeUtils;
 import org.opentripplanner.middleware.utils.ItineraryUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.DayOfWeek;
 import java.time.ZonedDateTime;
@@ -30,8 +28,6 @@ import static org.opentripplanner.middleware.utils.DateTimeUtils.DEFAULT_DATE_FO
  * particular day of the week.
  */
 public class ItineraryExistence extends Model {
-    private static final Logger LOG = LoggerFactory.getLogger(ItineraryExistence.class);
-
     /**
      * Initial set of requests on which to base the itinerary existence checks. We do not want these persisted.
      */

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -205,9 +205,9 @@ public class MonitoredTrip extends Model {
     ) throws URISyntaxException {
         // Get queries to execute by date.
         List<OtpRequest> queriesByDate = getItineraryExistenceQueries();
-        this.itineraryExistence = new ItineraryExistence(queriesByDate, this.itinerary, this.arriveBy, otpResponseProvider);
-        this.itineraryExistence.checkExistence(this);
-        boolean itineraryExists = this.itineraryExistence.allMonitoredDaysAreValid(this);
+        itineraryExistence = new ItineraryExistence(queriesByDate, itinerary, arriveBy, otpResponseProvider);
+        itineraryExistence.checkExistence(this);
+        boolean itineraryExists = itineraryExistence.allMonitoredDaysAreValid(this);
         // If itinerary should be replaced, do so if all checked days are valid.
         return replaceItinerary && itineraryExists
             ? this.updateTripWithVerifiedItinerary()
@@ -215,19 +215,10 @@ public class MonitoredTrip extends Model {
     }
 
     /**
-     * Checks that, for each query provided, an itinerary exists.
-     * @return a summary of the itinerary existence results for each day of the week
+     * Shorthand for above method using the default otpResponseProvider.
      */
     public boolean checkItineraryExistence(boolean replaceItinerary) throws URISyntaxException {
-        // Get queries to execute by date.
-        List<OtpRequest> queriesByDate = getItineraryExistenceQueries();
-        this.itineraryExistence = new ItineraryExistence(queriesByDate, this.itinerary, this.arriveBy);
-        this.itineraryExistence.checkExistence(this);
-        boolean itineraryExists = this.itineraryExistence.allMonitoredDaysAreValid(this);
-        // If itinerary should be replaced, do so if all checked days are valid.
-        return replaceItinerary && itineraryExists
-            ? this.updateTripWithVerifiedItinerary()
-            : itineraryExists;
+        return checkItineraryExistence(replaceItinerary, null);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcher.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcher.java
@@ -140,7 +140,7 @@ public class OtpDispatcher {
             otpDispatcherResponse = otpDispatcherResponseSupplier.get();
         } catch (Exception e) {
             BugsnagReporter.reportErrorToBugsnag(
-                "Encountered an error while making a request ot the OTP server.",
+                "Encountered an error while making a request to the OTP server.",
                 e
             );
             return null;

--- a/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcher.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcher.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
+import java.util.function.Supplier;
 
 import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
 
@@ -126,9 +127,17 @@ public class OtpDispatcher {
     }
 
     public static OtpResponse sendOtpRequestWithErrorHandling(String sentParams) {
+        return handleOtpDispatcherResponse(() -> sendOtpPlanRequest(OtpVersion.OTP1, sentParams));
+    }
+
+    public static OtpResponse sendOtpRequestWithErrorHandling(OtpRequest otpRequest) {
+        return handleOtpDispatcherResponse(() -> sendOtpPlanRequest(OtpVersion.OTP1, otpRequest));
+    }
+
+    private static OtpResponse handleOtpDispatcherResponse(Supplier<OtpDispatcherResponse> otpDispatcherResponseSupplier) {
         OtpDispatcherResponse otpDispatcherResponse;
         try {
-            otpDispatcherResponse = sendOtpPlanRequest(OtpVersion.OTP1, sentParams);
+            otpDispatcherResponse = otpDispatcherResponseSupplier.get();
         } catch (Exception e) {
             BugsnagReporter.reportErrorToBugsnag(
                 "Encountered an error while making a request ot the OTP server.",
@@ -154,4 +163,5 @@ public class OtpDispatcher {
             return null;
         }
     }
+
 }

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -56,9 +56,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -90,9 +90,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -123,9 +123,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
           responseSchema:
+            $ref: "#/definitions/Job"
+          schema:
             $ref: "#/definitions/Job"
   /api/admin/user:
     get:
@@ -155,9 +155,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -178,9 +178,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -220,9 +220,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -269,9 +269,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -309,9 +309,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -356,9 +356,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -402,9 +402,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -447,9 +447,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/TokenHolder"
           responseSchema:
+            $ref: "#/definitions/TokenHolder"
+          schema:
             $ref: "#/definitions/TokenHolder"
   /api/secure/application/fromtoken:
     get:
@@ -464,9 +464,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -498,9 +498,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -531,9 +531,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
           responseSchema:
+            $ref: "#/definitions/Job"
+          schema:
             $ref: "#/definitions/Job"
   /api/secure/application:
     get:
@@ -563,9 +563,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -586,9 +586,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -628,9 +628,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -677,9 +677,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -717,9 +717,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -754,9 +754,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -788,9 +788,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -821,9 +821,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
           responseSchema:
+            $ref: "#/definitions/Job"
+          schema:
             $ref: "#/definitions/Job"
   /api/secure/cdp:
     get:
@@ -853,9 +853,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -876,9 +876,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -918,9 +918,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -967,9 +967,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1007,9 +1007,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1050,9 +1050,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ItineraryExistence"
           responseSchema:
+            $ref: "#/definitions/ItineraryExistence"
+          schema:
             $ref: "#/definitions/ItineraryExistence"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1102,9 +1102,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1125,9 +1125,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
           responseSchema:
+            $ref: "#/definitions/MonitoredTrip"
+          schema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1167,9 +1167,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
           responseSchema:
+            $ref: "#/definitions/MonitoredTrip"
+          schema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1216,9 +1216,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
           responseSchema:
+            $ref: "#/definitions/MonitoredTrip"
+          schema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1257,9 +1257,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
           responseSchema:
+            $ref: "#/definitions/MonitoredTrip"
+          schema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1298,9 +1298,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/TrackingResponse"
           responseSchema:
+            $ref: "#/definitions/TrackingResponse"
+          schema:
             $ref: "#/definitions/TrackingResponse"
   /api/secure/monitoredtrip/updatetracking:
     post:
@@ -1319,9 +1319,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/TrackingResponse"
           responseSchema:
+            $ref: "#/definitions/TrackingResponse"
+          schema:
             $ref: "#/definitions/TrackingResponse"
   /api/secure/monitoredtrip/track:
     post:
@@ -1340,9 +1340,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/TrackingResponse"
           responseSchema:
+            $ref: "#/definitions/TrackingResponse"
+          schema:
             $ref: "#/definitions/TrackingResponse"
   /api/secure/monitoredtrip/endtracking:
     post:
@@ -1361,9 +1361,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/EndTrackingResponse"
           responseSchema:
+            $ref: "#/definitions/EndTrackingResponse"
+          schema:
             $ref: "#/definitions/EndTrackingResponse"
   /api/secure/monitoredtrip/forciblyendtracking:
     post:
@@ -1382,9 +1382,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/EndTrackingResponse"
           responseSchema:
+            $ref: "#/definitions/EndTrackingResponse"
+          schema:
             $ref: "#/definitions/EndTrackingResponse"
   /api/secure/triprequests:
     get:
@@ -1430,9 +1430,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/TripRequest"
           responseSchema:
+            $ref: "#/definitions/TripRequest"
+          schema:
             $ref: "#/definitions/TripRequest"
   /api/secure/monitoredcomponent:
     get:
@@ -1462,9 +1462,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1485,9 +1485,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredComponent"
           responseSchema:
+            $ref: "#/definitions/MonitoredComponent"
+          schema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1527,9 +1527,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredComponent"
           responseSchema:
+            $ref: "#/definitions/MonitoredComponent"
+          schema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1576,9 +1576,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredComponent"
           responseSchema:
+            $ref: "#/definitions/MonitoredComponent"
+          schema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1617,9 +1617,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredComponent"
           responseSchema:
+            $ref: "#/definitions/MonitoredComponent"
+          schema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1660,9 +1660,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/VerificationResult"
           responseSchema:
+            $ref: "#/definitions/VerificationResult"
+          schema:
             $ref: "#/definitions/VerificationResult"
   /api/secure/user/{id}/verify_sms/{code}:
     post:
@@ -1683,9 +1683,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/VerificationResult"
           responseSchema:
+            $ref: "#/definitions/VerificationResult"
+          schema:
             $ref: "#/definitions/VerificationResult"
   /api/secure/user/fromtoken:
     get:
@@ -1700,9 +1700,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1734,9 +1734,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1767,9 +1767,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
           responseSchema:
+            $ref: "#/definitions/Job"
+          schema:
             $ref: "#/definitions/Job"
   /api/secure/user:
     get:
@@ -1799,9 +1799,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1822,9 +1822,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1864,9 +1864,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1913,9 +1913,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1953,9 +1953,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -2010,11 +2010,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/ApiUsageResult"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/ApiUsageResult"
@@ -2041,11 +2041,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/BugsnagEvent"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/BugsnagEvent"
@@ -2072,11 +2072,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/CDPFile"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/CDPFile"
@@ -2097,11 +2097,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/URL"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/URL"
@@ -2509,6 +2509,8 @@ definitions:
       timestamp:
         type: "string"
         format: "date"
+      otpResponseProvider:
+        $ref: "#/definitions/Function"
   Currency:
     type: "object"
     properties:

--- a/src/test/java/org/opentripplanner/middleware/utils/ItineraryUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/ItineraryUtilsTest.java
@@ -153,7 +153,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
         assertFalse(existence.wednesday.isValid());
         assertFalse(existence.friday.isValid());
 
-        // Make sure all mpcks were used
+        // Make sure all mocks were used
         assertTrue(mockResponses.areAllMocksUsed());
     }
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR removes the use of a mock OTP server for itinerary existence checks. (a mock response getter is used instead).
This may help with E2E tests in #219.
