### PR TITLE
Use OTP2 data for bus notifications, improve logging.

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/BusOperatorActions.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/BusOperatorActions.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import static org.opentripplanner.middleware.utils.ItineraryUtils.getAgencyIdFromLeg;
+import static org.opentripplanner.middleware.utils.ItineraryUtils.getAgencyGtfsIdFromLeg;
 import static org.opentripplanner.middleware.utils.ItineraryUtils.removeAgencyPrefix;
 
 /** Holds configured bus notification actions. */
@@ -49,7 +49,7 @@ public class BusOperatorActions {
      * Get the action that matches the given agency id.
      */
     public AgencyAction getAgencyAction(TravelerPosition travelerPosition) {
-        String agencyId = removeAgencyPrefix(getAgencyIdFromLeg(travelerPosition.nextLeg));
+        String agencyId = removeAgencyPrefix(getAgencyGtfsIdFromLeg(travelerPosition.nextLeg));
         if (agencyId != null) {
             for (AgencyAction agencyAction : agencyActions) {
                 if (agencyAction.agencyId.equalsIgnoreCase(agencyId)) {
@@ -73,6 +73,8 @@ public class BusOperatorActions {
                 LOG.error("Could not trigger class {} for agency {}", action.trigger, action.agencyId, e);
                 throw new RuntimeException(e);
             }
+        } else {
+            LOG.warn("No bus notification action was found for location {}.", travelerPosition.currentPosition);
         }
     }
 

--- a/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettBusOpNotificationMessage.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettBusOpNotificationMessage.java
@@ -10,10 +10,10 @@ import java.util.List;
 import java.util.Map;
 
 import static org.opentripplanner.middleware.utils.DateTimeUtils.getOtpZoneId;
-import static org.opentripplanner.middleware.utils.ItineraryUtils.getAgencyIdFromLeg;
-import static org.opentripplanner.middleware.utils.ItineraryUtils.getRouteIdFromLeg;
-import static org.opentripplanner.middleware.utils.ItineraryUtils.getStopIdFromPlace;
-import static org.opentripplanner.middleware.utils.ItineraryUtils.getTripIdFromLeg;
+import static org.opentripplanner.middleware.utils.ItineraryUtils.getAgencyGtfsIdFromLeg;
+import static org.opentripplanner.middleware.utils.ItineraryUtils.getRouteGtfsIdFromLeg;
+import static org.opentripplanner.middleware.utils.ItineraryUtils.getStopGtfsIdFromPlace;
+import static org.opentripplanner.middleware.utils.ItineraryUtils.getTripGtfsIdFromLeg;
 import static org.opentripplanner.middleware.utils.ItineraryUtils.removeAgencyPrefix;
 
 /**
@@ -81,15 +81,15 @@ public class UsRideGwinnettBusOpNotificationMessage {
     public UsRideGwinnettBusOpNotificationMessage(Instant currentTime, TravelerPosition travelerPosition) {
         var nextLeg = travelerPosition.nextLeg;
         this.timestamp = BUS_OPERATOR_NOTIFIER_API_DATE_FORMAT.format(currentTime.atZone(ZoneOffset.UTC));
-        this.agency_id = removeAgencyPrefix(getAgencyIdFromLeg(nextLeg));
-        this.from_route_id = removeAgencyPrefix(getRouteIdFromLeg(nextLeg));
-        this.from_trip_id = removeAgencyPrefix(getTripIdFromLeg(nextLeg));
-        this.from_stop_id = removeAgencyPrefix(getStopIdFromPlace(nextLeg.from));
+        this.agency_id = removeAgencyPrefix(getAgencyGtfsIdFromLeg(nextLeg));
+        this.from_route_id = removeAgencyPrefix(getRouteGtfsIdFromLeg(nextLeg));
+        this.from_trip_id = removeAgencyPrefix(getTripGtfsIdFromLeg(nextLeg));
+        this.from_stop_id = removeAgencyPrefix(getStopGtfsIdFromPlace(nextLeg.from));
         // For now, assume one notification request is made per transit leg.
         // TODO: Determine how interlined legs should be handled.
         this.to_route_id = this.from_route_id;
         this.to_trip_id = this.from_trip_id;
-        this.to_stop_id = removeAgencyPrefix(getStopIdFromPlace(nextLeg.to));
+        this.to_stop_id = removeAgencyPrefix(getStopGtfsIdFromPlace(nextLeg.to));
         this.from_arrival_time = BUS_OPERATOR_NOTIFIER_API_TIME_FORMAT.format(
             nextLeg.getScheduledStartTime()
         );

--- a/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettNotifyBusOperator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/interactions/busnotifiers/UsRideGwinnettNotifyBusOperator.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
-import static org.opentripplanner.middleware.utils.ItineraryUtils.getRouteIdFromLeg;
+import static org.opentripplanner.middleware.utils.ItineraryUtils.getRouteGtfsIdFromLeg;
 import static org.opentripplanner.middleware.utils.ItineraryUtils.isBusLeg;
 
 /**
@@ -80,7 +80,7 @@ public class UsRideGwinnettNotifyBusOperator implements BusOperatorInteraction {
      * Stage notification to bus operator by making sure all required conditions are met.
      */
     public void sendNotification(TripStatus tripStatus, TravelerPosition travelerPosition) {
-        var routeId = getRouteIdFromLeg(travelerPosition.nextLeg);
+        var routeId = getRouteGtfsIdFromLeg(travelerPosition.nextLeg);
         try {
             if (
                 hasNotSentNotificationForRoute(travelerPosition.trackedJourney, routeId) &&
@@ -101,7 +101,7 @@ public class UsRideGwinnettNotifyBusOperator implements BusOperatorInteraction {
      * Cancel a previously sent notification for the next bus leg.
      */
     public void cancelNotification(TravelerPosition travelerPosition) {
-        var routeId = getRouteIdFromLeg(travelerPosition.nextLeg);
+        var routeId = getRouteGtfsIdFromLeg(travelerPosition.nextLeg);
         try {
             if (
                 isBusLeg(travelerPosition.nextLeg) && routeId != null &&
@@ -128,6 +128,8 @@ public class UsRideGwinnettNotifyBusOperator implements BusOperatorInteraction {
      * Makes a call to the bus driver notification API, followed by a call to the bus priority API.
      */
     private static void makeApiRequests(TravelerPosition travelerPosition, String body, String routeId, String action) {
+        LOG.info("Sending bus operator/priority requests: {}", body);
+
         var httpStatus = postBusDriverNotification(body);
         if (httpStatus == HttpStatus.OK_200) {
             travelerPosition.trackedJourney.updateNotificationMessage(routeId, body);

--- a/src/main/java/org/opentripplanner/middleware/utils/ItineraryUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/ItineraryUtils.java
@@ -327,37 +327,37 @@ public class ItineraryUtils {
     }
 
     /**
-     * Get the route id from leg.
+     * Get the route GTFS id from leg.
      */
-    public static String getRouteIdFromLeg(Leg leg) {
-        return (leg != null) ? leg.routeId : null;
+    public static String getRouteGtfsIdFromLeg(Leg leg) {
+        return (leg != null && leg.route != null) ? leg.route.gtfsId : null;
     }
 
     /**
-     * Get the agency id from leg.
+     * Get the agency GTFS id from leg.
      */
-    public static String getAgencyIdFromLeg(Leg leg) {
-        return (leg != null) ? leg.agencyId : null;
+    public static String getAgencyGtfsIdFromLeg(Leg leg) {
+        return (leg != null && leg.agency != null) ? leg.agency.gtfsId : null;
     }
 
     /**
-     * Get the trip id from leg.
+     * Get the trip GTFS id from leg.
      */
-    public static String getTripIdFromLeg(Leg leg) {
-        return (leg != null) ? leg.tripId : null;
+    public static String getTripGtfsIdFromLeg(Leg leg) {
+        return (leg != null && leg.trip != null) ? leg.trip.gtfsId : null;
     }
 
     /**
-     * Get the stop id from place.
+     * Get the stop GTFS id from place.
      */
-    public static String getStopIdFromPlace(Place place) {
-        return (place != null) ? place.stopId : null;
+    public static String getStopGtfsIdFromPlace(Place place) {
+        return (place != null && place.stop != null) ? place.stop.gtfsId : null;
     }
 
     /**
      * Get the route short name from leg.
      */
     public static String getRouteShortNameFromLeg(Leg leg) {
-        return leg.routeShortName;
+        return (leg != null && leg.route != null) ? leg.route.shortName : null;
     }
 }

--- a/src/test/resources/org/opentripplanner/middleware/controllers/api/27nb-midtown-to-ansley.json
+++ b/src/test/resources/org/opentripplanner/middleware/controllers/api/27nb-midtown-to-ansley.json
@@ -38,9 +38,14 @@
           "lat": 33.78645,
           "departure": 1718295483000,
           "vertexType": "TRANSIT",
-          "stopId": "MARTA:69356",
-          "arrival": 1718295183000,
-          "stopCode": "902581"
+          "stop": {
+            "id": "WEFU311FTYPS",
+            "gtfsId": "MARTA:69356",
+            "code": "902581",
+            "lon": -84.381713,
+            "lat": 33.78645
+          },
+          "arrival": 1718295183000
         },
         "legGeometry": {
           "points": "a|emE`t_bO?B@l@?`A?`@I?",
@@ -79,11 +84,14 @@
           "lat": 33.78645,
           "departure": 1718295483000,
           "vertexType": "TRANSIT",
-          "stopId": "MARTA:69356",
-          "arrival": 1718295183000,
-          "stopIndex": 3,
-          "stopSequence": 4,
-          "stopCode": "902581"
+          "stop": {
+            "id": "WEFU311FTYPS",
+            "gtfsId": "MARTA:69356",
+            "code": "902581",
+            "lon": -84.381713,
+            "lat": 33.78645
+          },
+          "arrival": 1718295183000
         },
         "to": {
           "name": "Piedmont Ave NE at Monroe Dr",
@@ -91,11 +99,14 @@
           "lat": 33.795571,
           "departure": 1718295780000,
           "vertexType": "TRANSIT",
-          "stopId": "MARTA:99973628",
-          "arrival": 1718295780000,
-          "stopIndex": 11,
-          "stopSequence": 12,
-          "stopCode": "213258"
+          "stop": {
+            "id": "GRWORJF55FD7",
+            "gtfsId": "MARTA:99973628",
+            "code": "213258",
+            "lon": -84.370392,
+            "lat": 33.795571
+          },
+          "arrival": 1718295780000
         },
         "legGeometry": {
           "points": "q|emEvx_bO?o@?a@DqJ??@eA?e@C_DS?gBA??C?_AA_@Iq@c@e@g@OQSQEG??SWeBoB_@c@k@o@??IMm@q@{@_AiCsBeFuD??MKWWm@c@_C{BoAkA??QQ_C{Bk@m@{AuAA???cC}BqAsA",
@@ -110,11 +121,14 @@
             "lat": 33.786415,
             "departure": 1718295521000,
             "vertexType": "TRANSIT",
-            "stopId": "MARTA:99972303",
-            "arrival": 1718295521000,
-            "stopIndex": 4,
-            "stopSequence": 5,
-            "stopCode": "211955"
+            "stop": {
+              "id": "WEFAETHHHDEE",
+              "gtfsId": "MARTA:99972303",
+              "code": "211955",
+              "lon": -84.379461,
+              "lat": 33.786415
+            },
+            "arrival": 1718295521000
           },
           {
             "name": "Piedmont Ave NE at 14th St NE",
@@ -122,11 +136,14 @@
             "lat": 33.78709,
             "departure": 1718295556000,
             "vertexType": "TRANSIT",
-            "stopId": "MARTA:69325",
-            "arrival": 1718295556000,
-            "stopIndex": 5,
-            "stopSequence": 6,
-            "stopCode": "902521"
+            "stop": {
+              "id": "REEGAKEI3432",
+              "gtfsId": "MARTA:69325",
+              "code": "902521",
+              "lon": -84.37807,
+              "lat": 33.78709
+            },
+            "arrival": 1718295556000
           },
           {
             "name": "Piedmont Ave NE at 15th St NE",
@@ -134,11 +151,14 @@
             "lat": 33.788224,
             "departure": 1718295583000,
             "vertexType": "TRANSIT",
-            "stopId": "MARTA:69326",
-            "arrival": 1718295583000,
-            "stopIndex": 6,
-            "stopSequence": 7,
-            "stopCode": "902522"
+            "stop": {
+              "id": "DET6UI8DSHU",
+              "gtfsId": "MARTA:69326",
+              "code": "902522",
+              "lon": -84.377418,
+              "lat": 33.788224
+            },
+            "arrival": 1718295583000
           },
           {
             "name": "Piedmont Ave NE at Prado",
@@ -146,11 +166,14 @@
             "lat": 33.7892,
             "departure": 1718295610000,
             "vertexType": "TRANSIT",
-            "stopId": "MARTA:69328",
-            "arrival": 1718295610000,
-            "stopIndex": 7,
-            "stopSequence": 8,
-            "stopCode": "902523"
+            "stop": {
+              "id": "EWWRTG82FRRHS",
+              "gtfsId": "MARTA:69328",
+              "code": "902523",
+              "lon": -84.376309,
+              "lat": 33.7892
+            },
+            "arrival": 1718295610000
           },
           {
             "name": "Piedmont Ave NE at The Prado",
@@ -158,11 +181,14 @@
             "lat": 33.791636,
             "departure": 1718295672000,
             "vertexType": "TRANSIT",
-            "stopId": "MARTA:69330",
-            "arrival": 1718295672000,
-            "stopIndex": 8,
-            "stopSequence": 9,
-            "stopCode": "902524"
+            "stop": {
+              "id": "HEATTTQE11FRBG",
+              "gtfsId": "MARTA:69330",
+              "code": "902524",
+              "lon": -84.374179,
+              "lat": 33.791636
+            },
+            "arrival": 1718295672000
           },
           {
             "name": "Piedmont Ave NE at Westminster Dr NE",
@@ -170,11 +196,14 @@
             "lat": 33.793095,
             "departure": 1718295710000,
             "vertexType": "TRANSIT",
-            "stopId": "MARTA:69332",
-            "arrival": 1718295710000,
-            "stopIndex": 9,
-            "stopSequence": 10,
-            "stopCode": "902528"
+            "stop": {
+              "id": "RRHSRG3122HSW",
+              "gtfsId": "MARTA:69332",
+              "code": "902528",
+              "lon": -84.37282,
+              "lat": 33.793095
+            },
+            "arrival": 1718295710000
           },
           {
             "name": "Piedmont Ave NE at Avery Dr NE",
@@ -182,26 +211,38 @@
             "lat": 33.79451,
             "departure": 1718295747000,
             "vertexType": "TRANSIT",
-            "stopId": "MARTA:69334",
-            "arrival": 1718295747000,
-            "stopIndex": 10,
-            "stopSequence": 11,
-            "stopCode": "902529"
+            "stop": {
+              "id": "TUU78KIEGSH33",
+              "gtfsId": "MARTA:69334",
+              "code": "902529",
+              "lon": -84.371451,
+              "lat": 33.79451
+            },
+            "arrival": 1718295747000
           }
         ],
         "steps": [],
-        "agencyName": "Metropolitan Atlanta Rapid Transit Authority",
-        "agencyUrl": "https://www.itsmarta.com",
-        "routeType": 3,
-        "routeId": "MARTA:21634",
-        "agencyId": "MARTA:MARTA",
-        "tripBlockId": "1153735",
-        "tripId": "MARTA:9101693",
+        "agency": {
+          "id": "KEJA42D21ERT",
+          "gtfsId": "MARTA:MARTA",
+          "name": "Metropolitan Atlanta Rapid Transit Authority",
+          "url": "https://www.itsmarta.com"
+        },
+        "route": {
+          "color": "FF0080",
+          "id": "UWRFADT5DS23",
+          "gtfsId": "MARTA:21634",
+          "longName": "Cheshire Bridge Road",
+          "shortName": "27",
+          "textColor": "000000",
+          "type": 3
+        },
+        "trip": {
+          "id": "HIENA23DAJM1Q",
+          "gtfsId": "MARTA:9101693",
+          "blockId": "1153735"
+        },
         "serviceDate": "2024-06-13",
-        "routeShortName": "27",
-        "routeLongName": "Cheshire Bridge Road",
-        "routeColor": "FF0080",
-        "routeTextColor": "000000",
         "headsign": "Lenox Station"
       },
       {
@@ -220,9 +261,14 @@
           "lat": 33.795571,
           "departure": 1718295780000,
           "vertexType": "TRANSIT",
-          "stopId": "MARTA:99973628",
-          "arrival": 1718295780000,
-          "stopCode": "213258"
+          "stop": {
+            "id": "GRWORJF55FD7",
+            "gtfsId": "MARTA:99973628",
+            "code": "213258",
+            "lon": -84.370392,
+            "lat": 33.795571
+          },
+          "arrival": 1718295780000
         },
         "to": {
           "name": "Ansley Mall Pet Shop",


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

More or less a subset of #263.

This PR updates bus notification code to use route and trip data from OTP2 data structures, and improves logging when sending bus notifications.
