### PR TITLE
Ignore unknown fields passed in OtpUser and other user payload

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/models/AbstractUser.java
+++ b/src/main/java/org/opentripplanner/middleware/models/AbstractUser.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.middleware.models;
 
 import com.auth0.exception.Auth0Exception;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.opentripplanner.middleware.auth.Auth0Connection;
 import org.opentripplanner.middleware.auth.RequestingUser;
 import org.opentripplanner.middleware.auth.Permission;
@@ -19,6 +20,7 @@ import static org.opentripplanner.middleware.auth.Auth0Users.deleteAuth0User;
  * It provides a place to centralize common fields that all users share (e.g., email) and common methods (such as the
  * authorization check {@link #canBeManagedBy}.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class AbstractUser extends Model {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractUser.class);
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Trying to modify a user setting after editing a trip with a dependent involved, or after searching trips for a dependent (https://github.com/opentripplanner/otp-react-redux/pull/1302), would result in an error message and changes discarded. This PR fixes that.

