### PR TITLE
Fix gap with no instruction on first walk section.

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -215,6 +215,8 @@ public class TravelerLocator {
                 } else if (isWithinStepRange(travelerPosition, nextStep)) {
                     return new ContinueInstruction(nextStep, locale);
                 }
+            } else if (nextStep != null) {
+                return new ContinueInstruction(nextStep, locale);
             }
         }
         return null;

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -50,6 +50,7 @@ public class ManageLegTraversalTest {
 
     private static Itinerary adairAvenueToMonroeDriveItinerary;
     private static Itinerary midtownToAnsleyItinerary;
+    private static Itinerary midtownWalkItinerary;
     private static List<Place> midtownToAnsleyIntermediateStops;
     private static Itinerary firstLegBusTransit;
     private static Itinerary baptistChurchToEastCroganStreetIntinerary;
@@ -76,6 +77,10 @@ public class ManageLegTraversalTest {
         );
         midtownToAnsleyItinerary = JsonUtils.getPOJOFromJSON(
             CommonTestUtils.getTestResourceAsString("controllers/api/27nb-midtown-to-ansley.json"),
+            Itinerary.class
+        );
+        midtownWalkItinerary = JsonUtils.getPOJOFromJSON(
+            CommonTestUtils.getTestResourceAsString("controllers/api/midtown-walk.json"),
             Itinerary.class
         );
         firstLegBusTransit = JsonUtils.getPOJOFromJSON(
@@ -216,6 +221,7 @@ public class ManageLegTraversalTest {
         Coordinates originCoords = new Coordinates(adairAvenueToMonroeDriveLeg.from);
         Coordinates destinationCoords = new Coordinates(adairAvenueToMonroeDriveLeg.to);
         Coordinates adairAvenueNortheastCoords = new Coordinates(adairAvenueNortheastStep);
+        Coordinates midtownWalkCoords = new Coordinates(33.784372, -84.381410); //33.784382, -84.381743);
         Coordinates virginiaCircleNortheastCoords = new Coordinates(virginiaCircleNortheastStep);
         Coordinates ponceDeLeonPlaceNortheastCoords = new Coordinates(ponceDeLeonPlaceNortheastStep);
         Coordinates virginiaAvenuePoint = new Coordinates(virginiaAvenueNortheastStep);
@@ -234,6 +240,9 @@ public class ManageLegTraversalTest {
 
         Leg legToDestinationAwayFromSidewalk = destinationAwayFromSidewalk.legs.get(0);
         Coordinates pointNearEndOfSidewalk = new Coordinates(33.958954, -84.006451);
+
+        Leg midtownWalkLeg = midtownWalkItinerary.legs.get(0);
+        Step midtownWalkFirstStep = midtownWalkLeg.steps.get(0);
 
         return Stream.of(
             Arguments.of(
@@ -428,6 +437,15 @@ public class ManageLegTraversalTest {
                     pointNearEndOfSidewalk,
                      TRIP_INSTRUCTION_END_OF_ROUTING,
                     "Provide instruction for reaching destination if it is not near end of shape of walk leg."
+                )
+            ),
+            Arguments.of(
+                midtownWalkLeg,
+                new TraceData(
+                    midtownWalkCoords,
+                    new ContinueInstruction(midtownWalkFirstStep, locale),
+                    false,
+                    "Immediately after departure instruction. Should provide a 'Continue' instruction and not 'No instruction'."
                 )
             )
         );

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -221,7 +221,7 @@ public class ManageLegTraversalTest {
         Coordinates originCoords = new Coordinates(adairAvenueToMonroeDriveLeg.from);
         Coordinates destinationCoords = new Coordinates(adairAvenueToMonroeDriveLeg.to);
         Coordinates adairAvenueNortheastCoords = new Coordinates(adairAvenueNortheastStep);
-        Coordinates midtownWalkCoords = new Coordinates(33.784372, -84.381410); //33.784382, -84.381743);
+        Coordinates midtownWalkCoords = new Coordinates(33.784372, -84.381410);
         Coordinates virginiaCircleNortheastCoords = new Coordinates(virginiaCircleNortheastStep);
         Coordinates ponceDeLeonPlaceNortheastCoords = new Coordinates(ponceDeLeonPlaceNortheastStep);
         Coordinates virginiaAvenuePoint = new Coordinates(virginiaAvenueNortheastStep);

--- a/src/test/resources/org/opentripplanner/middleware/controllers/api/midtown-walk.json
+++ b/src/test/resources/org/opentripplanner/middleware/controllers/api/midtown-walk.json
@@ -1,0 +1,118 @@
+{
+    "duration": 564,
+    "startTime": 1738165800000,
+    "endTime": 1738166364000,
+    "walkTime": 564,
+    "transitTime": 0,
+    "waitingTime": 0,
+    "walkDistance": 0,
+    "walkLimitExceeded": false,
+    "elevationLost": 0,
+    "elevationGained": 0,
+    "transfers": 0,
+    "fare": null,
+    "legs": [
+        {
+            "startTime": 1738165800000,
+            "endTime": 1738166364000,
+            "departureDelay": 0,
+            "arrivalDelay": 0,
+            "realTime": false,
+            "distance": 718.75,
+            "mode": "WALK",
+            "interlineWithPreviousLeg": false,
+            "from": {
+                "name": "(Current Location)",
+                "lon": -84.3813736,
+                "lat": 33.7843782,
+                "vertexType": "NORMAL"
+            },
+            "to": {
+                "name": "1161 14th Place NE, Atlanta, GA, USA",
+                "lon": -84.3791163,
+                "lat": 33.7864105,
+                "vertexType": "NORMAL"
+            },
+            "legGeometry": {
+                "points": "ioemErv_bO?fA@nAWCwAAuAA?aC@uBBaC@mE?GBiB@E@AAAMEICA@ACCAOE_AUq@My@EA?A@??AB?P?pB?b@",
+                "length": 31
+            },
+            "rentedBike": false,
+            "transitLeg": false,
+            "duration": 564,
+            "steps": [
+                {
+                    "distance": 70.49,
+                    "relativeDirection": "DEPART",
+                    "streetName": "12th Street Northeast",
+                    "absoluteDirection": "WEST",
+                    "stayOn": false,
+                    "area": false,
+                    "lon": -84.3813737,
+                    "lat": 33.7843714
+                },
+                {
+                    "distance": 110.68,
+                    "relativeDirection": "RIGHT",
+                    "streetName": "Juniper Street Northeast",
+                    "absoluteDirection": "NORTH",
+                    "stayOn": true,
+                    "area": false,
+                    "lon": -84.3821362,
+                    "lat": 33.7843651
+                },
+                {
+                    "distance": 326.91,
+                    "relativeDirection": "RIGHT",
+                    "streetName": "13th Street Northeast",
+                    "absoluteDirection": "EAST",
+                    "stayOn": true,
+                    "area": false,
+                    "lon": -84.3820913,
+                    "lat": 33.7853585
+                },
+                {
+                    "distance": 16.76,
+                    "relativeDirection": "LEFT",
+                    "streetName": "crossing over 13th Street Northeast",
+                    "absoluteDirection": "NORTH",
+                    "stayOn": false,
+                    "area": false,
+                    "lon": -84.3785614,
+                    "lat": 33.7852777
+                },
+                {
+                    "distance": 112.73,
+                    "relativeDirection": "CONTINUE",
+                    "streetName": "Piedmont Avenue Northeast",
+                    "absoluteDirection": "NORTHEAST",
+                    "stayOn": false,
+                    "area": false,
+                    "lon": -84.378514,
+                    "lat": 33.7854188
+                },
+                {
+                    "distance": 3.08,
+                    "relativeDirection": "LEFT",
+                    "streetName": "Piedmont Avenue Northeast",
+                    "absoluteDirection": "NORTHWEST",
+                    "stayOn": true,
+                    "area": false,
+                    "lon": -84.3782455,
+                    "lat": 33.7863984
+                },
+                {
+                    "distance": 78.12,
+                    "relativeDirection": "SLIGHTLY_LEFT",
+                    "streetName": "14th Street Northeast",
+                    "absoluteDirection": "WEST",
+                    "stayOn": true,
+                    "area": false,
+                    "lon": -84.3782709,
+                    "lat": 33.7864153
+                }
+            ]
+        }
+    ],
+    "alerts": []
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR addresses a lack of instructions on a walk leg after a traveler leaves the origin and follows the first street.
