### PR TITLE
Handle Request batchId

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/OtpRequestProcessor.java
@@ -190,12 +190,8 @@ public class OtpRequestProcessor implements Endpoint {
                 *
                 * Other requests will still be proxied, just not stored.
                 */
-                QueryVariables queryVariables = getPOJOFromJSON(requestBody, Query.class).variables;
-
-                // Follows the method used in otp-ui core-utils storage.js
-                String randomBatchId = Integer.toString((int) (Math.random() * 1_000_000_000), 36);
-
-                if (!handlePlanTripResponse(randomBatchId, queryVariables, otpDispatcherResponse, otpUser)) {
+                Query query = getPOJOFromJSON(requestBody, Query.class);
+                if (!handlePlanTripResponse(query.batchId, query.variables, otpDispatcherResponse, otpUser)) {
                     logMessageAndHalt(
                             request,
                             HttpStatus.INTERNAL_SERVER_ERROR_500,

--- a/src/main/java/org/opentripplanner/middleware/otp/graphql/Query.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/graphql/Query.java
@@ -1,7 +1,17 @@
 package org.opentripplanner.middleware.otp.graphql;
 
-/** Wraps an OTP GraphQL query data. Field names below are defined by OTP. */
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Wraps an OTP GraphQL query data.
+ * Field names below are defined by OTP, except for batchId which helps group OTP plan requests for a particular search.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Query {
+    public String batchId;
+
     public String query;
 
     public QueryVariables variables;


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

To be used with https://github.com/opentripplanner/otp-react-redux/pull/1252.

This PR corrects the persistence of trip requests (for applicable users) by persisting the `batchId` parameter provided by the UI client instead of creating a `batchId` that is not related to the search performed in the UI.

