### PR TITLE
Fix bus notifications

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettBusOpNotificationMessage.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettBusOpNotificationMessage.java
@@ -5,7 +5,6 @@ import org.opentripplanner.middleware.triptracker.TravelerPosition;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +44,7 @@ public class UsRideGwinnettBusOpNotificationMessage {
      */
     private static Map<String, Integer> createMobilityCodesLookup() {
         HashMap<String, Integer> codes = new HashMap<>();
+        codes.put("None", 0);
         codes.put("Device", 1);
         codes.put("MScooter", 2);
         codes.put("WChairE", 3);
@@ -95,14 +95,10 @@ public class UsRideGwinnettBusOpNotificationMessage {
 
     /**
      * Get the mobility code that matches the mobility mode. The API can accept multiple codes (probably to cover
-     * multiple travelers at the same stop), but the OTP middleware currently only provides one.
+     * multiple travelers at the same stop), but the OTP middleware currently only provides exactly one.
      */
-    private static List<Integer> getMobilityCode(String mobilityMode) {
-        List<Integer> mobilityCodes = new ArrayList<>();
-        Integer code = MOBILITY_CODES_LOOKUP.get(mobilityMode);
-        if (code != null) {
-            mobilityCodes.add(code);
-        }
-        return mobilityCodes;
+    static List<Integer> getMobilityCode(String mobilityMode) {
+        // Fallback on the "None" mobility profile (code 0) if the given mode is unknown.
+        return List.of(MOBILITY_CODES_LOOKUP.getOrDefault(mobilityMode, 0));
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettBusOpNotificationMessage.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettBusOpNotificationMessage.java
@@ -70,6 +70,8 @@ public class UsRideGwinnettBusOpNotificationMessage {
     public String from_route_id;
     public String from_trip_id;
     public String from_stop_id;
+    public String to_route_id;
+    public String to_trip_id;
     public String to_stop_id;
     public String from_arrival_time;
     public Integer msg_type;
@@ -83,6 +85,10 @@ public class UsRideGwinnettBusOpNotificationMessage {
         this.from_route_id = removeAgencyPrefix(getRouteIdFromLeg(nextLeg));
         this.from_trip_id = removeAgencyPrefix(getTripIdFromLeg(nextLeg));
         this.from_stop_id = removeAgencyPrefix(getStopIdFromPlace(nextLeg.from));
+        // For now, assume one notification request is made per transit leg.
+        // TODO: Determine how interlined legs should be handled.
+        this.to_route_id = this.from_route_id;
+        this.to_trip_id = this.from_trip_id;
         this.to_stop_id = removeAgencyPrefix(getStopIdFromPlace(nextLeg.to));
         this.from_arrival_time = BUS_OPERATOR_NOTIFIER_API_TIME_FORMAT.format(
             nextLeg.getScheduledStartTime()

--- a/src/test/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettBusOpNotificationMessageTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettBusOpNotificationMessageTest.java
@@ -1,0 +1,32 @@
+package org.opentripplanner.middleware.triptracker.interactions.busnotifiers;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UsRideGwinnettBusOpNotificationMessageTest {
+    @ParameterizedTest
+    @MethodSource("createGetMobilityCodeCases")
+    void testGetMobilityCode(String mobilityMode, int expectedCode) {
+        List<Integer> sentCodes = UsRideGwinnettBusOpNotificationMessage.getMobilityCode(mobilityMode);
+        assertEquals(1, sentCodes.size());
+        assertEquals(expectedCode, sentCodes.get(0));
+    }
+
+    private static Stream<Arguments> createGetMobilityCodeCases() {
+        return Stream.of(
+            Arguments.of("MScooter", 2),
+            Arguments.of("Device-LowVision", 8),
+            // This test is more about the edge cases than when a mode that denotes disability is passed.
+            Arguments.of("None", 0),
+            Arguments.of("", 0),
+            Arguments.of("Unknown-mode", 0),
+            Arguments.of(null, 0)
+        );
+    }
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR brings fixes to bus operator notifications in Gwinnett County GA USA.
- Destination route and trip id populated (assuming one bus driver notification per transit leg, not taking account for interlined legs)
- Default mode zero passed for mobility modes without disabilities or blank or unknown mode strings.
