### PR TITLE
fix(TravelerLocator): Handle missing intermediateStops field from OTP

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -282,7 +282,9 @@ public class TravelerLocator {
     }
 
     private static List<Place> getIntermediateAndLastStop(Leg leg) {
-        ArrayList<Place> stops = new ArrayList<>(leg.intermediateStops);
+        ArrayList<Place> stops = leg.intermediateStops == null
+            ? new ArrayList<>()
+            : new ArrayList<>(leg.intermediateStops);
         stops.add(leg.to);
         return stops;
     }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve => Error log shown below.
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Sometimes, calls to the `track` endpoint will fail if transit legs in OTP responses don't contain the `intermediateStops` field (see log excerpt below). This PR addresses that.

```
java.lang.NullPointerException: null
	at java.base/java.util.ArrayList.<init>(ArrayList.java:179)
	at org.opentripplanner.middleware.triptracker.TravelerLocator.getIntermediateAndLastStop(TravelerLocator.java:285)
	at org.opentripplanner.middleware.triptracker.TravelerLocator.alignTravelerToTransitTrip(TravelerLocator.java:172)
	at org.opentripplanner.middleware.triptracker.TravelerLocator.getInstruction(TravelerLocator.java:72)
	at org.opentripplanner.middleware.triptracker.ManageTripTracking.doUpdateTracking(ManageTripTracking.java:76)
	at org.opentripplanner.middleware.triptracker.ManageTripTracking.startOrUpdateTracking(ManageTripTracking.java:103)
        ...
```
