### PR TITLE
OTP-1458 Provide traveler with continue instruction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,13 +125,6 @@
             <version>2.7</version>
         </dependency>
 
-        <!-- Use for better object state checking. -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.17.0</version>
-        </dependency>
-
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,13 @@
             <version>2.7</version>
         </dependency>
 
+        <!-- Use for better object state checking. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.17.0</version>
+        </dependency>
+
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.NO_INSTRUCTION;
 import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.TRIP_INSTRUCTION_IMMEDIATE_RADIUS;
 import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.TRIP_INSTRUCTION_UPCOMING_RADIUS;
@@ -194,30 +193,47 @@ public class TravelerLocator {
                 locale
             );
         }
-        return (travelerHasDeviated || (isNotEmpty(tripInstruction) && tripInstruction.hasInstruction()))
+        return (travelerHasDeviated || (tripInstruction != null && tripInstruction.hasInstruction()))
             ? tripInstruction
             : getContinueInstruction(travelerPosition, nextStep, locale);
     }
 
     /**
      * Traveler is on track, but no immediate instruction is available. Provide a "continue on street" reassurance
-     * instruction providing they are on a walk leg. This will be based on the current or previous step depending on the
-     * traveler's relative position to the next leg.
+     * instruction if the traveler is on a walk leg. This will be based on the next or previous step depending on the
+     * traveler's relative position to both.
      */
     private static ContinueInstruction getContinueInstruction(
         TravelerPosition travelerPosition,
         Step nextStep,
         Locale locale
     ) {
-        if (!travelerPosition.expectedLeg.transitLeg && nextStep != null) {
-            Step currentStep = isPositionPastStep(travelerPosition, nextStep)
-                ? nextStep :
-                getPreviousStep(travelerPosition.expectedLeg.steps, nextStep);
-            if (currentStep != null) {
-                return new ContinueInstruction(currentStep, locale);
+        if (
+            Boolean.TRUE.equals(!travelerPosition.expectedLeg.transitLeg) &&
+            travelerPosition.expectedLeg.steps != null &&
+            !travelerPosition.expectedLeg.steps.isEmpty()
+        ) {
+            Step previousStep = getPreviousStep(travelerPosition.expectedLeg.steps, nextStep);
+            if (previousStep != null) {
+                boolean travelerBetweenSteps = isPointBetween(previousStep.toCoordinates(), nextStep.toCoordinates(), travelerPosition.currentPosition);
+                if (travelerBetweenSteps) {
+                    return new ContinueInstruction(previousStep, locale);
+                } else if (isWithinStepRange(travelerPosition, previousStep)) {
+                    return new ContinueInstruction(previousStep, locale);
+                } else if (isWithinStepRange(travelerPosition, nextStep)) {
+                    return new ContinueInstruction(nextStep, locale);
+                }
             }
         }
         return null;
+    }
+
+    /**
+     * The traveler is still with the provided step range.
+     */
+    private static boolean isWithinStepRange(TravelerPosition travelerPosition, Step step) {
+        double distanceFromTravelerToStep = getDistance(travelerPosition.currentPosition, step.toCoordinates());
+        return distanceFromTravelerToStep < step.distance;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -4,6 +4,7 @@ import io.leonard.PolylineUtils;
 import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.Place;
 import org.opentripplanner.middleware.otp.response.Step;
+import org.opentripplanner.middleware.triptracker.instruction.ContinueInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.DeviatedInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.GetOffHereTransitInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.GetOffNextStopTransitInstruction;
@@ -27,7 +28,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.NO_INSTRUCTION;
 import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.TRIP_INSTRUCTION_IMMEDIATE_RADIUS;
 import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.TRIP_INSTRUCTION_UPCOMING_RADIUS;
@@ -59,7 +62,7 @@ public class TravelerLocator {
     ) {
         if (hasRequiredWalkLeg(travelerPosition)) {
             if (hasRequiredTripStatus(tripStatus)) {
-                TripInstruction tripInstruction = alignTravelerToTrip(travelerPosition, isStartOfTrip);
+                TripInstruction tripInstruction = alignTravelerToTrip(travelerPosition, isStartOfTrip, false);
                 if (tripInstruction != null) {
                     return tripInstruction.build();
                 }
@@ -124,7 +127,7 @@ public class TravelerLocator {
         TravelerPosition travelerPosition,
         boolean isStartOfTrip
     ) {
-        TripInstruction instruction = alignTravelerToTrip(travelerPosition, isStartOfTrip);
+        TripInstruction instruction = alignTravelerToTrip(travelerPosition, isStartOfTrip, true);
         if (instruction != null && instruction.hasInstruction()) {
             return instruction;
         }
@@ -169,7 +172,8 @@ public class TravelerLocator {
     @Nullable
     public static TripInstruction alignTravelerToTrip(
         TravelerPosition travelerPosition,
-        boolean isStartOfTrip
+        boolean isStartOfTrip,
+        boolean travelerHasDeviated
     ) {
         Locale locale = travelerPosition.locale;
 
@@ -182,14 +186,53 @@ public class TravelerLocator {
         }
 
         Step nextStep = snapToWaypoint(travelerPosition, travelerPosition.expectedLeg.steps);
+        TripInstruction tripInstruction = null;
         if (nextStep != null && (!isPositionPastStep(travelerPosition, nextStep) || isStartOfTrip)) {
-            return new OnTrackInstruction(
+            tripInstruction = new OnTrackInstruction(
                 getDistance(travelerPosition.currentPosition, new Coordinates(nextStep)),
                 nextStep,
                 locale
             );
         }
+        return (travelerHasDeviated || (isNotEmpty(tripInstruction) && tripInstruction.hasInstruction()))
+            ? tripInstruction
+            : getContinueInstruction(travelerPosition, nextStep, locale);
+    }
+
+    /**
+     * Traveler is on track, but no immediate instruction is available. Provide a "continue on street" reassurance
+     * instruction providing they are on a walk leg. This will be based on the current or previous step depending on the
+     * traveler's relative position to the next leg.
+     */
+    private static ContinueInstruction getContinueInstruction(
+        TravelerPosition travelerPosition,
+        Step nextStep,
+        Locale locale
+    ) {
+        if (!travelerPosition.expectedLeg.transitLeg && nextStep != null) {
+            Step currentStep = isPositionPastStep(travelerPosition, nextStep)
+                ? nextStep :
+                getPreviousStep(travelerPosition.expectedLeg.steps, nextStep);
+            if (currentStep != null) {
+                return new ContinueInstruction(currentStep, locale);
+            }
+        }
         return null;
+    }
+
+    /**
+     * Get the step prior to the next step provided.
+     */
+    private static Step getPreviousStep(List<Step> steps, Step nextStep) {
+        if (steps.get(0).equals(nextStep)) {
+            return null;
+        }
+        Optional<Step> previousStep = IntStream
+            .range(0, steps.size())
+            .filter(i -> steps.get(i).equals(nextStep))
+            .mapToObj(i -> steps.get(i - 1))
+            .findFirst();
+        return previousStep.orElse(null);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/ContinueInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/ContinueInstruction.java
@@ -1,10 +1,9 @@
 package org.opentripplanner.middleware.triptracker.instruction;
 
+import org.apache.logging.log4j.util.Strings;
 import org.opentripplanner.middleware.otp.response.Step;
 
 import java.util.Locale;
-
-import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 
 public class ContinueInstruction extends SelfLegInstruction {
     public ContinueInstruction(Step legStep, Locale locale) {
@@ -14,7 +13,7 @@ public class ContinueInstruction extends SelfLegInstruction {
 
     @Override
     public String build() {
-        if (isNotEmpty(legStep) && isNotEmpty(legStep.streetName)) {
+        if (legStep != null && !Strings.isBlank(legStep.streetName)) {
             // TODO: i18n
             return String.format("Continue on %s", legStep.streetName);
         }

--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/ContinueInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/ContinueInstruction.java
@@ -1,0 +1,23 @@
+package org.opentripplanner.middleware.triptracker.instruction;
+
+import org.opentripplanner.middleware.otp.response.Step;
+
+import java.util.Locale;
+
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+
+public class ContinueInstruction extends SelfLegInstruction {
+    public ContinueInstruction(Step legStep, Locale locale) {
+        this.legStep = legStep;
+        this.locale = locale;
+    }
+
+    @Override
+    public String build() {
+        if (isNotEmpty(legStep) && isNotEmpty(legStep.streetName)) {
+            // TODO: i18n
+            return String.format("Continue on %s", legStep.streetName);
+        }
+        return NO_INSTRUCTION;
+    }
+}

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -351,7 +351,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
             Arguments.of(
                 monitoredTrip,
                 createPoint(firstStepCoords, 20, WEST_BEARING),
-                new ContinueInstruction(virginiaCircleNortheastStep, locale).build(),
+                new ContinueInstruction(adairAvenueNortheastStep, locale).build(),
                 TripStatus.ON_SCHEDULE,
                 "Coords along a step should produce a continue on street instruction"
             ),

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -16,6 +16,7 @@ import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.models.TrackedJourney;
 import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.otp.response.Leg;
+import org.opentripplanner.middleware.otp.response.Step;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.testutils.ApiTestUtils;
 import org.opentripplanner.middleware.testutils.CommonTestUtils;
@@ -27,6 +28,10 @@ import org.opentripplanner.middleware.triptracker.ManageTripTracking;
 import org.opentripplanner.middleware.triptracker.TrackingLocation;
 import org.opentripplanner.middleware.triptracker.TripStatus;
 import org.opentripplanner.middleware.triptracker.TripTrackingData;
+import org.opentripplanner.middleware.triptracker.instruction.ContinueInstruction;
+import org.opentripplanner.middleware.triptracker.instruction.DeviatedInstruction;
+import org.opentripplanner.middleware.triptracker.instruction.OnTrackInstruction;
+import org.opentripplanner.middleware.triptracker.instruction.WaitForTransitInstruction;
 import org.opentripplanner.middleware.triptracker.payload.EndTrackingPayload;
 import org.opentripplanner.middleware.triptracker.payload.ForceEndTrackingPayload;
 import org.opentripplanner.middleware.triptracker.payload.StartTrackingPayload;
@@ -39,10 +44,12 @@ import org.opentripplanner.middleware.utils.DateTimeUtils;
 import org.opentripplanner.middleware.utils.HttpResponseValues;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -288,88 +295,105 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         final int NORTH_WEST_BEARING = 315;
         final int NORTH_EAST_BEARING = 45;
         final int WEST_BEARING = 270;
+        final Locale locale = Locale.US;
 
         Leg firstLeg = itinerary.legs.get(0);
-        Coordinates firstStepCoords = new Coordinates(firstLeg.steps.get(0));
-        Coordinates thirdStepCoords = new Coordinates(firstLeg.steps.get(2));
+        Step adairAvenueNortheastStep = firstLeg.steps.get(0);
+        Step virginiaCircleNortheastStep = firstLeg.steps.get(1);
+        Step ponceDeLeonPlaceNortheastStep = firstLeg.steps.get(2);
+        Coordinates firstStepCoords = new Coordinates(adairAvenueNortheastStep);
+        Coordinates thirdStepCoords = new Coordinates(ponceDeLeonPlaceNortheastStep);
         Coordinates destinationCoords = new Coordinates(firstLeg.to);
+        String monroeDrDestinationName = firstLeg.to.name;
 
         Leg multiItinFirstLeg = multiLegItinerary.legs.get(0);
-        Coordinates multiItinFirstLegDestCoords = new Coordinates(multiItinFirstLeg.to);
         Leg multiItinLastLeg = multiLegItinerary.legs.get(multiLegItinerary.legs.size() - 1);
+        Leg multiItinBusLeg = multiLegItinerary.legs.get(multiLegItinerary.legs.size() - 2);
+        Coordinates multiItinFirstLegDestCoords = new Coordinates(multiItinFirstLeg.to);
         Coordinates multiItinLastLegDestCoords = new Coordinates(multiItinLastLeg.to);
+        String ansleyMallPetShopDestinationName = multiItinLastLeg.to.name;
 
         return Stream.of(
             Arguments.of(
                 monitoredTrip,
                 createPoint(firstStepCoords, 1, NORTH_EAST_BEARING),
-                "IMMEDIATE: Head WEST on Adair Avenue Northeast",
+                new OnTrackInstruction(1, adairAvenueNortheastStep, locale).build(),
                 TripStatus.ON_SCHEDULE,
                 "Coords near first step should produce relevant instruction"
             ),
             Arguments.of(
                 monitoredTrip,
                 createPoint(firstStepCoords, 4, NORTH_EAST_BEARING),
-                "UPCOMING: Head WEST on Adair Avenue Northeast",
+                new OnTrackInstruction(4, adairAvenueNortheastStep, locale).build(),
                 TripStatus.DEVIATED,
                 "Coords deviated but near first step should produce relevant instruction"
             ),
             Arguments.of(
                 monitoredTrip,
                 createPoint(firstStepCoords, 30, NORTH_EAST_BEARING),
-                "Head to Adair Avenue Northeast",
+                new DeviatedInstruction(adairAvenueNortheastStep.streetName, locale).build(),
                 TripStatus.DEVIATED,
                 "Deviated coords near first step should produce instruction to head to first step #1"
             ),
             Arguments.of(
                 monitoredTrip,
                 createPoint(firstStepCoords, 15, NORTH_WEST_BEARING),
-                "Head to Adair Avenue Northeast",
+                new DeviatedInstruction(adairAvenueNortheastStep.streetName, locale).build(),
                 TripStatus.DEVIATED,
                 "Deviated coords near first step should produce instruction to head to first step #2"
             ),
             Arguments.of(
                 monitoredTrip,
                 createPoint(firstStepCoords, 20, WEST_BEARING),
-                NO_INSTRUCTION,
+                new ContinueInstruction(virginiaCircleNortheastStep, locale).build(),
                 TripStatus.ON_SCHEDULE,
-                "Coords along a step should produce no instruction"
+                "Coords along a step should produce a continue on street instruction"
             ),
             Arguments.of(
                 monitoredTrip,
                 thirdStepCoords,
-                "IMMEDIATE: LEFT on Ponce de Leon Place Northeast",
+                new OnTrackInstruction(0, ponceDeLeonPlaceNortheastStep, locale).build(),
                 TripStatus.AHEAD_OF_SCHEDULE,
                 "Coords near a not-first step should produce relevant instruction"
             ),
             Arguments.of(
                 monitoredTrip,
                 createPoint(thirdStepCoords, 30, NORTH_WEST_BEARING),
-                "Head to Ponce de Leon Place Northeast",
+                new DeviatedInstruction(ponceDeLeonPlaceNortheastStep.streetName, locale).build(),
                 TripStatus.DEVIATED,
                 "Deviated coords near a not-first step should produce instruction to head to step"
             ),
             Arguments.of(
                 monitoredTrip,
                 createPoint(destinationCoords, 1, NORTH_WEST_BEARING),
-                "ARRIVED: Monroe Dr NE at Cooledge Ave NE",
+                new OnTrackInstruction(2, monroeDrDestinationName, locale).build(),
                 TripStatus.COMPLETED,
                 "Instructions for destination coordinate"
             ),
             Arguments.of(
                 multiLegMonitoredTrip,
                 createPoint(multiItinFirstLegDestCoords, 1.5, WEST_BEARING),
-                // Time is in US Pacific time zone (instead of US Eastern) by configuration for other E2E tests.
-                "Wait 6 minutes for your bus, route 27, scheduled at 9:18 AM, on time",
+                new WaitForTransitInstruction(
+                    multiItinBusLeg,
+                    multiItinBusLeg.getScheduledStartTime().toInstant().minus(Duration.ofMinutes(6)),
+                    locale)
+                    .build(),
                 TripStatus.AHEAD_OF_SCHEDULE,
                 "Arriving ahead of schedule to a bus stop at the end of first leg."
             ),
             Arguments.of(
                 multiLegMonitoredTrip,
                 createPoint(multiItinLastLegDestCoords, 1, NORTH_WEST_BEARING),
-                "ARRIVED: Ansley Mall Pet Shop",
+                new OnTrackInstruction(1, ansleyMallPetShopDestinationName, locale).build(),
                 TripStatus.COMPLETED,
                 "Instructions for destination coordinate of multi-leg trip"
+            ),
+            Arguments.of(
+                monitoredTrip,
+                createPoint(thirdStepCoords, 1000, NORTH_WEST_BEARING),
+                NO_INSTRUCTION,
+                TripStatus.DEVIATED,
+                "Deviated significantly from nearest step should produce no instruction"
             )
         );
     }

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -51,6 +51,7 @@ public class ManageLegTraversalTest {
     private static Itinerary midtownToAnsleyItinerary;
     private static List<Place> midtownToAnsleyIntermediateStops;
     private static Itinerary firstLegBusTransit;
+    private static Itinerary baptistChurchToEastCroganStreetIntinerary;
 
     private static final Locale locale = Locale.US;
 
@@ -77,6 +78,10 @@ public class ManageLegTraversalTest {
         );
         firstLegBusTransit = JsonUtils.getPOJOFromJSON(
             CommonTestUtils.getTestResourceAsString("controllers/api/first-leg-transit.json"),
+            Itinerary.class
+        );
+        baptistChurchToEastCroganStreetIntinerary = JsonUtils.getPOJOFromJSON(
+            CommonTestUtils.getTestResourceAsString("controllers/api/baptist-church-to-east-crogan-street.json"),
             Itinerary.class
         );
         // Hold on to the original list of intermediate stops (some tests will overwrite it)
@@ -209,6 +214,11 @@ public class ManageLegTraversalTest {
         Coordinates busStopCoords = new Coordinates(firstBusLeg.from);
         String busStopName = firstBusLeg.from.name;
 
+        Leg toEastCroganFirstLeg = baptistChurchToEastCroganStreetIntinerary.legs.get(0);
+        Step southClaytonSt = toEastCroganFirstLeg.steps.get(1);
+        Step eastCroganSt = toEastCroganFirstLeg.steps.get(2);
+        Coordinates pointOnSouthClaytonSt = new Coordinates(33.955561, -83.988204);
+
         return Stream.of(
             Arguments.of(
                 firstBusLeg,
@@ -271,7 +281,7 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     createPoint(virginiaCircleNortheastCoords, 12, SOUTH_WEST_BEARING),
-                    new ContinueInstruction(ponceDeLeonPlaceNortheastStep, locale).build(),
+                    new ContinueInstruction(virginiaCircleNortheastStep, locale).build(),
                     false,
                     "On track approaching second step, provide continue instruction."
                 )
@@ -358,6 +368,33 @@ public class ManageLegTraversalTest {
                     new OnTrackInstruction(2, destinationName, locale).build(),
                     false,
                     "On destination instruction."
+                )
+            ),
+            Arguments.of(
+                toEastCroganFirstLeg,
+                new TraceData(
+                    pointOnSouthClaytonSt,
+                    new ContinueInstruction(southClaytonSt, locale).build(),
+                    false,
+                    "On track passed second step and not near to next step, provide continue instruction for second step."
+                )
+            ),
+            Arguments.of(
+                toEastCroganFirstLeg,
+                new TraceData(
+                    createPoint(pointOnSouthClaytonSt, 12, NORTH_WEST_BEARING),
+                    new ContinueInstruction(southClaytonSt, locale).build(),
+                    false,
+                    "On track a bit near to the next step, provide continue instruction for second step."
+                )
+            ),
+            Arguments.of(
+                toEastCroganFirstLeg,
+                new TraceData(
+                    createPoint(pointOnSouthClaytonSt, 72, NORTH_BEARING),
+                    new ContinueInstruction(eastCroganSt, locale).build(),
+                    false,
+                    "On track passed next step, provide continue instruction for next step."
                 )
             )
         );

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -15,6 +15,7 @@ import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.Place;
 import org.opentripplanner.middleware.otp.response.Step;
 import org.opentripplanner.middleware.testutils.CommonTestUtils;
+import org.opentripplanner.middleware.triptracker.instruction.ContinueInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.DeviatedInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.OnTrackInstruction;
 import org.opentripplanner.middleware.utils.ConfigUtils;
@@ -270,9 +271,9 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     createPoint(virginiaCircleNortheastCoords, 12, SOUTH_WEST_BEARING),
-                    NO_INSTRUCTION,
+                    new ContinueInstruction(ponceDeLeonPlaceNortheastStep, locale).build(),
                     false,
-                    "On track approaching second step, but not close enough for instruction."
+                    "On track approaching second step, provide continue instruction."
                 )
             ),
             Arguments.of(
@@ -336,9 +337,9 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     createPoint(pointAfterTurn, 0, calculateBearing(pointAfterTurn, virginiaAvenuePoint)),
-                    NO_INSTRUCTION,
+                    new ContinueInstruction(virginiaAvenueNortheastStep, locale).build(),
                     false,
-                    "After turn left on to Virginia Avenue should not produce turn instruction."
+                    "After turn left on to Virginia Avenue should provide continue instruction."
                 )
             ),
             Arguments.of(

--- a/src/test/resources/org/opentripplanner/middleware/controllers/api/baptist-church-to-east-crogan-street.json
+++ b/src/test/resources/org/opentripplanner/middleware/controllers/api/baptist-church-to-east-crogan-street.json
@@ -1,0 +1,107 @@
+{
+  "duration": 478,
+  "startTime": 1731606660000,
+  "endTime": 1731607138000,
+  "walkTime": 478,
+  "transitTime": 0,
+  "waitingTime": 0,
+  "walkDistance": 0,
+  "walkLimitExceeded": false,
+  "elevationLost": 0,
+  "elevationGained": 0,
+  "transfers": 0,
+  "fare": null,
+  "legs": [
+    {
+      "startTime": 1731606660000,
+      "endTime": 1731607138000,
+      "departureDelay": 0,
+      "arrivalDelay": 0,
+      "realTime": false,
+      "distance": 636.31,
+      "mode": "WALK",
+      "interlineWithPreviousLeg": false,
+      "from": {
+        "name": "First Baptist Church of Lawrenceville, Lawrenceville, GA, USA",
+        "lon": -83.9881534,
+        "lat": 33.9549491,
+        "vertexType": "NORMAL"
+      },
+      "to": {
+        "name": "49 East Crogan Street, Lawrenceville, GA, USA",
+        "lon": -83.9833418,
+        "lat": 33.9565218,
+        "vertexType": "NORMAL"
+      },
+      "legGeometry": {
+        "points": "myfnEz|r_OG@G?A?wBLI?I@_@?{@DG?Ek@GeBCk@G?I?I?A?AK?G?E?a@?]?AAE?G?M?M?E?EGwB?EAEAGAC?A@?@Y@[?C@@H@L@@?ACAAAKAQ?U?KAKAeA?O?K?KA]?K?KAg@?IAO?KE{B",
+        "length": 62
+      },
+      "rentedBike": false,
+      "transitLeg": false,
+      "duration": 478,
+      "steps": [
+        {
+          "distance": 10.11,
+          "relativeDirection": "DEPART",
+          "streetName": "crossing over Luckie Street☆☆☆",
+          "absoluteDirection": "NORTH",
+          "stayOn": false,
+          "area": false,
+          "lon": -83.9881362,
+          "lat": 33.9549515
+        },
+        {
+          "distance": 134.71,
+          "relativeDirection": "CONTINUE",
+          "streetName": "South Clayton Street★★★",
+          "absoluteDirection": "NORTH",
+          "stayOn": false,
+          "area": false,
+          "lon": -83.9881458,
+          "lat": 33.955042
+        },
+        {
+          "distance": 88.77,
+          "relativeDirection": "RIGHT",
+          "streetName": "East Crogan Street★★★",
+          "absoluteDirection": "EAST",
+          "stayOn": true,
+          "area": false,
+          "lon": -83.9882578,
+          "lat": 33.9562495
+        },
+        {
+          "distance": 17.43,
+          "relativeDirection": "LEFT",
+          "streetName": "crossing over East Crogan Street☆☆☆",
+          "absoluteDirection": "NORTH",
+          "stayOn": true,
+          "area": false,
+          "lon": -83.9873003,
+          "lat": 33.9563302
+        },
+        {
+          "distance": 177.64,
+          "relativeDirection": "RIGHT",
+          "streetName": "East Crogan Street★★★",
+          "absoluteDirection": "EAST",
+          "stayOn": false,
+          "area": false,
+          "lon": -83.9873097,
+          "lat": 33.9564868
+        },
+        {
+          "distance": 207.65,
+          "relativeDirection": "LEFT",
+          "streetName": "East Crogan Street★★★",
+          "absoluteDirection": "EAST",
+          "stayOn": true,
+          "area": false,
+          "lon": -83.985582,
+          "lat": 33.9564082
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Provide a "continue on street" reassurance instruction when the traveler is on track, but no immediate instruction is available.
