### PR TITLE
Correctly unsnooze snoozed trips

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -674,8 +674,8 @@ public class CheckMonitoredTrip implements Runnable {
         // For trips that are snoozed, see if they should be unsnoozed first.
         if (trip.snoozed) {
             if (shouldUnsnoozeTrip()) {
-                // Clear previous journey state and matching itinerary as we want to start afresh.
-                // This will let
+                // Clear previous matching itinerary as we want to start afresh.
+                // The snoozed state will be updated later in the process.
                 previousMatchingItinerary = null;
             } else {
                 LOG.info("Skipping: Trip is snoozed.");

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -670,17 +671,23 @@ public class CheckMonitoredTrip implements Runnable {
             return true;
         }
 
+        // For trips that are snoozed, see if they should be unsnoozed first.
+        if (trip.snoozed) {
+            if (shouldUnsnoozeTrip()) {
+                // Clear previous journey state and matching itinerary as we want to start afresh.
+                // This will let
+                previousMatchingItinerary = null;
+            } else {
+                LOG.info("Skipping: Trip is snoozed.");
+                return true;
+            }
+        }
+
         if (isPrevMatchingItineraryNotConcluded()) {
             // Skip checking the trip the rest of the time that it is active if the trip was deemed not possible for the
             // next possible time during a previous query to find candidate itinerary matches.
             if (previousJourneyState.tripStatus == TripStatus.NEXT_TRIP_NOT_POSSIBLE) {
                 LOG.info("Skipping: Next trip is not possible.");
-                return true;
-            }
-
-            // skip checking the trip if it has been snoozed
-            if (trip.snoozed) {
-                LOG.info("Skipping: Trip is snoozed.");
                 return true;
             }
 
@@ -928,5 +935,23 @@ public class CheckMonitoredTrip implements Runnable {
 
     private String getTripUrl() {
         return String.format("%s%s/%s", OTP_UI_URL, TRIPS_PATH, trip.id);
+    }
+
+    /**
+     * Whether a trip should be unsnoozed and monitoring should resume.
+     * @return true if the current time is after the calendar day (midnight) after the matching trip start day, false otherwise.
+     */
+    public boolean shouldUnsnoozeTrip() {
+        ZoneId otpZoneId = DateTimeUtils.getOtpZoneId();
+        var midnightAfterPreviousTrip = ZonedDateTime
+            .ofInstant(
+                previousJourneyState.matchingItinerary.startTime.toInstant().plus(1, ChronoUnit.DAYS),
+                otpZoneId
+            )
+            .withHour(0)
+            .withMinute(0)
+            .withSecond(0);
+
+        return DateTimeUtils.nowAsZonedDateTime(otpZoneId).isAfter(midnightAfterPreviousTrip);
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -939,19 +939,22 @@ public class CheckMonitoredTrip implements Runnable {
 
     /**
      * Whether a trip should be unsnoozed and monitoring should resume.
-     * @return true if the current time is after the calendar day (midnight) after the matching trip start day, false otherwise.
+     * @return true if the current time is after the calendar day (on or after midnight)
+     * after the matching trip start day, false otherwise.
      */
     public boolean shouldUnsnoozeTrip() {
         ZoneId otpZoneId = DateTimeUtils.getOtpZoneId();
-        var midnightAfterPreviousTrip = ZonedDateTime
+        var midnightAfterLastChecked = ZonedDateTime
             .ofInstant(
-                previousJourneyState.matchingItinerary.startTime.toInstant().plus(1, ChronoUnit.DAYS),
+                Instant.ofEpochMilli(previousJourneyState.lastCheckedEpochMillis).plus(1, ChronoUnit.DAYS),
                 otpZoneId
             )
             .withHour(0)
             .withMinute(0)
             .withSecond(0);
 
-        return DateTimeUtils.nowAsZonedDateTime(otpZoneId).isAfter(midnightAfterPreviousTrip);
+        ZonedDateTime now = DateTimeUtils.nowAsZonedDateTime(otpZoneId);
+        // Include equal or after midnight as true.
+        return !now.isBefore(midnightAfterLastChecked);
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -771,7 +771,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // After snoozed trip is over, trip checks on that trip should not be skipped
         CheckMonitoredTrip check = new CheckMonitoredTrip(monitoredTrip, this::mockOtpPlanResponse);
 
-        // Add artifacts of prior monitoring (e.g. monitoring was active until a few minutes before trip start)
+        // Add artifacts of prior monitoring (e.g. monitoring was active until a few minutes before trip snooze)
         JourneyState journeyState = monitoredTrip.journeyState;
         journeyState.targetDate = "2020-06-09";
         journeyState.tripStatus = TripStatus.TRIP_UPCOMING;

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -749,7 +749,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
     @ParameterizedTest
     @MethodSource("createCanUnsnoozeTripCases")
-    void canUnsnoozeTrip(ZonedDateTime time, boolean shouldUnsnooze) throws Exception {
+    void canUnsnoozeTrip(ZonedDateTime lastCheckedTime, ZonedDateTime clockTime, boolean shouldUnsnooze) throws Exception {
         MonitoredTrip monitoredTrip = PersistenceTestUtils.createMonitoredTrip(
             user.id,
             OtpTestUtils.OTP2_DISPATCHER_PLAN_RESPONSE.clone(),
@@ -759,10 +759,14 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip.id = UUID.randomUUID().toString();
         // Mark trip as snoozed
         monitoredTrip.snoozed = true;
+        // Set monitored days to Tuesday only.
+        monitoredTrip.monday = false;
+        monitoredTrip.tuesday = true;
+
         Persistence.monitoredTrips.create(monitoredTrip);
 
         // Mock the current time
-        DateTimeUtils.useFixedClockAt(time);
+        DateTimeUtils.useFixedClockAt(clockTime);
 
         // After snoozed trip is over, trip checks on that trip should not be skipped
         CheckMonitoredTrip check = new CheckMonitoredTrip(monitoredTrip, this::mockOtpPlanResponse);
@@ -771,10 +775,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         JourneyState journeyState = monitoredTrip.journeyState;
         journeyState.targetDate = "2020-06-09";
         journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
-        journeyState.lastCheckedEpochMillis = Instant
-            .ofEpochMilli(monitoredTrip.itinerary.startTime.getTime())
-            .minus(10, ChronoUnit.MINUTES)
-            .toEpochMilli();
+        // Set last-checked-time
+        journeyState.lastCheckedEpochMillis = lastCheckedTime.toInstant().toEpochMilli();
         journeyState.matchingItinerary = monitoredTrip.itinerary;
         check.previousJourneyState = journeyState;
         check.previousMatchingItinerary = monitoredTrip.itinerary;
@@ -791,12 +793,18 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
     private static Stream<Arguments> createCanUnsnoozeTripCases() {
         // (Trips from above response above starts on Tuesday, June 9, 2020 at 8:40am and ends at 8:58am.)
+        ZonedDateTime tuesday = noonMonday8June2020.withDayOfMonth(9).withHour(0).withMinute(0).withSecond(0);
+        ZonedDateTime wednesday = tuesday.withDayOfMonth(10);
+
         return Stream.of(
-            // At 9:00am on Tuesday, June 9, 2020 (right after trip ends), snoozed trip should remain snoozed.
-            Arguments.of(noonMonday8June2020.withDayOfMonth(9).withHour(9).withMinute(0), false),
-            // At 00:00am on Wednesday, June 10, 2020, snoozed trip should be unsnoozed
+            // Trip snoozed at 8:00am on Tuesday, June 9, 2020, should remain snoozed right after trip ends at 9:00am.
+            Arguments.of(tuesday.withHour(8), tuesday.withHour(9), false),
+            // Trip snoozed at 8:00am on Tuesday, June 9, 2020, should unsnooze at 00:00am on Wednesday, June 10, 2020,
             // but it is too early for the trip to be analyzed again.
-            Arguments.of(noonMonday8June2020.withDayOfMonth(10).withHour(0).withMinute(0), true)
+            Arguments.of(tuesday.withHour(8), wednesday, true),
+            // Trip snoozed on Monday, June 8, 2020 (a day before the trip starts), should unsnooze at 00:00 on
+            // Tuesday, June 9, 2020.
+            Arguments.of(noonMonday8June2020, tuesday, true)
         );
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -746,4 +746,57 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         assertEquals(expectedAttempts, monitoredTrip.attemptsToGetMatchingItinerary);
         assertEquals(expectedTripStatus, monitoredTrip.journeyState.tripStatus);
     }
+
+    @ParameterizedTest
+    @MethodSource("createCanUnsnoozeTripCases")
+    void canUnsnoozeTrip(ZonedDateTime time, boolean shouldUnsnooze) throws Exception {
+        MonitoredTrip monitoredTrip = PersistenceTestUtils.createMonitoredTrip(
+            user.id,
+            OtpTestUtils.OTP2_DISPATCHER_PLAN_RESPONSE.clone(),
+            false,
+            OtpTestUtils.createDefaultJourneyState()
+        );
+        monitoredTrip.id = UUID.randomUUID().toString();
+        // Mark trip as snoozed
+        monitoredTrip.snoozed = true;
+        Persistence.monitoredTrips.create(monitoredTrip);
+
+        // Mock the current time
+        DateTimeUtils.useFixedClockAt(time);
+
+        // After snoozed trip is over, trip checks on that trip should not be skipped
+        CheckMonitoredTrip check = new CheckMonitoredTrip(monitoredTrip, this::mockOtpPlanResponse);
+
+        // Add artifacts of prior monitoring (e.g. monitoring was active until a few minutes before trip start)
+        JourneyState journeyState = monitoredTrip.journeyState;
+        journeyState.targetDate = "2020-06-09";
+        journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
+        journeyState.lastCheckedEpochMillis = Instant
+            .ofEpochMilli(monitoredTrip.itinerary.startTime.getTime())
+            .minus(10, ChronoUnit.MINUTES)
+            .toEpochMilli();
+        journeyState.matchingItinerary = monitoredTrip.itinerary;
+        check.previousJourneyState = journeyState;
+        check.previousMatchingItinerary = monitoredTrip.itinerary;
+
+        assertEquals(shouldUnsnooze, check.shouldUnsnoozeTrip());
+        check.shouldSkipMonitoredTripCheck();
+
+        MonitoredTrip modifiedTrip = Persistence.monitoredTrips.getById(monitoredTrip.id);
+        assertEquals(!shouldUnsnooze, modifiedTrip.snoozed);
+
+        // Clear the created trip.
+        PersistenceTestUtils.deleteMonitoredTrip(modifiedTrip);
+    }
+
+    private static Stream<Arguments> createCanUnsnoozeTripCases() {
+        // (Trips from above response above starts on Tuesday, June 9, 2020 at 8:40am and ends at 8:58am.)
+        return Stream.of(
+            // At 9:00am on Tuesday, June 9, 2020 (right after trip ends), snoozed trip should remain snoozed.
+            Arguments.of(noonMonday8June2020.withDayOfMonth(9).withHour(9).withMinute(0), false),
+            // At 00:00am on Wednesday, June 10, 2020, snoozed trip should be unsnoozed
+            // but it is too early for the trip to be analyzed again.
+            Arguments.of(noonMonday8June2020.withDayOfMonth(10).withHour(0).withMinute(0), true)
+        );
+    }
 }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -792,18 +792,18 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     }
 
     private static Stream<Arguments> createCanUnsnoozeTripCases() {
-        // (Trips from above response above starts on Tuesday, June 9, 2020 at 8:40am and ends at 8:58am.)
+        // (Trips for these tests start on Tuesday, June 9, 2020 at 8:40am and ends at 8:58am.)
         ZonedDateTime tuesday = noonMonday8June2020.withDayOfMonth(9).withHour(0).withMinute(0).withSecond(0);
         ZonedDateTime wednesday = tuesday.withDayOfMonth(10);
 
         return Stream.of(
             // Trip snoozed at 8:00am on Tuesday, June 9, 2020, should remain snoozed right after trip ends at 9:00am.
             Arguments.of(tuesday.withHour(8), tuesday.withHour(9), false),
-            // Trip snoozed at 8:00am on Tuesday, June 9, 2020, should unsnooze at 00:00am on Wednesday, June 10, 2020,
-            // but it is too early for the trip to be analyzed again.
+            // Trip snoozed at 8:00am on Tuesday, June 9, 2020, should unsnooze at 12:00am (midnight) on
+            // Wednesday, June 10, 2020, but it is too early for the trip to be analyzed again.
             Arguments.of(tuesday.withHour(8), wednesday, true),
-            // Trip snoozed on Monday, June 8, 2020 (a day before the trip starts), should unsnooze at 00:00 on
-            // Tuesday, June 9, 2020.
+            // Trip snoozed on Monday, June 8, 2020 (a day before the trip starts), should unsnooze at 12:00am (midnight)
+            // on Tuesday, June 9, 2020.
             Arguments.of(noonMonday8June2020, tuesday, true)
         );
     }


### PR DESCRIPTION

### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes an issue where monitoring on snoozed trip did not resume automatically the next calendar day.
