### PR TITLE
Trip sharing

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/controllers/api/ApiController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/ApiController.java
@@ -189,6 +189,14 @@ public abstract class ApiController<T extends Model> implements Endpoint {
     }
 
     /**
+     * Provides an entity filter for requests on entities that contain a userId field,
+     * whether the request is made with the userId param or a token.
+     */
+    protected Bson getEntityFilter(OtpUser user) {
+        return Filters.eq(USER_ID_PARAM, user.id);
+    }
+
+    /**
      * HTTP endpoint to get multiple entities based on the user permissions
      */
     // FIXME Maybe better if the user check (and filtering) was done in a pre hook?
@@ -203,7 +211,7 @@ public abstract class ApiController<T extends Model> implements Endpoint {
         if (userId != null) {
             OtpUser otpUser = Persistence.otpUsers.getById(userId);
             if (requestingUser.canManageEntity(otpUser)) {
-                return persistence.getResponseList(Filters.eq(USER_ID_PARAM, userId), offset, limit);
+                return persistence.getResponseList(getEntityFilter(otpUser), offset, limit);
             } else {
                 res.status(HttpStatus.FORBIDDEN_403);
                 return null;
@@ -231,7 +239,7 @@ public abstract class ApiController<T extends Model> implements Endpoint {
         } else {
             // For all other cases the assumption is that the request is being made by an Otp user and the requested
             // entities have a 'userId' parameter. Only entities that match the requesting user id are returned.
-            return persistence.getResponseList(Filters.eq(USER_ID_PARAM, requestingUser.otpUser.id), offset, limit);
+            return persistence.getResponseList(getEntityFilter(requestingUser.otpUser), offset, limit);
         }
     }
 

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -10,6 +10,7 @@ import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.controllers.response.ResponseList;
 import org.opentripplanner.middleware.models.ItineraryExistence;
 import org.opentripplanner.middleware.models.MonitoredTrip;
+import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTrip;
 import org.opentripplanner.middleware.tripmonitor.jobs.MonitoredTripLocks;
@@ -66,6 +67,16 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
                 MonitoredTripController::checkItinerary, JsonUtils::toJson);
         // Add the regular CRUD methods after defining the controller-specific routes.
         super.buildEndpoint(modifiedEndpoint);
+    }
+
+    @Override
+    protected Bson getEntityFilter(OtpUser user) {
+        return Filters.or(
+            Filters.eq(USER_ID_PARAM, user.id),
+            Filters.eq("primary.userId", user.id),
+            Filters.eq("companion.email", user.email),
+            Filters.eq("observers.email", user.email)
+        );
     }
 
     private ResponseList<MonitoredTrip> getTrips(Request req, Response res) {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -5,11 +5,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.mongodb.client.model.Filters;
 import org.bson.conversions.Bson;
 import org.eclipse.jetty.http.HttpStatus;
+import org.opentripplanner.middleware.auth.Auth0Connection;
+import org.opentripplanner.middleware.auth.RequestingUser;
+import org.opentripplanner.middleware.controllers.response.ResponseList;
 import org.opentripplanner.middleware.models.ItineraryExistence;
 import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTrip;
 import org.opentripplanner.middleware.tripmonitor.jobs.MonitoredTripLocks;
+import org.opentripplanner.middleware.utils.HttpUtils;
 import org.opentripplanner.middleware.utils.InvalidItineraryReason;
 import org.opentripplanner.middleware.utils.JsonUtils;
 import org.opentripplanner.middleware.utils.SwaggerUtils;
@@ -43,6 +47,17 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
     protected void buildEndpoint(ApiEndpoint baseEndpoint) {
         // Add the api key route BEFORE the regular CRUD methods
         ApiEndpoint modifiedEndpoint = baseEndpoint
+            // Get all trips, including shared trips created by others.
+            .get(path(ROOT_ROUTE + "/gettrips")
+                    .withDescription(
+                        "Gets a paginated list of trips created by the current user and shared trips created by others where the current user is the primary traveler or a companion or an observer."
+                    )
+                    .withQueryParam(LIMIT)
+                    .withQueryParam(OFFSET)
+                    .withProduces(HttpUtils.JSON_ONLY)
+                    .withResponseType(ResponseList.class),
+                this::getTrips, JsonUtils::toJson
+            )
             .post(path("/checkitinerary")
                     .withDescription("Returns the itinerary existence check results for a monitored trip.")
                     .withRequestType(MonitoredTrip.class)
@@ -51,6 +66,20 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
                 MonitoredTripController::checkItinerary, JsonUtils::toJson);
         // Add the regular CRUD methods after defining the controller-specific routes.
         super.buildEndpoint(modifiedEndpoint);
+    }
+
+    private ResponseList<MonitoredTrip> getTrips(Request req, Response res) {
+        int limit = HttpUtils.getQueryParamFromRequest(req, LIMIT_PARAM, 0, DEFAULT_LIMIT, 100);
+        int offset = HttpUtils.getQueryParamFromRequest(req, OFFSET_PARAM, 0, DEFAULT_OFFSET);
+        RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
+
+        String userId = requestingUser.otpUser.id;
+        Bson finalFilter = Filters.or(
+            Filters.eq(USER_ID_PARAM, userId),
+            Filters.eq("primary.userId", userId),
+            Filters.eq("observers.email", requestingUser.otpUser.email)
+        );
+        return persistence.getResponseList(finalFilter, offset, limit);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -77,6 +77,7 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
         Bson finalFilter = Filters.or(
             Filters.eq(USER_ID_PARAM, userId),
             Filters.eq("primary.userId", userId),
+            Filters.eq("companion.email", requestingUser.otpUser.email),
             Filters.eq("observers.email", requestingUser.otpUser.email)
         );
         return persistence.getResponseList(finalFilter, offset, limit);

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -5,16 +5,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.mongodb.client.model.Filters;
 import org.bson.conversions.Bson;
 import org.eclipse.jetty.http.HttpStatus;
-import org.opentripplanner.middleware.auth.Auth0Connection;
-import org.opentripplanner.middleware.auth.RequestingUser;
-import org.opentripplanner.middleware.controllers.response.ResponseList;
 import org.opentripplanner.middleware.models.ItineraryExistence;
 import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTrip;
 import org.opentripplanner.middleware.tripmonitor.jobs.MonitoredTripLocks;
-import org.opentripplanner.middleware.utils.HttpUtils;
 import org.opentripplanner.middleware.utils.InvalidItineraryReason;
 import org.opentripplanner.middleware.utils.JsonUtils;
 import org.opentripplanner.middleware.utils.SwaggerUtils;
@@ -48,17 +44,6 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
     protected void buildEndpoint(ApiEndpoint baseEndpoint) {
         // Add the api key route BEFORE the regular CRUD methods
         ApiEndpoint modifiedEndpoint = baseEndpoint
-            // Get all trips, including shared trips created by others.
-            .get(path(ROOT_ROUTE + "/gettrips")
-                    .withDescription(
-                        "Gets a paginated list of trips created by the current user and shared trips created by others where the current user is the primary traveler or a companion or an observer."
-                    )
-                    .withQueryParam(LIMIT)
-                    .withQueryParam(OFFSET)
-                    .withProduces(HttpUtils.JSON_ONLY)
-                    .withResponseType(ResponseList.class),
-                this::getTrips, JsonUtils::toJson
-            )
             .post(path("/checkitinerary")
                     .withDescription("Returns the itinerary existence check results for a monitored trip.")
                     .withRequestType(MonitoredTrip.class)
@@ -77,21 +62,6 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
             Filters.eq("companion.email", user.email),
             Filters.eq("observers.email", user.email)
         );
-    }
-
-    private ResponseList<MonitoredTrip> getTrips(Request req, Response res) {
-        int limit = HttpUtils.getQueryParamFromRequest(req, LIMIT_PARAM, 0, DEFAULT_LIMIT, 100);
-        int offset = HttpUtils.getQueryParamFromRequest(req, OFFSET_PARAM, 0, DEFAULT_OFFSET);
-        RequestingUser requestingUser = Auth0Connection.getUserFromRequest(req);
-
-        String userId = requestingUser.otpUser.id;
-        Bson finalFilter = Filters.or(
-            Filters.eq(USER_ID_PARAM, userId),
-            Filters.eq("primary.userId", userId),
-            Filters.eq("companion.email", requestingUser.otpUser.email),
-            Filters.eq("observers.email", requestingUser.otpUser.email)
-        );
-        return persistence.getResponseList(finalFilter, offset, limit);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -176,7 +176,7 @@ public class MonitoredTrip extends Model {
      */
     public boolean notifyAtLeadingInterval = true;
 
-    public RelatedUser primary;
+    public MobilityProfileLite primary;
     public RelatedUser companion;
     public List<RelatedUser> observers = new ArrayList<>();
 

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -1031,6 +1031,35 @@ paths:
           description: "An error occurred while performing the request. Contact an\
             \ API administrator for more information."
           examples: {}
+  /api/secure/monitoredtrip/gettrips:
+    get:
+      tags:
+      - "api/secure/monitoredtrip"
+      description: "Gets a paginated list of trips created by the current user and\
+        \ shared trips created by others where the current user is the primary traveler\
+        \ or a companion or an observer."
+      produces:
+      - "application/json"
+      parameters:
+      - name: "limit"
+        in: "query"
+        description: "If specified, the maximum number of items to return."
+        required: false
+        type: "string"
+        default: "10"
+      - name: "offset"
+        in: "query"
+        description: "If specified, the number of records to skip/offset."
+        required: false
+        type: "string"
+        default: "0"
+      responses:
+        "200":
+          description: "successful operation"
+          responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
+            $ref: "#/definitions/ResponseList"
   /api/secure/monitoredtrip/checkitinerary:
     post:
       tags:
@@ -1686,9 +1715,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MobilityProfileLite"
           responseSchema:
+            $ref: "#/definitions/MobilityProfileLite"
+          schema:
             $ref: "#/definitions/MobilityProfileLite"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -2536,6 +2565,17 @@ definitions:
         $ref: "#/definitions/Fare"
       details:
         $ref: "#/definitions/FareDetails"
+  MobilityProfileLite:
+    type: "object"
+    properties:
+      userId:
+        type: "string"
+      mobilityMode:
+        type: "string"
+      email:
+        type: "string"
+      name:
+        type: "string"
   LocalizedAlert:
     type: "object"
     properties:
@@ -2636,7 +2676,7 @@ definitions:
       notifyAtLeadingInterval:
         type: "boolean"
       primary:
-        $ref: "#/definitions/RelatedUser"
+        $ref: "#/definitions/MobilityProfileLite"
       companion:
         $ref: "#/definitions/RelatedUser"
       observers:

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -1031,35 +1031,6 @@ paths:
           description: "An error occurred while performing the request. Contact an\
             \ API administrator for more information."
           examples: {}
-  /api/secure/monitoredtrip/gettrips:
-    get:
-      tags:
-      - "api/secure/monitoredtrip"
-      description: "Gets a paginated list of trips created by the current user and\
-        \ shared trips created by others where the current user is the primary traveler\
-        \ or a companion or an observer."
-      produces:
-      - "application/json"
-      parameters:
-      - name: "limit"
-        in: "query"
-        description: "If specified, the maximum number of items to return."
-        required: false
-        type: "string"
-        default: "10"
-      - name: "offset"
-        in: "query"
-        description: "If specified, the number of records to skip/offset."
-        required: false
-        type: "string"
-        default: "0"
-      responses:
-        "200":
-          description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
-          schema:
-            $ref: "#/definitions/ResponseList"
   /api/secure/monitoredtrip/checkitinerary:
     post:
       tags:

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -11,25 +11,29 @@ import org.opentripplanner.middleware.auth.Auth0Users;
 import org.opentripplanner.middleware.controllers.response.ResponseList;
 import org.opentripplanner.middleware.models.AdminUser;
 import org.opentripplanner.middleware.models.ItineraryExistence;
+import org.opentripplanner.middleware.models.MobilityProfileLite;
 import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.models.OtpUser;
+import org.opentripplanner.middleware.models.RelatedUser;
 import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.otp.response.Place;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.testutils.ApiTestUtils;
 import org.opentripplanner.middleware.testutils.OtpMiddlewareTestEnvironment;
-import org.opentripplanner.middleware.testutils.OtpTestUtils;
 import org.opentripplanner.middleware.testutils.PersistenceTestUtils;
 import org.opentripplanner.middleware.utils.HttpResponseValues;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
 import java.util.Date;
-import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.auth.Auth0Connection.restoreDefaultAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Connection.setAuthDisabled;
@@ -66,7 +70,6 @@ public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     private static final String UI_QUERY_PARAMS
         = "?fromPlace=fromplace%3A%3A28.556631%2C-81.411781&toPlace=toplace%3A%3A28.545925%2C-81.348609&date=2020-11-13&time=14%3A21&arriveBy=false&mode=WALK%2CBUS%2CRAIL&numItineraries=3";
     private static final String DUMMY_STRING = "ABCDxyz";
-    private static HashMap<String, String> guardianHeaders;
 
     /**
      * Create Otp and Admin user accounts. Create Auth0 account for just the Otp users. If
@@ -146,7 +149,6 @@ public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
 
         // Multi Otp user has 'enhanced' admin credentials, still expect only 1 trip to be returned as the scope will
         // limit the requesting user to a single 'otp-user' user type.
-        // TODO: Determine if a separate admin endpoint should be maintained for getting all/combined trips.
         assertEquals(1, multiTrips.data.size());
 
         // Get trips for only the multi Otp user by specifying Otp user id.
@@ -224,5 +226,78 @@ public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip.to.name = "To Place";
 
         Persistence.monitoredTrips.create(monitoredTrip);
+    }
+
+    @Test
+    void canGetSharedTrips() throws Exception {
+        MonitoredTrip ownTrip = new MonitoredTrip();
+        ownTrip.id = "shared-trips-own-trip";
+        ownTrip.userId = soloOtpUser.id;
+
+        RelatedUser companion = new RelatedUser();
+        companion.email = "companion@example.com";
+
+        RelatedUser soloAsCompanion = new RelatedUser();
+        soloAsCompanion.email = soloOtpUser.email;
+
+        MonitoredTrip ownTripWithCompanion = new MonitoredTrip();
+        ownTripWithCompanion.id = "shared-trips-own-trip-with-companion";
+        ownTripWithCompanion.companion = companion;
+        ownTripWithCompanion.userId = soloOtpUser.id;
+
+        MonitoredTrip ownTripWithObservers = new MonitoredTrip();
+        ownTripWithObservers.id = "shared-trips-own-trip-with-observers";
+        ownTripWithObservers.observers = List.of(companion);
+        ownTripWithObservers.userId = soloOtpUser.id;
+
+        MobilityProfileLite soloAsPrimary = new MobilityProfileLite();
+        soloAsPrimary.userId = soloOtpUser.id;
+
+        MobilityProfileLite otherAsPrimary = new MobilityProfileLite();
+        otherAsPrimary.userId = multiOtpUser.id;
+
+        MonitoredTrip ownTripForDependent = new MonitoredTrip();
+        ownTripForDependent.id = "shared-trips-own-trip-for-dependent";
+        ownTripForDependent.primary = otherAsPrimary;
+        ownTripForDependent.userId = soloOtpUser.id;
+
+        MonitoredTrip otherTrip = new MonitoredTrip();
+        otherTrip.id = "shared-trips-other-trip";
+        otherTrip.userId = multiOtpUser.id;
+
+        MonitoredTrip otherTripWithSoloAsDependent = new MonitoredTrip();
+        otherTripWithSoloAsDependent.id = "shared-trips-other-trip-solo-primary";
+        otherTripWithSoloAsDependent.primary = soloAsPrimary;
+        otherTripWithSoloAsDependent.userId = multiOtpUser.id;
+
+        MonitoredTrip otherTripWithSoloAsCompanion = new MonitoredTrip();
+        otherTripWithSoloAsCompanion.id = "shared-trips-other-trip-solo-companion";
+        otherTripWithSoloAsCompanion.companion = soloAsCompanion;
+        otherTripWithSoloAsCompanion.userId = multiOtpUser.id;
+
+        MonitoredTrip otherTripWithSoloAsObserver = new MonitoredTrip();
+        otherTripWithSoloAsObserver.id = "shared-trips-other-trip-solo-observer";
+        otherTripWithSoloAsObserver.observers = List.of(soloAsCompanion);
+        otherTripWithSoloAsObserver.userId = multiOtpUser.id;
+
+        List<MonitoredTrip> trips = List.of(
+            ownTrip,
+            ownTripForDependent,
+            ownTripWithCompanion,
+            ownTripWithObservers,
+            otherTrip,
+            otherTripWithSoloAsDependent,
+            otherTripWithSoloAsCompanion,
+            otherTripWithSoloAsObserver
+        );
+        trips.forEach(Persistence.monitoredTrips::create);
+
+        List<MonitoredTrip> fetchedTrips = getMonitoredTripsForUser(MONITORED_TRIP_PATH, soloOtpUser).data;
+        assertEquals(trips.size() - 1, fetchedTrips.size());
+
+        Set<String> ids = trips.stream().map(t -> t.id).collect(Collectors.toSet());
+        ids.remove(otherTrip.id);
+        Set<String> fetchedIds = fetchedTrips.stream().map(t -> t.id).collect(Collectors.toSet());
+        assertTrue(ids.containsAll(fetchedIds));
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Provides a new endpoint to query a given user's monitored trips, including trips on which a user is a companion and or an observer. The field type for `primary` user is changed to `MobilityProfileLite` as a result from introducing the endpoint in #266 for querying the dependent profile.

Out of scope: email notifications to users added as companions/observers/primary travelers will be addressed in a separate PR.