### PR TITLE
Config params for trip survey upload folder and file prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ The special E2E client settings should be defined in `env.yml`:
 | TRIP_SURVEY_ID | string | Optional | abcdef123y | The ID of a survey (on the platform of your choice) for trip-related feedback. |
 | TRIP_SURVEY_SUBDOMAIN | string | Optional | abcabc12a | The subdomain of a website where the trip-related surveys are administered. |
 | TRIP_SURVEY_API_TOKEN | string | Optional | abcdef123y | The token for the survey API for downloading responses. |
+| TRIP_SURVEY_RESPONSES_FILE_PREFIX | string | Optional | trip-survey-responses | The file name prefix for compiled trip survey responses. |
+| TRIP_SURVEY_RESPONSES_FOLDER | string | Optional | trip-survey-responses | The S3 folder name where compiled survey responses will be uploaded. |
 | TWILIO_ACCOUNT_SID | string | Optional | your-account-sid | Twilio settings available at: https://twilio.com/user/account |
 | TRUSTED_COMPANION_CONFIRMATION_PAGE_URL | string | Optional | https://otp-server.example.com/trusted/confirmation | URL to the trusted companion confirmation page. This page should support handling an error URL parameter. |
 | TWILIO_AUTH_TOKEN | string | Optional | your-auth-token | Twilio settings available at: https://twilio.com/user/account |

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TripSurveyUploadJob.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TripSurveyUploadJob.java
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.opentripplanner.middleware.connecteddataplatform.ConnectedDataManager.CONNECTED_DATA_PLATFORM_S3_BUCKET_NAME;
+import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
 
 /**
  * This job will analyze completed trips with deviations and send survey notifications about select trips.
@@ -28,7 +29,10 @@ import static org.opentripplanner.middleware.connecteddataplatform.ConnectedData
 public class TripSurveyUploadJob extends IntervalUploadJob<TripSurveyUpload> {
     private static final Logger LOG = LoggerFactory.getLogger(TripSurveyUploadJob.class);
 
-    public static final String SURVEY_ZIP_FILE_PREFIX = "merged";
+
+    public static final String DEFAULT_TRIP_SURVEY_PREFIX = "trip-survey-responses";
+    public static final String SURVEY_ZIP_FILE_PREFIX = getConfigPropertyAsText("TRIP_SURVEY_RESPONSES_FILE_PREFIX", DEFAULT_TRIP_SURVEY_PREFIX);
+    public static final String SURVEY_FOLDER = getConfigPropertyAsText("TRIP_SURVEY_RESPONSES_FOLDER", DEFAULT_TRIP_SURVEY_PREFIX);
 
     private final Function<LocalDateTime, Responses> surveyApiResponseProvider;
 
@@ -79,7 +83,7 @@ public class TripSurveyUploadJob extends IntervalUploadJob<TripSurveyUpload> {
         String tempDataFile = uploadFiles.getTempDataFile();
         try (uploadFiles) {
             FileUtils.writeToFile(tempDataFile, false, responses.toCsv(csvHeaders));
-            uploadFiles.compressAndUpload("trip-survey-responses");
+            uploadFiles.compressAndUpload(SURVEY_FOLDER);
             return true;
         } catch (IOException e) {
             LOG.warn("Error writing survey results to {}", tempDataFile);

--- a/src/main/resources/env.schema.json
+++ b/src/main/resources/env.schema.json
@@ -334,6 +334,16 @@
       "examples": ["abcdef123y"],
       "description": "The token for the survey API for downloading responses."
     },
+    "TRIP_SURVEY_RESPONSES_FILE_PREFIX": {
+      "type": "string",
+      "examples": ["trip-survey-responses"],
+      "description": "The file name prefix for compiled trip survey responses."
+    },
+    "TRIP_SURVEY_RESPONSES_FOLDER": {
+      "type": "string",
+      "examples": ["trip-survey-responses"],
+      "description": "The S3 folder name where compiled survey responses will be uploaded."
+    },
     "TWILIO_ACCOUNT_SID": {
       "type": "string",
       "examples": ["your-account-sid"],


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR makes the S3 folder and file prefix for the compiled trip surveys configurable. New optional config params:
- `TRIP_SURVEY_RESPONSES_FILE_PREFIX` for the file names
- `TRIP_SURVEY_RESPONSES_FOLDER` for the S3 folder of the existing connected data platform bucket.
