### PR TITLE
fix(typeform/Response): Handle null answers.

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/typeform/Response.java
+++ b/src/main/java/org/opentripplanner/middleware/typeform/Response.java
@@ -3,6 +3,7 @@ package org.opentripplanner.middleware.typeform;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /** Data structure for TypeForm survey responses. Only including relevant fields. */
@@ -83,7 +84,12 @@ public class Response {
             hidden.notification_id,
             hidden.trip_id,
             hidden.user_id,
-            answers.stream().map(Answer::toCsvContent).collect(Collectors.joining(","))
+            answers == null
+                ? ""
+                : answers.stream()
+                    .filter(Objects::nonNull)
+                    .map(Answer::toCsvContent)
+                    .collect(Collectors.joining(","))
         );
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/typeform/ResponseTest.java
+++ b/src/test/java/org/opentripplanner/middleware/typeform/ResponseTest.java
@@ -1,20 +1,33 @@
 package org.opentripplanner.middleware.typeform;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ResponseTest {
 
-    public static final String EXPECTED_CSV_ROW = "response-id-0,completed,2024-10-25T15:37:42Z,2024-10-25T15:46:27Z,notification-id-1,trip-id-2,user-id-3,\"Field1 choice\",\"Field2, ChoiceA;Field2, ChoiceB\",\"Field3 answer\"";
+    public static final String EXPECTED_CSV_BEGINNING = "response-id-0,completed,2024-10-25T15:37:42Z,2024-10-25T15:46:27Z,notification-id-1,trip-id-2,user-id-3,";
+    public static final String EXPECTED_CSV_ENDING = "\"Field1 choice\",\"Field2, ChoiceA;Field2, ChoiceB\",\"Field3 answer\"";
+    public static final String EXPECTED_CSV_ROW = EXPECTED_CSV_BEGINNING + EXPECTED_CSV_ENDING;
 
+    @ParameterizedTest
+    @MethodSource("createToCsvRowCases")
+    void toCsvRow(Response response, String expected) {
+        assertEquals(expected, response.toCsvRow());
+    }
 
-    @Test
-    void toCsvRow() {
-        Response response = makeResponse();
-        assertEquals(EXPECTED_CSV_ROW, response.toCsvRow());
+    private static Stream<Arguments> createToCsvRowCases() {
+        Response responseWithoutAnswers = makeResponse();
+        responseWithoutAnswers.answers = null;
+        return Stream.of(
+            Arguments.of(makeResponse(), EXPECTED_CSV_ROW),
+            Arguments.of(responseWithoutAnswers, EXPECTED_CSV_BEGINNING)
+        );
     }
 
     public static Response makeResponse() {


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes a silent crash when processing a TypeForm response with no answers (the responder just submitted the survey without entering responses to any of the questions).
