### PR TITLE
Hide getPrimaryTraveler from Mongo and JSON serialization

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -493,6 +493,8 @@ public class MonitoredTrip extends Model {
      * @return The id of the primary traveler (the primary user of a trip,
      * or the user who created the trip if no primary user has been set).
      */
+    @JsonIgnore
+    @BsonIgnore
     public String getPrimaryTravelerId() {
         return primary != null ? primary.userId : userId;
     }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR hides a getter method that is unnecessarily serialized in Mongo.