### PR TITLE
Fix bus notification cancellation [OTP-1316]

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettNotifyBusOperator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettNotifyBusOperator.java
@@ -106,9 +106,10 @@ public class UsRideGwinnettNotifyBusOperator implements BusOperatorInteraction {
                     );
                     // Changed the saved message type from notify to cancel.
                     body.msg_type = 0;
-                    var httpStatus = doPost(JsonUtils.toJson(body));
+                    String bodyJson = JsonUtils.toJson(body);
+                    var httpStatus = doPost(bodyJson);
                     if (httpStatus == HttpStatus.OK_200) {
-                        travelerPosition.trackedJourney.updateNotificationMessage(routeId, JsonUtils.toJson(body));
+                        travelerPosition.trackedJourney.updateNotificationMessage(routeId, bodyJson);
                     } else {
                         LOG.error("Error {} while trying to cancel Ride Gwinnett notification to bus operator.", httpStatus);
                     }

--- a/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettNotifyBusOperator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettNotifyBusOperator.java
@@ -96,7 +96,7 @@ public class UsRideGwinnettNotifyBusOperator implements BusOperatorInteraction {
         try {
             if (
                 isBusLeg(travelerPosition.nextLeg) && routeId != null &&
-                hasNotCancelledNotificationForRoute(travelerPosition.trackedJourney, routeId)
+                hasNotCanceledNotificationForRoute(travelerPosition.trackedJourney, routeId)
             ) {
                 Map<String, String> busNotificationRequests = travelerPosition.trackedJourney.busNotificationMessages;
                 if (busNotificationRequests.containsKey(routeId)) {
@@ -165,7 +165,7 @@ public class UsRideGwinnettNotifyBusOperator implements BusOperatorInteraction {
     /**
      * Has a previous notification already been cancelled.
      */
-    public static boolean hasNotCancelledNotificationForRoute(
+    public static boolean hasNotCanceledNotificationForRoute(
         TrackedJourney trackedJourney,
         String routeId
     ) throws JsonProcessingException {
@@ -174,7 +174,7 @@ public class UsRideGwinnettNotifyBusOperator implements BusOperatorInteraction {
             throw new IllegalStateException("A notification must exist before it can be cancelled!");
         }
         UsRideGwinnettBusOpNotificationMessage message = getNotificationMessage(messageBody);
-        return message.msg_type != 1;
+        return message.msg_type != 0;
     }
 
     public static UsRideGwinnettBusOpNotificationMessage getNotificationMessage(String body) throws JsonProcessingException {

--- a/src/test/java/org/opentripplanner/middleware/triptracker/NotifyBusOperatorTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/NotifyBusOperatorTest.java
@@ -106,14 +106,19 @@ class NotifyBusOperatorTest extends OtpMiddlewareTestEnvironment {
     void canCancelBusOperatorNotification() throws JsonProcessingException {
         trackedJourney = createAndPersistTrackedJourney(getEndOfWalkLegCoordinates());
         TravelerPosition travelerPosition = new TravelerPosition(trackedJourney, walkToBusTransition, createOtpUser());
+
         busOperatorActions.handleSendNotificationAction(TripStatus.ON_SCHEDULE, travelerPosition);
         TrackedJourney updated = Persistence.trackedJourneys.getById(trackedJourney.id);
         assertTrue(updated.busNotificationMessages.containsKey(routeId));
-        busOperatorActions.handleCancelNotificationAction(travelerPosition);
-        updated = Persistence.trackedJourneys.getById(trackedJourney.id);
         String messageBody = updated.busNotificationMessages.get(routeId);
         UsRideGwinnettBusOpNotificationMessage message = getNotificationMessage(messageBody);
         assertEquals(1, message.msg_type);
+
+        busOperatorActions.handleCancelNotificationAction(travelerPosition);
+        updated = Persistence.trackedJourneys.getById(trackedJourney.id);
+        String cancelMessageBody = updated.busNotificationMessages.get(routeId);
+        UsRideGwinnettBusOpNotificationMessage cancelMessage = getNotificationMessage(cancelMessageBody);
+        assertEquals(0, cancelMessage.msg_type);
     }
 
     @Test

--- a/src/test/java/org/opentripplanner/middleware/triptracker/NotifyBusOperatorTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/NotifyBusOperatorTest.java
@@ -25,8 +25,8 @@ import org.opentripplanner.middleware.utils.Coordinates;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
 import java.io.IOException;
-import java.sql.Date;
 import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Stream;
@@ -103,32 +103,54 @@ class NotifyBusOperatorTest extends OtpMiddlewareTestEnvironment {
     }
 
     @Test
-    void canCancelBusOperatorNotification() throws JsonProcessingException {
+    void canCancelBusOperatorNotification() throws JsonProcessingException, InterruptedException {
         trackedJourney = createAndPersistTrackedJourney(getEndOfWalkLegCoordinates());
         TravelerPosition travelerPosition = new TravelerPosition(trackedJourney, walkToBusTransition, createOtpUser());
 
         busOperatorActions.handleSendNotificationAction(TripStatus.ON_SCHEDULE, travelerPosition);
         TrackedJourney updated = Persistence.trackedJourneys.getById(trackedJourney.id);
         assertTrue(updated.busNotificationMessages.containsKey(routeId));
-        String messageBody = updated.busNotificationMessages.get(routeId);
-        UsRideGwinnettBusOpNotificationMessage message = getNotificationMessage(messageBody);
-        assertEquals(1, message.msg_type);
+        assertEquals(1, getMessage(updated).msg_type);
 
         busOperatorActions.handleCancelNotificationAction(travelerPosition);
-        updated = Persistence.trackedJourneys.getById(trackedJourney.id);
-        String cancelMessageBody = updated.busNotificationMessages.get(routeId);
-        UsRideGwinnettBusOpNotificationMessage cancelMessage = getNotificationMessage(cancelMessageBody);
-        assertEquals(0, cancelMessage.msg_type);
+        UsRideGwinnettBusOpNotificationMessage cancelMessage1 = getMessage(
+            Persistence.trackedJourneys.getById(trackedJourney.id)
+        );
+        assertEquals(0, cancelMessage1.msg_type);
+
+
+        // A second request to cancel should not touch the previous request.
+        Thread.sleep(20);
+        busOperatorActions.handleCancelNotificationAction(travelerPosition);
+        UsRideGwinnettBusOpNotificationMessage cancelMessage2 = getMessage(
+            Persistence.trackedJourneys.getById(trackedJourney.id)
+        );
+        assertEquals(0, cancelMessage2.msg_type);
+        assertEquals(cancelMessage1.timestamp, cancelMessage2.timestamp);
+    }
+
+    private static UsRideGwinnettBusOpNotificationMessage getMessage(TrackedJourney updated) throws JsonProcessingException {
+        String messageBody = updated.busNotificationMessages.get(routeId);
+        return getNotificationMessage(messageBody);
     }
 
     @Test
-    void canNotifyBusOperatorOnlyOnce() {
+    void canNotifyBusOperatorOnlyOnce() throws InterruptedException, JsonProcessingException {
         trackedJourney = createAndPersistTrackedJourney(getEndOfWalkLegCoordinates());
         TravelerPosition travelerPosition = new TravelerPosition(trackedJourney, walkToBusTransition, createOtpUser());
+
         busOperatorActions.handleSendNotificationAction(TripStatus.ON_SCHEDULE, travelerPosition);
         TrackedJourney updated = Persistence.trackedJourneys.getById(trackedJourney.id);
         assertTrue(updated.busNotificationMessages.containsKey(routeId));
-        assertFalse(UsRideGwinnettNotifyBusOperator.hasNotSentNotificationForRoute(trackedJourney, routeId));
+        assertFalse(UsRideGwinnettNotifyBusOperator.hasNotSentNotificationForRoute(updated, routeId));
+        UsRideGwinnettBusOpNotificationMessage notifyMessage = getMessage(updated);
+
+        // A second request to notify the operator should not touch the previous request.
+        Thread.sleep(20);
+        busOperatorActions.handleSendNotificationAction(TripStatus.ON_SCHEDULE, travelerPosition);
+        TrackedJourney updated2 = Persistence.trackedJourneys.getById(trackedJourney.id);
+        assertFalse(UsRideGwinnettNotifyBusOperator.hasNotSentNotificationForRoute(updated2, routeId));
+        assertEquals(notifyMessage.timestamp, getMessage(updated2).timestamp);
     }
 
     @ParameterizedTest

--- a/src/test/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettNotifyBusOperatorTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettNotifyBusOperatorTest.java
@@ -1,0 +1,27 @@
+package org.opentripplanner.middleware.triptracker.interactions.busnotifiers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.middleware.models.TrackedJourney;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UsRideGwinnettNotifyBusOperatorTest {
+    @Test
+    void hasNotCanceledNotificationForRoute() throws JsonProcessingException {
+        TrackedJourney journey = new TrackedJourney();
+        // A request was sent to the bus driver on bus route 10.
+        journey.busNotificationMessages.put("Route10", "{\"msg_type\": 1}");
+        // A request was sent then canceled to the bus driver on bus route 20.
+        journey.busNotificationMessages.put("Route20", "{\"msg_type\": 0}");
+
+        assertTrue(UsRideGwinnettNotifyBusOperator.hasNotSentNotificationForRoute(journey, "Route30"));
+        assertThrows(IllegalStateException.class, () -> UsRideGwinnettNotifyBusOperator.hasNotCanceledNotificationForRoute(journey, "Route30"));
+
+        assertTrue(UsRideGwinnettNotifyBusOperator.hasNotCanceledNotificationForRoute(journey, "Route10"));
+
+        assertFalse(UsRideGwinnettNotifyBusOperator.hasNotCanceledNotificationForRoute(journey, "Route20"));
+    }
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes handling in bus operator notifications where cancellation requests were not sent. PR also improves existing tests against duplicate requests.
