### PR TITLE
fix(OtpDispatcher): Match request timeout to OTP with GraphQL timeout [OTP-878]

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcher.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/OtpDispatcher.java
@@ -37,7 +37,11 @@ public class OtpDispatcher {
      */
     public static final String OTP_GRAPHQL_ENDPOINT = getConfigPropertyAsText("OTP_GRAPHQL_ENDPOINT", "/routers/default/index/graphql");
 
-    private static final int OTP_SERVER_REQUEST_TIMEOUT_IN_SECONDS = 10;
+    /**
+     * Match the OTP GraphQL request timeout defined at
+     * https://github.com/opentripplanner/OpenTripPlanner/blob/176e5f51923e82f8a4c2aa2a0b8284e1497b4439/src/main/java/org/opentripplanner/apis/gtfs/GtfsGraphQLAPI.java#L54
+     */
+    private static final int OTP_SERVER_REQUEST_TIMEOUT_IN_SECONDS = 30;
 
     /**
      * Provides a response from the OTP server target service based on the query parameters provided.


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

This PR changes the timeout of OTP requests from 10s to 30s to match the timeout for GraphQL requests made by OTP.
