### PR TITLE
Improve instructions for last portion of walk leg

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/otp/response/Step.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/response/Step.java
@@ -12,6 +12,9 @@ import org.opentripplanner.middleware.utils.ConvertsToCoordinates;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Step implements ConvertsToCoordinates, Cloneable {
 
+    public static final String DEPART = "DEPART";
+    public static final String END_OF_ROUTING = "END_OF_ROUTING";
+
     public Double distance;
     public String relativeDirection;
     public String streetName;

--- a/src/main/java/org/opentripplanner/middleware/otp/response/Step.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/response/Step.java
@@ -1,7 +1,9 @@
 package org.opentripplanner.middleware.otp.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.opentripplanner.middleware.utils.Coordinates;
 import org.opentripplanner.middleware.utils.ConvertsToCoordinates;
 
@@ -36,5 +38,11 @@ public class Step implements ConvertsToCoordinates, Cloneable {
 
     public Coordinates toCoordinates() {
         return new Coordinates(lat, lon);
+    }
+
+    @JsonIgnore
+    @BsonIgnore
+    public boolean isEndOfRouting() {
+        return END_OF_ROUTING.equals(relativeDirection);
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -206,7 +206,7 @@ public class TravelerLocator {
         ) {
             Step previousStep = getPreviousStep(travelerPosition.expectedLeg.steps, nextStep);
             if (previousStep != null) {
-                boolean travelerBetweenSteps = isPointBetween(previousStep.toCoordinates(), nextStep.toCoordinates(), travelerPosition.currentPosition);
+                boolean travelerBetweenSteps = nextStep == null || isPointBetween(previousStep.toCoordinates(), nextStep.toCoordinates(), travelerPosition.currentPosition);
                 if (travelerBetweenSteps) {
                     return new ContinueInstruction(previousStep, locale);
                 } else if (isWithinStepRange(travelerPosition, previousStep)) {
@@ -239,7 +239,7 @@ public class TravelerLocator {
             .filter(i -> steps.get(i).equals(nextStep))
             .mapToObj(i -> steps.get(i - 1))
             .findFirst();
-        return previousStep.orElse(null);
+        return previousStep.orElse(steps.get(steps.size() - 1));
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -199,14 +199,15 @@ public class TravelerLocator {
         Step nextStep,
         Locale locale
     ) {
-        if (
-            Boolean.TRUE.equals(!travelerPosition.expectedLeg.transitLeg) &&
-            travelerPosition.expectedLeg.steps != null &&
-            !travelerPosition.expectedLeg.steps.isEmpty()
-        ) {
-            Step previousStep = getPreviousStep(travelerPosition.expectedLeg.steps, nextStep);
+        List<Step> steps = travelerPosition.expectedLeg.steps;
+        if (Boolean.TRUE.equals(!travelerPosition.expectedLeg.transitLeg) && steps != null && !steps.isEmpty()) {
+            Step previousStep = getPreviousStep(steps, nextStep);
             if (previousStep != null) {
-                boolean travelerBetweenSteps = nextStep == null || isPointBetween(previousStep.toCoordinates(), nextStep.toCoordinates(), travelerPosition.currentPosition);
+                boolean travelerBetweenSteps = nextStep == null || isPointBetween(
+                    previousStep.toCoordinates(),
+                    nextStep.toCoordinates(),
+                    travelerPosition.currentPosition
+                );
                 if (travelerBetweenSteps) {
                     return new ContinueInstruction(previousStep, locale);
                 } else if (isWithinStepRange(travelerPosition, previousStep)) {

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -286,7 +286,7 @@ public class TravelerLocator {
             return new GetOffHereTransitInstruction(finalStop, locale);
         }
 
-        Place nextStop = snapToWaypoint(travelerPosition, getIntermediateAndLastStop(expectedLeg), true);
+        Place nextStop = snapToWaypoint(travelerPosition, getIntermediateAndLastStop(expectedLeg), true, false);
         if (nextStop != null) {
             int stopsRemaining = stopsUntilEndOfLeg(nextStop, expectedLeg);
             double distance = getDistance(travelerPosition.currentPosition, new Coordinates(nextStop));
@@ -471,18 +471,39 @@ public class TravelerLocator {
     /**
      * Align the traveler to the transit leg and provide the next waypoint from this point forward.
      */
-    private static <T extends ConvertsToCoordinates> T snapToWaypoint(TravelerPosition pos, List<T> waypoints, boolean excludeCurrent) {
+    private static <T extends ConvertsToCoordinates> T snapToWaypoint(TravelerPosition pos, List<T> waypoints, boolean excludeCurrent, boolean useLastShapePoint) {
         List<Coordinates> legPositions = injectWaypointsIntoLegPositions(pos.expectedLeg, waypoints);
         int pointIndex = getNearestPointIndex(legPositions, pos.currentPosition);
         int startingIndex = excludeCurrent ? Math.min(pointIndex + 1, legPositions.size() - 1) : pointIndex;
-        return pointIndex != -1 ? getNextWayPoint(legPositions, waypoints, startingIndex) : null;
+        List<T> finalWaypoints = waypoints;
+
+        // If directed so, add the last point of the leg shape (second to last in legPositions)
+        // for end-of-routing instructions.
+        if (useLastShapePoint && legPositions.size() > 2) {
+            finalWaypoints = new ArrayList<>(waypoints);
+            finalWaypoints.add((T) createEndOfRoutingStep(legPositions));
+        }
+
+        return pointIndex != -1 ? getNextWayPoint(legPositions, finalWaypoints, startingIndex) : null;
+    }
+
+    /**
+     * Creates a special end-of-routing step to instruct that no further routing instructions are available.
+     */
+    private static Step createEndOfRoutingStep(List<Coordinates> legPositions) {
+        Coordinates lastShapeCoordinate = legPositions.get(legPositions.size() - 2);
+        Step step = new Step();
+        step.lat = lastShapeCoordinate.lat;
+        step.lon = lastShapeCoordinate.lon;
+        step.relativeDirection = Step.END_OF_ROUTING;
+        return step;
     }
 
     /**
      * Align the traveler to the transit leg and provide the next waypoint forward, excluding the current position.
      */
     private static <T extends ConvertsToCoordinates> T snapToWaypoint(TravelerPosition pos, List<T> waypoints) {
-        return snapToWaypoint(pos, waypoints, false);
+        return snapToWaypoint(pos, waypoints, false, true);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -131,7 +131,7 @@ public class TravelerLocator {
     private static TripInstruction getDeviatedInstruction(TravelerPosition travelerPosition) {
         if (!isBusLeg(travelerPosition.expectedLeg)) {
             Step nearestStep = snapToWaypoint(travelerPosition, travelerPosition.expectedLeg.steps);
-            return (nearestStep != null)
+            return (nearestStep != null && !nearestStep.isEndOfRouting())
                 ? new DeviatedInstruction(nearestStep.streetName, travelerPosition.locale)
                 : null;
         } else if (atStartOfTransitTrip(travelerPosition)) {

--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/OnTrackInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/OnTrackInstruction.java
@@ -15,6 +15,9 @@ public class OnTrackInstruction extends SelfLegInstruction {
     /** The prefix to use when arrived at the destination. */
     public static final String TRIP_INSTRUCTION_ARRIVED_PREFIX = "ARRIVED: ";
 
+    /** Generic text when arriving at the end of routing. */
+    public static final String TRIP_INSTRUCTION_END_OF_ROUTING = "Your destination is in the vicinity.";
+
     public OnTrackInstruction(boolean isDestination, double distance, Locale locale) {
         this.distance = distance;
         this.locale = locale;
@@ -62,10 +65,15 @@ public class OnTrackInstruction extends SelfLegInstruction {
     public String build() {
         if (hasInstruction()) {
             if (legStep != null) {
-                String relativeDirection = (legStep.relativeDirection.equals("DEPART"))
-                    ? "Head " + legStep.absoluteDirection
-                    : legStep.relativeDirection;
-                return String.format("%s%s on %s", prefix, relativeDirection, legStep.streetName);
+                String relativeDirection = legStep.relativeDirection;
+                if (relativeDirection.equals(Step.END_OF_ROUTING)) {
+                    return TRIP_INSTRUCTION_END_OF_ROUTING;
+                } else {
+                    String instruction = relativeDirection.equals(Step.DEPART)
+                        ? "Head " + legStep.absoluteDirection
+                        : relativeDirection;
+                    return String.format("%s%s on %s", prefix, instruction, legStep.streetName);
+                }
             } else if (locationName != null) {
                 return String.format("%s%s", prefix, locationName);
             }

--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/OnTrackInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/OnTrackInstruction.java
@@ -65,13 +65,12 @@ public class OnTrackInstruction extends SelfLegInstruction {
     public String build() {
         if (hasInstruction()) {
             if (legStep != null) {
-                String relativeDirection = legStep.relativeDirection;
-                if (relativeDirection.equals(Step.END_OF_ROUTING)) {
+                if (legStep.isEndOfRouting()) {
                     return TRIP_INSTRUCTION_END_OF_ROUTING;
                 } else {
-                    String instruction = relativeDirection.equals(Step.DEPART)
+                    String instruction = legStep.relativeDirection.equals(Step.DEPART)
                         ? "Head " + legStep.absoluteDirection
-                        : relativeDirection;
+                        : legStep.relativeDirection;
                     return String.format("%s%s on %s", prefix, instruction, legStep.streetName);
                 }
             } else if (locationName != null) {

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -232,7 +232,7 @@ public class ManageLegTraversalTest {
                 new TraceData(
                     TripStatus.DEVIATED,
                     createPoint(busStopCoords, 12, NORTH_WEST_BEARING),
-                    new DeviatedInstruction(busStopName, locale).build(),
+                    new DeviatedInstruction(busStopName, locale),
                     true,
                     "Deviated from the start of a trip which starts with a bus leg. Suggest path to head towards."
                 )
@@ -241,7 +241,7 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     originCoords,
-                    new OnTrackInstruction(10, adairAvenueNortheastStep, locale).build(),
+                    new OnTrackInstruction(10, adairAvenueNortheastStep, locale),
                     true,
                     "Just started the trip and near to the instruction for the first step. "
                 )
@@ -250,7 +250,7 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     originCoords,
-                    new OnTrackInstruction(10, adairAvenueNortheastStep, locale).build(),
+                    new OnTrackInstruction(10, adairAvenueNortheastStep, locale),
                     false,
                     "Coming up on first instruction."
                 )
@@ -259,7 +259,7 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     adairAvenueNortheastCoords,
-                    new OnTrackInstruction(2, adairAvenueNortheastStep, locale).build(),
+                    new OnTrackInstruction(2, adairAvenueNortheastStep, locale),
                     false,
                     "On first instruction."
                 )
@@ -269,7 +269,7 @@ public class ManageLegTraversalTest {
                 new TraceData(
                     TripStatus.DEVIATED,
                     createPoint(adairAvenueNortheastCoords, 12, NORTH_WEST_BEARING),
-                    new DeviatedInstruction(adairAvenueNortheastStep.streetName, locale).build(),
+                    new DeviatedInstruction(adairAvenueNortheastStep.streetName, locale),
                     false,
                     "Deviated to the north of east to west path. Suggest path to head towards."
                 )
@@ -279,7 +279,7 @@ public class ManageLegTraversalTest {
                 new TraceData(
                     TripStatus.DEVIATED,
                     createPoint(adairAvenueNortheastCoords, 12, SOUTH_WEST_BEARING),
-                    new DeviatedInstruction(adairAvenueNortheastStep.streetName, locale).build(),
+                    new DeviatedInstruction(adairAvenueNortheastStep.streetName, locale),
                     false,
                     "Deviated to the south of east to west path. Suggest path to head towards."
                 )
@@ -288,7 +288,7 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     createPoint(virginiaCircleNortheastCoords, 12, SOUTH_WEST_BEARING),
-                    new ContinueInstruction(virginiaCircleNortheastStep, locale).build(),
+                    new ContinueInstruction(virginiaCircleNortheastStep, locale),
                     false,
                     "On track approaching second step, provide continue instruction."
                 )
@@ -298,7 +298,7 @@ public class ManageLegTraversalTest {
                 new TraceData(
                     TripStatus.DEVIATED,
                     createPoint(virginiaCircleNortheastCoords, 8, NORTH_BEARING),
-                    new OnTrackInstruction(9, virginiaCircleNortheastStep, locale).build(),
+                    new OnTrackInstruction(9, virginiaCircleNortheastStep, locale),
                     false,
                     "Deviated from path, but within the upcoming radius of second instruction."
                 )
@@ -307,7 +307,7 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     virginiaCircleNortheastCoords,
-                    new OnTrackInstruction(0, virginiaCircleNortheastStep, locale).build(),
+                    new OnTrackInstruction(0, virginiaCircleNortheastStep, locale),
                     false,
                     "On second instruction."
                 )
@@ -317,7 +317,7 @@ public class ManageLegTraversalTest {
                 new TraceData(
                     TripStatus.DEVIATED,
                     createPoint(ponceDeLeonPlaceNortheastCoords, 10, NORTH_WEST_BEARING),
-                    new DeviatedInstruction(ponceDeLeonPlaceNortheastStep.streetName, locale).build(),
+                    new DeviatedInstruction(ponceDeLeonPlaceNortheastStep.streetName, locale),
                     false,
                     "Deviated to the west of south to north path. Suggest path to head towards."
                 )
@@ -327,7 +327,7 @@ public class ManageLegTraversalTest {
                 new TraceData(
                     TripStatus.DEVIATED,
                     createPoint(ponceDeLeonPlaceNortheastCoords, 10, NORTH_EAST_BEARING),
-                    new DeviatedInstruction(ponceDeLeonPlaceNortheastStep.streetName, locale).build(),
+                    new DeviatedInstruction(ponceDeLeonPlaceNortheastStep.streetName, locale),
                     false,
                     "Deviated to the east of south to north path. Suggest path to head towards."
                 )
@@ -336,7 +336,7 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     createPoint(pointBeforeTurn, 8, calculateBearing(pointBeforeTurn, virginiaAvenuePoint)),
-                    new OnTrackInstruction(10, virginiaAvenueNortheastStep, locale).build(),
+                    new OnTrackInstruction(10, virginiaAvenueNortheastStep, locale),
                     false,
                     "Approaching left turn on Virginia Avenue (Test to make sure turn is not missed)."
                 )
@@ -345,7 +345,7 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     createPoint(pointBeforeTurn, 17, calculateBearing(pointBeforeTurn, virginiaAvenuePoint)),
-                    new OnTrackInstruction(2, virginiaAvenueNortheastStep, locale).build(),
+                    new OnTrackInstruction(2, virginiaAvenueNortheastStep, locale),
                     false,
                     "Turn left on to Virginia Avenue (Test to make sure turn is not missed)."
                 )
@@ -354,7 +354,7 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     createPoint(pointAfterTurn, 0, calculateBearing(pointAfterTurn, virginiaAvenuePoint)),
-                    new ContinueInstruction(virginiaAvenueNortheastStep, locale).build(),
+                    new ContinueInstruction(virginiaAvenueNortheastStep, locale),
                     false,
                     "After turn left on to Virginia Avenue should provide continue instruction."
                 )
@@ -363,7 +363,7 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     createPoint(pointOnKanugaStreet, 0, NORTH_WEST_BEARING),
-                    new ContinueInstruction(kanugaStreetStep, locale).build(),
+                    new ContinueInstruction(kanugaStreetStep, locale),
                     false,
                     "After final turn on to Kanuga Street should provide continue instruction."
                 )
@@ -372,7 +372,7 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     createPoint(destinationCoords, 8, SOUTH_BEARING),
-                    new OnTrackInstruction(10, destinationName, locale).build(),
+                    new OnTrackInstruction(10, destinationName, locale),
                     false,
                     "Coming up on destination instruction."
                 )
@@ -381,7 +381,7 @@ public class ManageLegTraversalTest {
                 walkLeg,
                 new TraceData(
                     destinationCoords,
-                    new OnTrackInstruction(2, destinationName, locale).build(),
+                    new OnTrackInstruction(2, destinationName, locale),
                     false,
                     "On destination instruction."
                 )
@@ -390,7 +390,7 @@ public class ManageLegTraversalTest {
                 toEastCroganFirstLeg,
                 new TraceData(
                     pointOnSouthClaytonSt,
-                    new ContinueInstruction(southClaytonSt, locale).build(),
+                    new ContinueInstruction(southClaytonSt, locale),
                     false,
                     "On track passed second step and not near to next step, provide continue instruction for second step."
                 )
@@ -399,7 +399,7 @@ public class ManageLegTraversalTest {
                 toEastCroganFirstLeg,
                 new TraceData(
                     createPoint(pointOnSouthClaytonSt, 12, NORTH_WEST_BEARING),
-                    new ContinueInstruction(southClaytonSt, locale).build(),
+                    new ContinueInstruction(southClaytonSt, locale),
                     false,
                     "On track a bit near to the next step, provide continue instruction for second step."
                 )
@@ -408,7 +408,7 @@ public class ManageLegTraversalTest {
                 toEastCroganFirstLeg,
                 new TraceData(
                     createPoint(pointOnSouthClaytonSt, 72, NORTH_BEARING),
-                    new ContinueInstruction(eastCroganSt, locale).build(),
+                    new ContinueInstruction(eastCroganSt, locale),
                     false,
                     "On track passed next step, provide continue instruction for next step."
                 )
@@ -624,13 +624,17 @@ public class ManageLegTraversalTest {
             this.message = message;
         }
 
+        public TraceData(Coordinates position, TripInstruction expectedInstruction, boolean isStartOfTrip, String message) {
+            this(position, expectedInstruction.build(), isStartOfTrip, message);
+        }
+
         public TraceData(Coordinates position, String expectedInstruction, String message) {
             this(position, expectedInstruction, false, message);
         }
 
         public TraceData(Coordinates position, String expectedInstruction, String message, boolean dismissIntermediateStops) {
             this(position, expectedInstruction, false, message);
-            this.dismissIntermediateStops = true;
+            this.dismissIntermediateStops = dismissIntermediateStops;
         }
 
         public TraceData(Coordinates position, int speed, String expectedInstruction, String message) {
@@ -644,6 +648,10 @@ public class ManageLegTraversalTest {
             this.expectedInstruction = expectedInstruction;
             this.isStartOfTrip = isStartOfTrip;
             this.message = message;
+        }
+
+        public TraceData(TripStatus tripStatus, Coordinates position, TripInstruction expectedInstruction, boolean isStartOfTrip, String message) {
+            this(tripStatus, position, expectedInstruction.build(), isStartOfTrip, message);
         }
 
         public TraceData(TripStatus tripStatus, Coordinates position, String expectedInstruction, String message) {

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -205,6 +205,7 @@ public class ManageLegTraversalTest {
         Step virginiaCircleNortheastStep = walkSteps.get(1);
         Step ponceDeLeonPlaceNortheastStep = walkSteps.get(2);
         Step virginiaAvenueNortheastStep = walkSteps.get(5);
+        Step kanugaStreetStep = walkSteps.get(7);
 
         Coordinates originCoords = new Coordinates(adairAvenueToMonroeDriveLeg.from);
         Coordinates destinationCoords = new Coordinates(adairAvenueToMonroeDriveLeg.to);
@@ -214,6 +215,7 @@ public class ManageLegTraversalTest {
         Coordinates virginiaAvenuePoint = new Coordinates(virginiaAvenueNortheastStep);
         Coordinates pointBeforeTurn = new Coordinates(33.78151,-84.36481);
         Coordinates pointAfterTurn = new Coordinates(33.78165, -84.36484);
+        Coordinates pointOnKanugaStreet = new Coordinates(33.781544, -84.367849);
 
         Leg firstBusLeg = firstLegBusTransit.legs.get(0);
         Coordinates busStopCoords = new Coordinates(firstBusLeg.from);
@@ -355,6 +357,15 @@ public class ManageLegTraversalTest {
                     new ContinueInstruction(virginiaAvenueNortheastStep, locale).build(),
                     false,
                     "After turn left on to Virginia Avenue should provide continue instruction."
+                )
+            ),
+            Arguments.of(
+                walkLeg,
+                new TraceData(
+                    createPoint(pointOnKanugaStreet, 0, NORTH_WEST_BEARING),
+                    new ContinueInstruction(kanugaStreetStep, locale).build(),
+                    false,
+                    "After final turn on to Kanuga Street should provide continue instruction."
                 )
             ),
             Arguments.of(

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -38,6 +38,7 @@ import static org.opentripplanner.middleware.triptracker.ManageLegTraversal.getS
 import static org.opentripplanner.middleware.triptracker.ManageLegTraversal.interpolatePoints;
 import static org.opentripplanner.middleware.triptracker.TravelerLocator.getNextWayPoint;
 import static org.opentripplanner.middleware.triptracker.TravelerLocator.isWithinExclusionZone;
+import static org.opentripplanner.middleware.triptracker.instruction.OnTrackInstruction.TRIP_INSTRUCTION_END_OF_ROUTING;
 import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.NO_INSTRUCTION;
 import static org.opentripplanner.middleware.utils.GeometryUtils.calculateBearing;
 import static org.opentripplanner.middleware.utils.GeometryUtils.createPoint;
@@ -52,6 +53,7 @@ public class ManageLegTraversalTest {
     private static List<Place> midtownToAnsleyIntermediateStops;
     private static Itinerary firstLegBusTransit;
     private static Itinerary baptistChurchToEastCroganStreetIntinerary;
+    private static Itinerary destinationAwayFromSidewalk;
 
     private static final Locale locale = Locale.US;
 
@@ -82,6 +84,10 @@ public class ManageLegTraversalTest {
         );
         baptistChurchToEastCroganStreetIntinerary = JsonUtils.getPOJOFromJSON(
             CommonTestUtils.getTestResourceAsString("controllers/api/baptist-church-to-east-crogan-street.json"),
+            Itinerary.class
+        );
+        destinationAwayFromSidewalk = JsonUtils.getPOJOFromJSON(
+            CommonTestUtils.getTestResourceAsString("controllers/api/destination-away-from-sidewalk.json"),
             Itinerary.class
         );
         // Hold on to the original list of intermediate stops (some tests will overwrite it)
@@ -225,6 +231,9 @@ public class ManageLegTraversalTest {
         Step southClaytonSt = toEastCroganFirstLeg.steps.get(1);
         Step eastCroganSt = toEastCroganFirstLeg.steps.get(2);
         Coordinates pointOnSouthClaytonSt = new Coordinates(33.955561, -83.988204);
+
+        Leg legToDestinationAwayFromSidewalk = destinationAwayFromSidewalk.legs.get(0);
+        Coordinates pointNearEndOfSidewalk = new Coordinates(33.958954, -84.006451);
 
         return Stream.of(
             Arguments.of(
@@ -411,6 +420,14 @@ public class ManageLegTraversalTest {
                     new ContinueInstruction(eastCroganSt, locale),
                     false,
                     "On track passed next step, provide continue instruction for next step."
+                )
+            ),
+            Arguments.of(
+                legToDestinationAwayFromSidewalk,
+                new TraceData(
+                    pointNearEndOfSidewalk,
+                     TRIP_INSTRUCTION_END_OF_ROUTING,
+                    "Provide instruction for reaching destination if it is not near end of shape of walk leg."
                 )
             )
         );

--- a/src/test/resources/org/opentripplanner/middleware/controllers/api/destination-away-from-sidewalk.json
+++ b/src/test/resources/org/opentripplanner/middleware/controllers/api/destination-away-from-sidewalk.json
@@ -1,0 +1,95 @@
+{
+  "accessibilityScore": null,
+  "duration": 214,
+  "endTime": 1736520694000,
+  "legs": [
+    {
+      "accessibilityScore": null,
+      "agency": null,
+      "alerts": [],
+      "arrivalDelay": 0,
+      "departureDelay": 0,
+      "distance": 266.62,
+      "dropoffType": "SCHEDULED",
+      "duration": 214,
+      "endTime": 1736520694000,
+      "fareProducts": [],
+      "from": {
+        "lat": 33.9604237,
+        "lon": -84.0044676,
+        "name": "33.96042, -84.00447",
+        "rentalVehicle": null,
+        "stop": null,
+        "vertexType": "NORMAL"
+      },
+      "headsign": null,
+      "interlineWithPreviousLeg": false,
+      "intermediateStops": null,
+      "legGeometry": {
+        "length": 20,
+        "points": "{{gnEpbv_OLKTRRTBFJHd@f@j@t@BF@@@BBDR`@NTXh@V^HJFPX|@D\\"
+      },
+      "mode": "WALK",
+      "pickupBookingInfo": null,
+      "pickupType": "SCHEDULED",
+      "realTime": false,
+      "realtimeState": null,
+      "rentedBike": false,
+      "rideHailingEstimate": null,
+      "route": null,
+      "startTime": 1736520480000,
+      "steps": [
+        {
+          "absoluteDirection": "SOUTHEAST",
+          "alerts": [],
+          "area": false,
+          "distance": 9.46,
+          "elevationProfile": [],
+          "lat": 33.9604623,
+          "lon": -84.0044086,
+          "relativeDirection": "DEPART",
+          "stayOn": false,
+          "streetName": "crossing over service road☆ tmp r0.675 l9.460"
+        },
+        {
+          "absoluteDirection": "SOUTHWEST",
+          "alerts": [],
+          "area": false,
+          "distance": 30.37,
+          "elevationProfile": [],
+          "lat": 33.9603955,
+          "lon": -84.0043451,
+          "relativeDirection": "RIGHT",
+          "stayOn": false,
+          "streetName": "crossing over West Pike Street☆"
+        },
+        {
+          "absoluteDirection": "SOUTHWEST",
+          "alerts": [],
+          "area": false,
+          "distance": 226.8,
+          "elevationProfile": [],
+          "lat": 33.9601889,
+          "lon": -84.0045587,
+          "relativeDirection": "CONTINUE",
+          "stayOn": false,
+          "streetName": "Old Norcross Road★"
+        }
+      ],
+      "to": {
+        "lat": 33.9585118,
+        "lon": -84.0066056,
+        "name": "578 Old Norcross Road, Lawrenceville, GA, USA",
+        "rentalVehicle": null,
+        "stop": null,
+        "vertexType": "NORMAL"
+      },
+      "transitLeg": false,
+      "trip": null
+    }
+  ],
+  "startTime": 1736520480000,
+  "transfers": 0,
+  "waitingTime": 0,
+  "walkTime": 214
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR improves instructions on walk legs after the last turn is taken:
- "Continue" instructions, instead of "NO_INSTRUCTION", are given on the last street/sidewalk/path,
- If the destination is away from the last street/sidewalk/path in an itinerary, an instruction: "Your destination is in the vicinity" is emitted when the traveler reaches the end of the leg shape. (An extra step is added behind the scenes to accommodate that).
