### PR TITLE
No deviation if near bus stop

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/ManageTripTracking.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/ManageTripTracking.java
@@ -130,8 +130,8 @@ public class ManageTripTracking {
 
             if (isDeviatedWithOnTrackInstruction(tripStatus, instruction)) {
                 // Deem traveler on track (not deviated) if they are in the 'upcoming' range of a bus stop
-                // or the departure loaction.
-                // (If near a bus stop, applicable bus notifications would have already been triggered.
+                // or the departure location.
+                // (If near a bus stop, applicable bus notifications would have already been triggered.)
                 tripStatus = TripStatus.getTimingStatus(travelerPosition);
             }
 

--- a/src/main/java/org/opentripplanner/middleware/triptracker/ManageTripTracking.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/ManageTripTracking.java
@@ -15,8 +15,10 @@ import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.OtpResponse;
 import org.opentripplanner.middleware.otp.response.TripPlan;
 import org.opentripplanner.middleware.persistence.Persistence;
+import org.opentripplanner.middleware.triptracker.instruction.OnTrackInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.SelfLegInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.TripInstruction;
+import org.opentripplanner.middleware.triptracker.instruction.WaitForTransitInstruction;
 import org.opentripplanner.middleware.triptracker.interactions.TripActions;
 import org.opentripplanner.middleware.triptracker.interactions.busnotifiers.BusOperatorActions;
 import org.opentripplanner.middleware.triptracker.response.EndTrackingResponse;
@@ -126,6 +128,13 @@ public class ManageTripTracking {
                 create || rerouted
             );
 
+            if (isDeviatedWithOnTrackInstruction(tripStatus, instruction)) {
+                // Deem traveler on track (not deviated) if they are in the 'upcoming' range of a bus stop
+                // or the departure loaction.
+                // (If near a bus stop, applicable bus notifications would have already been triggered.
+                tripStatus = TripStatus.getTimingStatus(travelerPosition);
+            }
+
             // Perform interactions such as triggering traffic signals when approaching segments so configured.
             // It is assumed to be ok to repeatedly perform the interaction.
             if (instruction instanceof SelfLegInstruction && instruction.distance <= TRIP_INSTRUCTION_UPCOMING_RADIUS) {
@@ -146,6 +155,15 @@ public class ManageTripTracking {
             logMessageAndHalt(request, HttpStatus.INTERNAL_SERVER_ERROR_500, e.getMessage());
         }
         return null;
+    }
+
+    /**
+     * Detect if we are deeming a traveler deviated while giving out a non-deviated instruction
+     * (to prevent, for instance, being offered rerouting while near a bus stop).
+     */
+    private static boolean isDeviatedWithOnTrackInstruction(TripStatus tripStatus, TripInstruction instruction) {
+        return tripStatus == TripStatus.DEVIATED &&
+            (instruction instanceof WaitForTransitInstruction || instruction instanceof OnTrackInstruction);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -168,12 +168,11 @@ public class TravelerLocator {
         Locale locale = travelerPosition.locale;
 
         if (isApproachingEndOfLeg(travelerPosition)) {
-            if (travelerPosition.isNearTransitLegOrigin()) {
-                // TODO: make sendBusNotification not return a boolean.
-                if (sendBusNotification(travelerPosition)) {
-                    // Regardless of whether the notification is sent or qualifies, provide a 'wait for bus' instruction.
-                    return new WaitForTransitInstruction(travelerPosition.nextLeg, travelerPosition.currentTime, locale);
-                }
+            Leg transitLeg = travelerPosition.getTransitLegWithClosestUpcomingOrigin();
+            if (transitLeg != null && shouldSendBusNotification(travelerPosition)) {
+                sendBusNotifications(travelerPosition, transitLeg);
+                // Regardless of whether the notification is sent or qualifies, provide a 'wait for bus' instruction.
+                return new WaitForTransitInstruction(travelerPosition.nextLeg, travelerPosition.currentTime, locale);
             }
             return new OnTrackInstruction(getDistanceToEndOfLeg(travelerPosition), travelerPosition.expectedLeg.to.name, locale);
         }
@@ -249,18 +248,21 @@ public class TravelerLocator {
     }
 
     /**
-     * Send bus notification if the first leg is a bus leg or approaching a bus leg and within the notify window.
+     * Whether to send a bus notification if the first leg is a bus leg or approaching a bus leg and within the notify window.
      */
-    public static boolean sendBusNotification(TravelerPosition travelerPosition) {
+    public static boolean shouldSendBusNotification(TravelerPosition travelerPosition) {
         // TODO: rework this condition
-        Leg busLeg = atStartOfTransitTrip(travelerPosition) || Boolean.TRUE.equals(travelerPosition.expectedLeg.transitLeg) ? travelerPosition.expectedLeg : travelerPosition.nextLeg;
-        if (isBusLeg(busLeg) && isWithinOperationalNotifyWindow(travelerPosition.currentTime, busLeg)) {
-            BusOperatorActions
-                .getDefault()
-                .handleSendNotificationAction(travelerPosition, busLeg);
-            return true;
-        }
-        return false;
+        Leg busLeg = atStartOfTransitTrip(travelerPosition) || travelerPosition.expectedLeg != null && Boolean.TRUE.equals(travelerPosition.expectedLeg.transitLeg) ? travelerPosition.expectedLeg : travelerPosition.nextLeg;
+        return (isBusLeg(busLeg) && isWithinOperationalNotifyWindow(travelerPosition.currentTime, busLeg));
+    }
+
+    /**
+     * Send bus notification for the corresponding leg.
+     */
+    private static void sendBusNotifications(TravelerPosition travelerPosition, Leg busLeg) {
+        BusOperatorActions
+            .getDefault()
+            .handleSendNotificationAction(travelerPosition, busLeg);
     }
 
     /**
@@ -283,12 +285,11 @@ public class TravelerLocator {
         Leg expectedLeg = travelerPosition.expectedLeg;
         String finalStop = expectedLeg.to.name;
 
-        if (travelerPosition.isNearTransitLegOrigin()) {
-            // TODO: Make sendBusNotification not return a boolean.
-            if (sendBusNotification(travelerPosition)) {
-                // Regardless of whether the notification is sent or qualifies, provide a 'wait for bus' instruction.
-                return new WaitForTransitInstruction(expectedLeg, travelerPosition.currentTime, locale);
-            }
+        Leg transitLeg = travelerPosition.getTransitLegWithClosestUpcomingOrigin();
+        if (transitLeg != null && shouldSendBusNotification(travelerPosition)) {
+            sendBusNotifications(travelerPosition, transitLeg);
+            // Regardless of whether the notification is sent or qualifies, provide a 'wait for bus' instruction.
+            return new WaitForTransitInstruction(expectedLeg, travelerPosition.currentTime, locale);
         }
 
         if (isApproachingEndOfLeg(travelerPosition)) {

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -169,10 +169,10 @@ public class TravelerLocator {
 
         if (isApproachingEndOfLeg(travelerPosition)) {
             Leg transitLeg = travelerPosition.getTransitLegWithClosestUpcomingOrigin();
-            if (transitLeg != null && shouldSendBusNotification(travelerPosition)) {
+            if (transitLeg != null && shouldSendBusNotification(transitLeg, travelerPosition.currentTime)) {
                 sendBusNotifications(travelerPosition, transitLeg);
                 // Regardless of whether the notification is sent or qualifies, provide a 'wait for bus' instruction.
-                return new WaitForTransitInstruction(travelerPosition.nextLeg, travelerPosition.currentTime, locale);
+                return new WaitForTransitInstruction(transitLeg, travelerPosition.currentTime, locale);
             }
             return new OnTrackInstruction(getDistanceToEndOfLeg(travelerPosition), travelerPosition.expectedLeg.to.name, locale);
         }
@@ -250,10 +250,8 @@ public class TravelerLocator {
     /**
      * Whether to send a bus notification if the first leg is a bus leg or approaching a bus leg and within the notify window.
      */
-    public static boolean shouldSendBusNotification(TravelerPosition travelerPosition) {
-        // TODO: rework this condition
-        Leg busLeg = atStartOfTransitTrip(travelerPosition) || travelerPosition.expectedLeg != null && Boolean.TRUE.equals(travelerPosition.expectedLeg.transitLeg) ? travelerPosition.expectedLeg : travelerPosition.nextLeg;
-        return (isBusLeg(busLeg) && isWithinOperationalNotifyWindow(travelerPosition.currentTime, busLeg));
+    public static boolean shouldSendBusNotification(Leg leg, Instant currentTime) {
+        return (isBusLeg(leg) && isWithinOperationalNotifyWindow(currentTime, leg));
     }
 
     /**
@@ -286,10 +284,10 @@ public class TravelerLocator {
         String finalStop = expectedLeg.to.name;
 
         Leg transitLeg = travelerPosition.getTransitLegWithClosestUpcomingOrigin();
-        if (transitLeg != null && shouldSendBusNotification(travelerPosition)) {
+        if (transitLeg != null && shouldSendBusNotification(transitLeg, travelerPosition.currentTime)) {
             sendBusNotifications(travelerPosition, transitLeg);
             // Regardless of whether the notification is sent or qualifies, provide a 'wait for bus' instruction.
-            return new WaitForTransitInstruction(expectedLeg, travelerPosition.currentTime, locale);
+            return new WaitForTransitInstruction(transitLeg, travelerPosition.currentTime, locale);
         }
 
         if (isApproachingEndOfLeg(travelerPosition)) {

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -168,9 +168,12 @@ public class TravelerLocator {
         Locale locale = travelerPosition.locale;
 
         if (isApproachingEndOfLeg(travelerPosition)) {
-            if (sendBusNotification(travelerPosition)) {
-                // Regardless of whether the notification is sent or qualifies, provide a 'wait for bus' instruction.
-                return new WaitForTransitInstruction(travelerPosition.nextLeg, travelerPosition.currentTime, locale);
+            if (travelerPosition.isNearTransitLegOrigin()) {
+                // TODO: make sendBusNotification not return a boolean.
+                if (sendBusNotification(travelerPosition)) {
+                    // Regardless of whether the notification is sent or qualifies, provide a 'wait for bus' instruction.
+                    return new WaitForTransitInstruction(travelerPosition.nextLeg, travelerPosition.currentTime, locale);
+                }
             }
             return new OnTrackInstruction(getDistanceToEndOfLeg(travelerPosition), travelerPosition.expectedLeg.to.name, locale);
         }
@@ -249,7 +252,8 @@ public class TravelerLocator {
      * Send bus notification if the first leg is a bus leg or approaching a bus leg and within the notify window.
      */
     public static boolean sendBusNotification(TravelerPosition travelerPosition) {
-        Leg busLeg = atStartOfTransitTrip(travelerPosition) ? travelerPosition.expectedLeg : travelerPosition.nextLeg;
+        // TODO: rework this condition
+        Leg busLeg = atStartOfTransitTrip(travelerPosition) || Boolean.TRUE.equals(travelerPosition.expectedLeg.transitLeg) ? travelerPosition.expectedLeg : travelerPosition.nextLeg;
         if (isBusLeg(busLeg) && isWithinOperationalNotifyWindow(travelerPosition.currentTime, busLeg)) {
             BusOperatorActions
                 .getDefault()
@@ -279,9 +283,12 @@ public class TravelerLocator {
         Leg expectedLeg = travelerPosition.expectedLeg;
         String finalStop = expectedLeg.to.name;
 
-        if (sendBusNotification(travelerPosition)) {
-            // Regardless of whether the notification is sent or qualifies, provide a 'wait for bus' instruction.
-            return new WaitForTransitInstruction(expectedLeg, travelerPosition.currentTime, locale);
+        if (travelerPosition.isNearTransitLegOrigin()) {
+            // TODO: Make sendBusNotification not return a boolean.
+            if (sendBusNotification(travelerPosition)) {
+                // Regardless of whether the notification is sent or qualifies, provide a 'wait for bus' instruction.
+                return new WaitForTransitInstruction(expectedLeg, travelerPosition.currentTime, locale);
+            }
         }
 
         if (isApproachingEndOfLeg(travelerPosition)) {

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerPosition.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerPosition.java
@@ -88,12 +88,12 @@ public class TravelerPosition {
      * Returns the closest transit leg in 'upcoming' radius eligible for a "Wait for transit" instruction.
      */
     public Leg getTransitLegWithClosestUpcomingOrigin() {
-        double distance1 = distanceToTransitLegOrigin(currentPosition, expectedLeg);
-        double distance2 = distanceToTransitLegOrigin(currentPosition, nextLeg);
+        double distancetoExpectedLeg = distanceToTransitLegOrigin(currentPosition, expectedLeg);
+        double distanceToNextLeg = distanceToTransitLegOrigin(currentPosition, nextLeg);
 
-        if (distance1 <= TRIP_INSTRUCTION_UPCOMING_RADIUS && distance1 < distance2) {
+        if (distancetoExpectedLeg <= TRIP_INSTRUCTION_UPCOMING_RADIUS && distancetoExpectedLeg < distanceToNextLeg) {
             return expectedLeg;
-        } else if (distance2 <= TRIP_INSTRUCTION_UPCOMING_RADIUS && distance2 < distance1) {
+        } else if (distanceToNextLeg <= TRIP_INSTRUCTION_UPCOMING_RADIUS && distanceToNextLeg < distancetoExpectedLeg) {
             return nextLeg;
         } else {
             return null;

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerPosition.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerPosition.java
@@ -87,9 +87,9 @@ public class TravelerPosition {
     /**
      * Whether someone is in 'upcoming' walking range of the origin/departure stop of a transit leg.
      */
-    public static boolean isNearTransitLegOrigin(TravelerPosition pos) {
-        double distance1 = distanceToTransitLegOrigin(pos.currentPosition, pos.expectedLeg);
-        double distance2 = distanceToTransitLegOrigin(pos.currentPosition, pos.nextLeg);
+    public boolean isNearTransitLegOrigin() {
+        double distance1 = distanceToTransitLegOrigin(currentPosition, expectedLeg);
+        double distance2 = distanceToTransitLegOrigin(currentPosition, nextLeg);
 
         return distance1 <= TRIP_INSTRUCTION_UPCOMING_RADIUS || distance2 <= TRIP_INSTRUCTION_UPCOMING_RADIUS;
     }

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerPosition.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerPosition.java
@@ -13,6 +13,8 @@ import java.util.Locale;
 import static org.opentripplanner.middleware.triptracker.ManageLegTraversal.getExpectedLeg;
 import static org.opentripplanner.middleware.triptracker.ManageLegTraversal.getNextLeg;
 import static org.opentripplanner.middleware.triptracker.ManageLegTraversal.getSegmentFromPosition;
+import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.TRIP_INSTRUCTION_UPCOMING_RADIUS;
+import static org.opentripplanner.middleware.utils.GeometryUtils.getDistance;
 import static org.opentripplanner.middleware.utils.GeometryUtils.getDistanceFromLine;
 import static org.opentripplanner.middleware.utils.ItineraryUtils.getFirstLeg;
 
@@ -80,6 +82,22 @@ public class TravelerPosition {
             this.locale = I18nUtils.getOtpUserLocale(otpUser);
         }
         firstLegOfTrip = getFirstLeg(itinerary);
+    }
+
+    /**
+     * Whether someone is in 'upcoming' walking range of the origin/departure stop of a transit leg.
+     */
+    public static boolean isNearTransitLegOrigin(TravelerPosition pos) {
+        double distance1 = distanceToTransitLegOrigin(pos.currentPosition, pos.expectedLeg);
+        double distance2 = distanceToTransitLegOrigin(pos.currentPosition, pos.nextLeg);
+
+        return distance1 <= TRIP_INSTRUCTION_UPCOMING_RADIUS || distance2 <= TRIP_INSTRUCTION_UPCOMING_RADIUS;
+    }
+
+    private static double distanceToTransitLegOrigin(Coordinates position, Leg leg) {
+        return leg != null && leg.transitLeg && leg.from != null
+            ? getDistance(position, leg.from.toCoordinates())
+            : Double.MAX_VALUE;
     }
 
     /** Computes the current deviation in meters from the expected itinerary. */

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerPosition.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerPosition.java
@@ -85,13 +85,19 @@ public class TravelerPosition {
     }
 
     /**
-     * Whether someone is in 'upcoming' walking range of the origin/departure stop of a transit leg.
+     * Returns the closest transit leg in 'upcoming' radius eligible for a "Wait for transit" instruction.
      */
-    public boolean isNearTransitLegOrigin() {
+    public Leg getTransitLegWithClosestUpcomingOrigin() {
         double distance1 = distanceToTransitLegOrigin(currentPosition, expectedLeg);
         double distance2 = distanceToTransitLegOrigin(currentPosition, nextLeg);
 
-        return distance1 <= TRIP_INSTRUCTION_UPCOMING_RADIUS || distance2 <= TRIP_INSTRUCTION_UPCOMING_RADIUS;
+        if (distance1 <= TRIP_INSTRUCTION_UPCOMING_RADIUS && distance1 < distance2) {
+            return expectedLeg;
+        } else if (distance2 <= TRIP_INSTRUCTION_UPCOMING_RADIUS && distance2 < distance1) {
+            return nextLeg;
+        } else {
+            return null;
+        }
     }
 
     private static double distanceToTransitLegOrigin(Coordinates position, Leg leg) {

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TripStatus.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TripStatus.java
@@ -71,21 +71,28 @@ public enum TripStatus {
             travelerPosition.legSegmentFromPosition != null &&
             isWithinModeRadius(travelerPosition)
         ) {
-            Instant segmentStartTime = getSegmentStartTime(travelerPosition);
-            Instant segmentEndTime = travelerPosition
-                .expectedLeg
-                .startTime
-                .toInstant()
-                .plusSeconds((long) travelerPosition.legSegmentFromPosition.cumulativeTime);
-            if (travelerPosition.currentTime.isBefore(segmentStartTime)) {
-                return TripStatus.AHEAD_OF_SCHEDULE;
-            } else if (travelerPosition.currentTime.isAfter(segmentEndTime)) {
-                return TripStatus.BEHIND_SCHEDULE;
-            } else {
-                return TripStatus.ON_SCHEDULE;
-            }
+            return getTimingStatus(travelerPosition);
         }
         return TripStatus.DEVIATED;
+    }
+
+    /**
+     * Get the timing status of the traveler.
+     */
+    public static TripStatus getTimingStatus(TravelerPosition travelerPosition) {
+        Instant segmentStartTime = getSegmentStartTime(travelerPosition);
+        Instant segmentEndTime = travelerPosition
+            .expectedLeg
+            .startTime
+            .toInstant()
+            .plusSeconds((long) travelerPosition.legSegmentFromPosition.cumulativeTime);
+        if (travelerPosition.currentTime.isBefore(segmentStartTime)) {
+            return TripStatus.AHEAD_OF_SCHEDULE;
+        } else if (travelerPosition.currentTime.isAfter(segmentEndTime)) {
+            return TripStatus.BEHIND_SCHEDULE;
+        } else {
+            return TripStatus.ON_SCHEDULE;
+        }
     }
 
     public static double getLegSegmentStartTime(LegSegment legSegmentFromPosition) {

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TripStatus.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TripStatus.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 
 import static org.opentripplanner.middleware.triptracker.TravelerLocator.isAtEndOfLeg;
 import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsInt;
-import static org.opentripplanner.middleware.utils.GeometryUtils.getDistanceFromLine;
 
 
 /**

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -348,8 +348,8 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
                 monitoredTrip,
                 createPoint(firstStepCoords, 4, NORTH_EAST_BEARING),
                 new OnTrackInstruction(4, adairAvenueNortheastStep, locale).build(),
-                TripStatus.DEVIATED,
-                "Coords deviated but near first step should produce relevant instruction"
+                TripStatus.ON_SCHEDULE,
+                "Coords in the 'upcoming' range of first step should produce relevant instruction and deemed not deviated."
             ),
             Arguments.of(
                 monitoredTrip,
@@ -403,6 +403,17 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
                     .build(),
                 TripStatus.AHEAD_OF_SCHEDULE,
                 "Arriving ahead of schedule to a bus stop at the end of first leg."
+            ),
+            Arguments.of(
+                multiLegMonitoredTrip,
+                createPoint(multiItinFirstLegDestCoords, 7, WEST_BEARING),
+                new WaitForTransitInstruction(
+                    multiItinBusLeg,
+                    multiItinBusLeg.getScheduledStartTime().toInstant().minus(Duration.ofMinutes(6)),
+                    locale)
+                    .build(),
+                TripStatus.AHEAD_OF_SCHEDULE,
+                "Arriving ahead of schedule near a bus stop (in 'upcoming' range) at the end of first leg."
             ),
             Arguments.of(
                 multiLegMonitoredTrip,

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -404,6 +404,19 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
                 TripStatus.AHEAD_OF_SCHEDULE,
                 "Arriving ahead of schedule to a bus stop at the end of first leg."
             ),
+            // This position overlaps with the beginning of the transit trip,
+            // but it is still within the 'upcoming' radius of the stop, so display a "wait for transit" instruction.
+            Arguments.of(
+                multiLegMonitoredTrip,
+                createPoint(multiItinFirstLegDestCoords, 1.5, NORTH_EAST_BEARING),
+                new WaitForTransitInstruction(
+                    multiItinBusLeg,
+                    multiItinBusLeg.getScheduledStartTime().toInstant().minus(Duration.ofMinutes(6)),
+                    locale)
+                    .build(),
+                TripStatus.AHEAD_OF_SCHEDULE,
+                "Arriving ahead of schedule to a bus stop at the end of first leg should produce a non-trivial instruction."
+            ),
             Arguments.of(
                 multiLegMonitoredTrip,
                 createPoint(multiItinFirstLegDestCoords, 7, WEST_BEARING),

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -488,9 +488,12 @@ public class ManageLegTraversalTest {
         TravelerPosition travelerPosition = new TravelerPosition.Builder()
             .setExpectedLeg(transitLeg)
             .setCurrentPosition(traceData.position)
-            .setCurrentTime(Instant.now())
+            // Unless specified in traceData, an instant corresponding to approx the trip start time should be provided
+            // for correct instructions to be produced.
+            .setCurrentTime(traceData.instant != null ? traceData.instant : transitLeg.startTime.toInstant())
             .setSpeed(traceData.speed)
             .build();
+        travelerPosition.locale = locale;
         TripInstruction tripInstruction = TravelerLocator.getInstruction(traceData.tripStatus, travelerPosition, false);
         assertEquals(traceData.expectedInstruction, tripInstruction != null ? tripInstruction.build() : NO_INSTRUCTION, traceData.message);
     }
@@ -508,7 +511,15 @@ public class ManageLegTraversalTest {
                 new TraceData(
                     originCoords,
                     NO_INSTRUCTION,
-                    "Just boarded the transit vehicle leg, there should not be an instruction."
+                    Instant.now(),
+                    "If present at the transit stop after the trip departure, there should not be an instruction."
+                )
+            ),
+            Arguments.of(
+                new TraceData(
+                    originCoords,
+                    new WaitForTransitInstruction(transitLeg, transitLeg.startTime.toInstant(), locale).build(),
+                    "At the bus stop, or just boarded the transit vehicle leg, it should still tell the user to board the bus."
                 )
             ),
             // This instruction can be missed if the transit vehicle is in a slow/congested area
@@ -674,6 +685,7 @@ public class ManageLegTraversalTest {
         String expectedInstruction;
         boolean isStartOfTrip;
         boolean dismissIntermediateStops;
+        Instant instant;
         String message;
 
         public TraceData(Coordinates position, String expectedInstruction, boolean isStartOfTrip, String message) {
@@ -689,6 +701,11 @@ public class ManageLegTraversalTest {
 
         public TraceData(Coordinates position, String expectedInstruction, String message) {
             this(position, expectedInstruction, false, message);
+        }
+
+        public TraceData(Coordinates position, String expectedInstruction, Instant instant, String message) {
+            this(position, expectedInstruction, false, message);
+            this.instant = instant;
         }
 
         public TraceData(Coordinates position, String expectedInstruction, String message, boolean dismissIntermediateStops) {

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -678,63 +678,6 @@ public class ManageLegTraversalTest {
         assertEquals(busStopToJusticeCenterItinerary.legs.get(0).duration, cumulative, 0.01f);
     }
 
-    private static class TraceData {
-        TripStatus tripStatus = TripStatus.ON_SCHEDULE;
-        Coordinates position;
-        int speed;
-        String expectedInstruction;
-        boolean isStartOfTrip;
-        boolean dismissIntermediateStops;
-        Instant instant;
-        String message;
-
-        public TraceData(Coordinates position, String expectedInstruction, boolean isStartOfTrip, String message) {
-            this.position = position;
-            this.expectedInstruction = expectedInstruction;
-            this.isStartOfTrip = isStartOfTrip;
-            this.message = message;
-        }
-
-        public TraceData(Coordinates position, TripInstruction expectedInstruction, boolean isStartOfTrip, String message) {
-            this(position, expectedInstruction.build(), isStartOfTrip, message);
-        }
-
-        public TraceData(Coordinates position, String expectedInstruction, String message) {
-            this(position, expectedInstruction, false, message);
-        }
-
-        public TraceData(Coordinates position, String expectedInstruction, Instant instant, String message) {
-            this(position, expectedInstruction, false, message);
-            this.instant = instant;
-        }
-
-        public TraceData(Coordinates position, String expectedInstruction, String message, boolean dismissIntermediateStops) {
-            this(position, expectedInstruction, false, message);
-            this.dismissIntermediateStops = dismissIntermediateStops;
-        }
-
-        public TraceData(Coordinates position, int speed, String expectedInstruction, String message) {
-            this(position, expectedInstruction, false, message);
-            this.speed = speed;
-        }
-
-        public TraceData(TripStatus tripStatus, Coordinates position, String expectedInstruction, boolean isStartOfTrip, String message) {
-            this.tripStatus = tripStatus;
-            this.position = position;
-            this.expectedInstruction = expectedInstruction;
-            this.isStartOfTrip = isStartOfTrip;
-            this.message = message;
-        }
-
-        public TraceData(TripStatus tripStatus, Coordinates position, TripInstruction expectedInstruction, boolean isStartOfTrip, String message) {
-            this(tripStatus, position, expectedInstruction.build(), isStartOfTrip, message);
-        }
-
-        public TraceData(TripStatus tripStatus, Coordinates position, String expectedInstruction, String message) {
-            this(tripStatus, position, expectedInstruction, false, message);
-        }
-    }
-
     private static List<LegSegment> createSegmentsForLeg() {
         return interpolatePoints(busStopToJusticeCenterItinerary.legs.get(0));
     }

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -465,6 +465,7 @@ public class ManageLegTraversalTest {
         TravelerPosition travelerPosition = new TravelerPosition.Builder()
             .setExpectedLeg(transitLeg)
             .setCurrentPosition(traceData.position)
+            .setCurrentTime(Instant.now())
             .setSpeed(traceData.speed)
             .build();
         TripInstruction tripInstruction = TravelerLocator.getInstruction(traceData.tripStatus, travelerPosition, false);

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -189,7 +189,7 @@ public class ManageLegTraversalTest {
 
     @ParameterizedTest
     @MethodSource("createTurnByTurnTrace")
-    void canTrackTurnByTurn(Leg firstLeg, TraceData traceData) {
+    void canTrackTurnByTurn(String message, Leg firstLeg, TraceData traceData) {
         TravelerPosition travelerPosition = new TravelerPosition.Builder()
             .setExpectedLeg(firstLeg)
             .setCurrentPosition(traceData.position)
@@ -199,7 +199,7 @@ public class ManageLegTraversalTest {
             .build();
         travelerPosition.locale = locale;
         TripInstruction tripInstruction = TravelerLocator.getInstruction(traceData.tripStatus, travelerPosition, traceData.isStartOfTrip);
-        assertEquals(traceData.expectedInstruction, tripInstruction != null ? tripInstruction.build() : NO_INSTRUCTION, traceData.message);
+        assertEquals(traceData.expectedInstruction, tripInstruction != null ? tripInstruction.build() : NO_INSTRUCTION, message);
     }
 
     private static Stream<Arguments> createTurnByTurnTrace() {
@@ -249,234 +249,192 @@ public class ManageLegTraversalTest {
 
         return Stream.of(
             Arguments.of(
+                "Deviated from the start of a trip which starts with a bus leg. Suggest path to head towards.",
                 firstBusLeg,
-                new TraceData(
-                    TripStatus.DEVIATED,
-                    createPoint(busStopCoords, 12, NORTH_WEST_BEARING),
-                    new DeviatedInstruction(busStopName, locale),
-                    true,
-                    "Deviated from the start of a trip which starts with a bus leg. Suggest path to head towards."
-                )
+                new TraceData()
+                    .withTripStatus(TripStatus.DEVIATED)
+                    .withPosition(createPoint(busStopCoords, 12, NORTH_WEST_BEARING))
+                    .withStartingTrip()
+                    .withExpectedInstruction(new DeviatedInstruction(busStopName, locale))
             ),
             Arguments.of(
+                "On-time and near the initial bus stop on trip which starts with a bus leg. Instructs to wait for bus.",
                 firstBusLeg,
-                new TraceData(
-                    TripStatus.ON_SCHEDULE,
-                    createPoint(busStopCoords, 4, NORTH_WEST_BEARING),
-                    new WaitForTransitInstruction(firstBusLeg, firstBusLeg.startTime.toInstant().minus(4, ChronoUnit.MINUTES), locale),
-                    true,
-                    "On-time and near the initial bus stop on trip which starts with a bus leg. Instructs to wait for bus."
-                )
+                new TraceData()
+                    .withPosition(createPoint(busStopCoords, 4, NORTH_WEST_BEARING))
+                    .withStartingTrip()
+                    .withExpectedInstruction(
+                        new WaitForTransitInstruction(firstBusLeg, firstBusLeg.startTime.toInstant().minus(4, ChronoUnit.MINUTES), locale)
+                    )
             ),
             Arguments.of(
+                "On transit leg away from the boarding location (or walked past the bus stop). No specific instruction to give.",
                 firstBusLeg,
-                new TraceData(
-                    TripStatus.ON_SCHEDULE,
-                    new Coordinates(33.916779, -84.226556),
-                    NO_INSTRUCTION,
-                    true,
-                    "On transit leg away from the boarding location (or walked past the bus stop). No specific instruction to give."
-                )
+                new TraceData()
+                    .withPosition(33.916779, -84.226556)
+                    .withStartingTrip()
+                    .withExpectedInstruction(NO_INSTRUCTION)
             ),
             Arguments.of(
+                "Just started the trip and near to the instruction for the first step.",
                 walkLeg,
-                new TraceData(
-                    originCoords,
-                    new OnTrackInstruction(10, adairAvenueNortheastStep, locale),
-                    true,
-                    "Just started the trip and near to the instruction for the first step. "
-                )
+                new TraceData()
+                    .withPosition(originCoords)
+                    .withStartingTrip()
+                    .withExpectedInstruction(new OnTrackInstruction(10, adairAvenueNortheastStep, locale))
             ),
             Arguments.of(
+                "Coming up on first walk instruction.",
                 walkLeg,
-                new TraceData(
-                    originCoords,
-                    new OnTrackInstruction(10, adairAvenueNortheastStep, locale),
-                    false,
-                    "Coming up on first instruction."
-                )
+                new TraceData()
+                    .withPosition(originCoords)
+                    .withExpectedInstruction(new OnTrackInstruction(10, adairAvenueNortheastStep, locale)),
+                    false
             ),
             Arguments.of(
+                "On first walk instruction.",
                 walkLeg,
-                new TraceData(
-                    adairAvenueNortheastCoords,
-                    new OnTrackInstruction(2, adairAvenueNortheastStep, locale),
-                    false,
-                    "On first instruction."
-                )
+                new TraceData()
+                    .withPosition(adairAvenueNortheastCoords)
+                    .withExpectedInstruction(new OnTrackInstruction(2, adairAvenueNortheastStep, locale))
             ),
             Arguments.of(
+                "Deviated to the north of east to west path. Suggest path to head towards.",
                 walkLeg,
-                new TraceData(
-                    TripStatus.DEVIATED,
-                    createPoint(adairAvenueNortheastCoords, 12, NORTH_WEST_BEARING),
-                    new DeviatedInstruction(adairAvenueNortheastStep.streetName, locale),
-                    false,
-                    "Deviated to the north of east to west path. Suggest path to head towards."
-                )
+                new TraceData()
+                    .withPosition(createPoint(adairAvenueNortheastCoords, 12, NORTH_WEST_BEARING))
+                    .withTripStatus(TripStatus.DEVIATED)
+                    .withExpectedInstruction(new DeviatedInstruction(adairAvenueNortheastStep.streetName, locale))
             ),
             Arguments.of(
+                "Deviated to the south of east to west path. Suggest path to head towards.",
                 walkLeg,
-                new TraceData(
-                    TripStatus.DEVIATED,
-                    createPoint(adairAvenueNortheastCoords, 12, SOUTH_WEST_BEARING),
-                    new DeviatedInstruction(adairAvenueNortheastStep.streetName, locale),
-                    false,
-                    "Deviated to the south of east to west path. Suggest path to head towards."
-                )
+                new TraceData()
+                    .withPosition(createPoint(adairAvenueNortheastCoords, 12, SOUTH_WEST_BEARING))
+                    .withTripStatus(TripStatus.DEVIATED)
+                    .withExpectedInstruction(new DeviatedInstruction(adairAvenueNortheastStep.streetName, locale))
             ),
             Arguments.of(
+                "On track approaching second step, provide continue instruction.",
                 walkLeg,
-                new TraceData(
-                    createPoint(virginiaCircleNortheastCoords, 12, SOUTH_WEST_BEARING),
-                    new ContinueInstruction(virginiaCircleNortheastStep, locale),
-                    false,
-                    "On track approaching second step, provide continue instruction."
-                )
+                new TraceData()
+                    .withPosition(createPoint(virginiaCircleNortheastCoords, 12, SOUTH_WEST_BEARING))
+                    .withExpectedInstruction(new ContinueInstruction(virginiaCircleNortheastStep, locale))
             ),
             Arguments.of(
+                "Deviated from path, but within the upcoming radius of second instruction.",
                 walkLeg,
-                new TraceData(
-                    TripStatus.DEVIATED,
-                    createPoint(virginiaCircleNortheastCoords, 8, NORTH_BEARING),
-                    new OnTrackInstruction(9, virginiaCircleNortheastStep, locale),
-                    false,
-                    "Deviated from path, but within the upcoming radius of second instruction."
-                )
+                new TraceData()
+                    .withPosition(createPoint(virginiaCircleNortheastCoords, 8, NORTH_BEARING))
+                    .withTripStatus(TripStatus.DEVIATED)
+                    .withExpectedInstruction(new OnTrackInstruction(9, virginiaCircleNortheastStep, locale))
             ),
             Arguments.of(
+                "On second walk instruction.",
                 walkLeg,
-                new TraceData(
-                    virginiaCircleNortheastCoords,
-                    new OnTrackInstruction(0, virginiaCircleNortheastStep, locale),
-                    false,
-                    "On second instruction."
-                )
+                new TraceData()
+                    .withPosition(virginiaCircleNortheastCoords)
+                    .withExpectedInstruction(new OnTrackInstruction(0, virginiaCircleNortheastStep, locale))
             ),
             Arguments.of(
+                "Deviated to the west of south to north path. Suggest path to head towards.",
                 walkLeg,
-                new TraceData(
-                    TripStatus.DEVIATED,
-                    createPoint(ponceDeLeonPlaceNortheastCoords, 10, NORTH_WEST_BEARING),
-                    new DeviatedInstruction(ponceDeLeonPlaceNortheastStep.streetName, locale),
-                    false,
-                    "Deviated to the west of south to north path. Suggest path to head towards."
-                )
+                new TraceData()
+                    .withPosition(createPoint(ponceDeLeonPlaceNortheastCoords, 10, NORTH_WEST_BEARING))
+                    .withTripStatus(TripStatus.DEVIATED)
+                    .withExpectedInstruction(new DeviatedInstruction(ponceDeLeonPlaceNortheastStep.streetName, locale))
             ),
             Arguments.of(
+                "Deviated to the east of south to north path. Suggest path to head towards.",
                 walkLeg,
-                new TraceData(
-                    TripStatus.DEVIATED,
-                    createPoint(ponceDeLeonPlaceNortheastCoords, 10, NORTH_EAST_BEARING),
-                    new DeviatedInstruction(ponceDeLeonPlaceNortheastStep.streetName, locale),
-                    false,
-                    "Deviated to the east of south to north path. Suggest path to head towards."
-                )
+                new TraceData()
+                    .withPosition(createPoint(ponceDeLeonPlaceNortheastCoords, 10, NORTH_EAST_BEARING))
+                    .withExpectedInstruction(new DeviatedInstruction(ponceDeLeonPlaceNortheastStep.streetName, locale))
+                    .withTripStatus(TripStatus.DEVIATED)
             ),
             Arguments.of(
+                "Approaching left turn on Virginia Avenue (Test to make sure turn is not missed).",
                 walkLeg,
-                new TraceData(
-                    createPoint(pointBeforeTurn, 8, calculateBearing(pointBeforeTurn, virginiaAvenuePoint)),
-                    new OnTrackInstruction(10, virginiaAvenueNortheastStep, locale),
-                    false,
-                    "Approaching left turn on Virginia Avenue (Test to make sure turn is not missed)."
-                )
+                new TraceData()
+                    .withPosition(createPoint(pointBeforeTurn, 8, calculateBearing(pointBeforeTurn, virginiaAvenuePoint)))
+                    .withExpectedInstruction(new OnTrackInstruction(10, virginiaAvenueNortheastStep, locale))
             ),
             Arguments.of(
+                "Turn left on to Virginia Avenue (Test to make sure turn is not missed).",
                 walkLeg,
-                new TraceData(
-                    createPoint(pointBeforeTurn, 17, calculateBearing(pointBeforeTurn, virginiaAvenuePoint)),
-                    new OnTrackInstruction(2, virginiaAvenueNortheastStep, locale),
-                    false,
-                    "Turn left on to Virginia Avenue (Test to make sure turn is not missed)."
-                )
+                new TraceData()
+                    .withPosition(createPoint(pointBeforeTurn, 17, calculateBearing(pointBeforeTurn, virginiaAvenuePoint)))
+                    .withExpectedInstruction(new OnTrackInstruction(2, virginiaAvenueNortheastStep, locale))
             ),
             Arguments.of(
+                "After turn left on to Virginia Avenue should provide continue instruction.",
                 walkLeg,
-                new TraceData(
-                    createPoint(pointAfterTurn, 0, calculateBearing(pointAfterTurn, virginiaAvenuePoint)),
-                    new ContinueInstruction(virginiaAvenueNortheastStep, locale),
-                    false,
-                    "After turn left on to Virginia Avenue should provide continue instruction."
-                )
+                new TraceData()
+                    .withPosition(createPoint(pointAfterTurn, 0, calculateBearing(pointAfterTurn, virginiaAvenuePoint)))
+                    .withExpectedInstruction(new ContinueInstruction(virginiaAvenueNortheastStep, locale))
             ),
             Arguments.of(
+                "After final turn on to Kanuga Street should provide continue instruction.",
                 walkLeg,
-                new TraceData(
-                    createPoint(pointOnKanugaStreet, 0, NORTH_WEST_BEARING),
-                    new ContinueInstruction(kanugaStreetStep, locale),
-                    false,
-                    "After final turn on to Kanuga Street should provide continue instruction."
-                )
+                new TraceData()
+                    .withPosition(createPoint(pointOnKanugaStreet, 0, NORTH_WEST_BEARING))
+                    .withExpectedInstruction(new ContinueInstruction(kanugaStreetStep, locale))
             ),
             Arguments.of(
+                "Coming up on destination instruction.",
                 walkLeg,
-                new TraceData(
-                    createPoint(destinationCoords, 8, SOUTH_BEARING),
-                    new OnTrackInstruction(10, destinationName, locale),
-                    false,
-                    "Coming up on destination instruction."
-                )
+                new TraceData()
+                    .withPosition(createPoint(destinationCoords, 8, SOUTH_BEARING))
+                    .withExpectedInstruction(new OnTrackInstruction(10, destinationName, locale))
             ),
             Arguments.of(
+                "On destination instruction.",
                 walkLeg,
-                new TraceData(
-                    destinationCoords,
-                    new OnTrackInstruction(2, destinationName, locale),
-                    false,
-                    "On destination instruction."
-                )
+                new TraceData()
+                    .withPosition(destinationCoords)
+                    .withExpectedInstruction(new OnTrackInstruction(2, destinationName, locale))
             ),
             Arguments.of(
+                "On track passed second step and not near to next step, provide continue instruction for second step.",
                 toEastCroganFirstLeg,
-                new TraceData(
-                    pointOnSouthClaytonSt,
-                    new ContinueInstruction(southClaytonSt, locale),
-                    false,
-                    "On track passed second step and not near to next step, provide continue instruction for second step."
-                )
+                new TraceData()
+                    .withPosition(pointOnSouthClaytonSt)
+                    .withExpectedInstruction(new ContinueInstruction(southClaytonSt, locale))
             ),
             Arguments.of(
+                "On track a bit near to the next step, provide continue instruction for second step.",
                 toEastCroganFirstLeg,
-                new TraceData(
-                    createPoint(pointOnSouthClaytonSt, 12, NORTH_WEST_BEARING),
-                    new ContinueInstruction(southClaytonSt, locale),
-                    false,
-                    "On track a bit near to the next step, provide continue instruction for second step."
-                )
+                new TraceData()
+                    .withPosition(createPoint(pointOnSouthClaytonSt, 12, NORTH_WEST_BEARING))
+                    .withExpectedInstruction(new ContinueInstruction(southClaytonSt, locale))
             ),
             Arguments.of(
+                "On track passed next step, provide continue instruction for next step.",
                 toEastCroganFirstLeg,
-                new TraceData(
-                    createPoint(pointOnSouthClaytonSt, 72, NORTH_BEARING),
-                    new ContinueInstruction(eastCroganSt, locale),
-                    false,
-                    "On track passed next step, provide continue instruction for next step."
-                )
+                new TraceData()
+                    .withPosition(createPoint(pointOnSouthClaytonSt, 72, NORTH_BEARING))
+                    .withExpectedInstruction(new ContinueInstruction(eastCroganSt, locale))
             ),
             Arguments.of(
+                "Provide instruction for reaching destination if it is not near end of shape of walk leg.",
                 legToDestinationAwayFromSidewalk,
-                new TraceData(
-                    pointNearEndOfSidewalk,
-                     TRIP_INSTRUCTION_END_OF_ROUTING,
-                    "Provide instruction for reaching destination if it is not near end of shape of walk leg."
-                )
+                new TraceData()
+                    .withPosition(pointNearEndOfSidewalk)
+                    .withExpectedInstruction(TRIP_INSTRUCTION_END_OF_ROUTING)
             ),
             Arguments.of(
+                "Immediately after departure instruction. Should provide a 'Continue' instruction and not 'No instruction'.",
                 midtownWalkLeg,
-                new TraceData(
-                    midtownWalkCoords,
-                    new ContinueInstruction(midtownWalkFirstStep, locale),
-                    false,
-                    "Immediately after departure instruction. Should provide a 'Continue' instruction and not 'No instruction'."
-                )
+                new TraceData()
+                    .withPosition(midtownWalkCoords)
+                    .withExpectedInstruction(new ContinueInstruction(midtownWalkFirstStep, locale))
             )
         );
     }
 
     @ParameterizedTest
     @MethodSource("createTransitRideTrace")
-    void canTrackTransitRide(TraceData traceData) {
+    void canTrackTransitRide(String message, TraceData traceData) {
         Itinerary itinerary = midtownToAnsleyItinerary;
         Leg transitLeg = itinerary.legs.get(1);
 
@@ -488,14 +446,14 @@ public class ManageLegTraversalTest {
         TravelerPosition travelerPosition = new TravelerPosition.Builder()
             .setExpectedLeg(transitLeg)
             .setCurrentPosition(traceData.position)
-            // Unless specified in traceData, an instant corresponding to approx the trip start time should be provided
+            // Unless specified in traceData, an instant corresponding to around the trip start time should be provided
             // for correct instructions to be produced.
             .setCurrentTime(traceData.instant != null ? traceData.instant : transitLeg.startTime.toInstant())
             .setSpeed(traceData.speed)
             .build();
         travelerPosition.locale = locale;
         TripInstruction tripInstruction = TravelerLocator.getInstruction(traceData.tripStatus, travelerPosition, false);
-        assertEquals(traceData.expectedInstruction, tripInstruction != null ? tripInstruction.build() : NO_INSTRUCTION, traceData.message);
+        assertEquals(traceData.expectedInstruction, tripInstruction != null ? tripInstruction.build() : NO_INSTRUCTION, message);
     }
 
     private static Stream<Arguments> createTransitRideTrace() {
@@ -508,87 +466,78 @@ public class ManageLegTraversalTest {
 
         return Stream.of(
             Arguments.of(
-                new TraceData(
-                    originCoords,
-                    NO_INSTRUCTION,
-                    Instant.now(),
-                    "If present at the transit stop after the trip departure, there should not be an instruction."
-                )
+                "If present at the transit stop after the trip departure, there should not be an instruction.",
+                new TraceData()
+                    .withPosition(originCoords)
+                    .withExpectedInstruction(NO_INSTRUCTION)
+                    .withInstant(Instant.now())
             ),
             Arguments.of(
-                new TraceData(
-                    originCoords,
-                    new WaitForTransitInstruction(transitLeg, transitLeg.startTime.toInstant(), locale).build(),
-                    "At the bus stop, or just boarded the transit vehicle leg, it should still tell the user to board the bus."
-                )
+                "At the bus stop, or just boarded the transit vehicle leg, it should still tell the user to board the bus.",
+                new TraceData()
+                    .withPosition(originCoords)
+                    .withExpectedInstruction(
+                        new WaitForTransitInstruction(transitLeg, transitLeg.startTime.toInstant(), locale)
+                    )
             ),
             // This instruction can be missed if the transit vehicle is in a slow/congested area
             // with speeds less than 5 meters/second (11.1 mph, 18 km/h).
             Arguments.of(
-                new TraceData(
-                    new Coordinates(33.78647, -84.38041),
-                    6, // meters per second, ~13.4 mph or 21.6 km/h. The threshold is 5 meters per second.
-                    String.format("Ride 4 min / 8 stops to %s", destinationName),
-                    "Summarize the transit trip as vehicle departs."
-                )
+                "Summarize the transit trip as vehicle departs.",
+                new TraceData()
+                    .withPosition(33.78647, -84.38041)
+                    .withSpeed(6) // meters per second, ~13.4 mph or 21.6 km/h. The threshold is 5 meters per second.
+                    .withExpectedInstruction(String.format("Ride 4 min / 8 stops to %s", destinationName))
             ),
             Arguments.of(
-                new TraceData(
-                    new Coordinates(33.78792, -84.37776),
-                    NO_INSTRUCTION,
-                    "On the transit segment, but far from the arrival stop, so no instruction is given."
-                )
+                "On the transit segment, but far from the arrival stop, so no instruction is given.",
+                new TraceData()
+                    .withPosition(33.78792, -84.37776)
+                    .withExpectedInstruction(NO_INSTRUCTION)
             ),
             Arguments.of(
-                new TraceData(
-                    new Coordinates(33.79139, -84.37441),
-                    String.format("Your stop is coming up (%s)", destinationName),
-                    "Upcoming arrival stop instruction."
-                )
+                "Upcoming arrival stop instruction.",
+                new TraceData()
+                    .withPosition(33.79139, -84.37441)
+                    .withExpectedInstruction(String.format("Your stop is coming up (%s)", destinationName))
             ),
             Arguments.of(
-                new TraceData(
-                    new Coordinates(33.79362, -84.37235),
-                    String.format("Your stop is coming up (%s)", destinationName),
-                    "Between the third and second to last stop."
-                )
+                "Between the third and second to last stop.",
+                new TraceData()
+                    .withPosition(33.79362, -84.37235)
+                    .withExpectedInstruction(String.format("Your stop is coming up (%s)", destinationName))
             ),
             Arguments.of(
-                new TraceData(
-                    new Coordinates(33.79445, -84.37156),
-                    String.format("Get off at next stop (%s)", destinationName),
-                    "One-stop warning (only within 'upcoming' distance of that stop) before the stop to get off"
-                )
+                "One-stop warning (only within 'upcoming' distance of that stop) before the stop to get off",
+                new TraceData()
+                    .withPosition(33.79445, -84.37156)
+                    .withExpectedInstruction(String.format("Get off at next stop (%s)", destinationName))
             ),
             Arguments.of(
-                new TraceData(
-                    new Coordinates(33.79478, -84.37127),
-                    String.format("Get off at next stop (%s)", destinationName),
-                    "Past the one-stop warning from the stop where you should get off.",
-                    true
-                )
+                "Past the one-stop warning from the stop where you should get off.",
+                new TraceData()
+                    .withPosition(33.79478, -84.37127)
+                    .withExpectedInstruction(String.format("Get off at next stop (%s)", destinationName))
+                    .withNullIntermediateStops()
             ),
             Arguments.of(
-                new TraceData(
-                    new Coordinates(33.79489, -84.37115),
-                    String.format("Get off at next stop (%s)", destinationName),
-                    "Past the one-stop warning from the stop where you should get off (#2)."
-                )
+                "Past the one-stop warning from the stop where you should get off (#2).",
+                new TraceData()
+                    .withPosition(33.79489, -84.37115)
+                    .withExpectedInstruction(String.format("Get off at next stop (%s)", destinationName))
             ),
             Arguments.of(
-                new TraceData(
-                    createPoint(destinationCoords, 8, SOUTH_WEST_BEARING),
-                    String.format("Get off here (%s)", destinationName),
-                    "Instruction approaching or at the stop where you should get off."
-                )
+                "Instruction approaching or at the stop where you should get off.",
+                new TraceData()
+                    .withPosition(createPoint(destinationCoords, 8, SOUTH_WEST_BEARING))
+                    .withExpectedInstruction(String.format("Get off here (%s)", destinationName))
             ),
             Arguments.of(
-                new TraceData(
-                    TripStatus.DEVIATED,
-                    new Coordinates(33.79371, -84.37711),
-                    NO_INSTRUCTION,
-                    "No instruction provided besides trip status if bus is deviated or user missed their stop."
-                )
+                "No instruction provided besides trip status if bus is deviated or user missed their stop.",
+                new TraceData()
+                    .withPosition(33.79371, -84.37711)
+                    .withTripStatus(TripStatus.DEVIATED)
+                    .withExpectedInstruction(NO_INSTRUCTION)
             )
         );
     }

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -19,6 +19,7 @@ import org.opentripplanner.middleware.triptracker.instruction.ContinueInstructio
 import org.opentripplanner.middleware.triptracker.instruction.DeviatedInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.OnTrackInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.TripInstruction;
+import org.opentripplanner.middleware.triptracker.instruction.WaitForTransitInstruction;
 import org.opentripplanner.middleware.utils.ConfigUtils;
 import org.opentripplanner.middleware.utils.Coordinates;
 import org.opentripplanner.middleware.utils.DateTimeUtils;
@@ -193,8 +194,10 @@ public class ManageLegTraversalTest {
             .setExpectedLeg(firstLeg)
             .setCurrentPosition(traceData.position)
             .setFirstLegOfTrip(firstLeg)
+            .setCurrentTime(firstLeg.startTime.toInstant().minus(4, ChronoUnit.MINUTES))
             .setSpeed(0)
             .build();
+        travelerPosition.locale = locale;
         TripInstruction tripInstruction = TravelerLocator.getInstruction(traceData.tripStatus, travelerPosition, traceData.isStartOfTrip);
         assertEquals(traceData.expectedInstruction, tripInstruction != null ? tripInstruction.build() : NO_INSTRUCTION, traceData.message);
     }
@@ -253,6 +256,26 @@ public class ManageLegTraversalTest {
                     new DeviatedInstruction(busStopName, locale),
                     true,
                     "Deviated from the start of a trip which starts with a bus leg. Suggest path to head towards."
+                )
+            ),
+            Arguments.of(
+                firstBusLeg,
+                new TraceData(
+                    TripStatus.ON_SCHEDULE,
+                    createPoint(busStopCoords, 4, NORTH_WEST_BEARING),
+                    new WaitForTransitInstruction(firstBusLeg, firstBusLeg.startTime.toInstant().minus(4, ChronoUnit.MINUTES), locale),
+                    true,
+                    "On-time and near the initial bus stop on trip which starts with a bus leg. Instructs to wait for bus."
+                )
+            ),
+            Arguments.of(
+                firstBusLeg,
+                new TraceData(
+                    TripStatus.ON_SCHEDULE,
+                    new Coordinates(33.916779, -84.226556),
+                    NO_INSTRUCTION,
+                    true,
+                    "On transit leg away from the boarding location (or walked past the bus stop). No specific instruction to give."
                 )
             ),
             Arguments.of(

--- a/src/test/java/org/opentripplanner/middleware/triptracker/NotifyBusOperatorTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/NotifyBusOperatorTest.java
@@ -287,7 +287,7 @@ class NotifyBusOperatorTest extends OtpMiddlewareTestEnvironment {
     @ParameterizedTest
     @MethodSource("shouldSendBusNotificationAtStartOfTripTrace")
     void shouldSendBusNotificationAtStartOfTrip(boolean expected, TravelerPosition travelerPosition, String message) {
-        assertEquals(expected, TravelerLocator.sendBusNotification(travelerPosition), message);
+        assertEquals(expected, TravelerLocator.shouldSendBusNotification(travelerPosition), message);
     }
 
     private static Stream<Arguments> shouldSendBusNotificationAtStartOfTripTrace() {

--- a/src/test/java/org/opentripplanner/middleware/triptracker/NotifyBusOperatorTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/NotifyBusOperatorTest.java
@@ -287,7 +287,7 @@ class NotifyBusOperatorTest extends OtpMiddlewareTestEnvironment {
     @ParameterizedTest
     @MethodSource("shouldSendBusNotificationAtStartOfTripTrace")
     void shouldSendBusNotificationAtStartOfTrip(boolean expected, TravelerPosition travelerPosition, String message) {
-        assertEquals(expected, TravelerLocator.shouldSendBusNotification(travelerPosition), message);
+        assertEquals(expected, TravelerLocator.shouldSendBusNotification(travelerPosition.nextLeg, travelerPosition.currentTime), message);
     }
 
     private static Stream<Arguments> shouldSendBusNotificationAtStartOfTripTrace() {

--- a/src/test/java/org/opentripplanner/middleware/triptracker/TraceData.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/TraceData.java
@@ -13,51 +13,47 @@ class TraceData {
     boolean isStartOfTrip;
     boolean dismissIntermediateStops;
     Instant instant;
-    String message;
 
-    public TraceData(Coordinates position, String expectedInstruction, boolean isStartOfTrip, String message) {
+    public TraceData withPosition(Coordinates position) {
         this.position = position;
-        this.expectedInstruction = expectedInstruction;
-        this.isStartOfTrip = isStartOfTrip;
-        this.message = message;
+        return this;
     }
 
-    public TraceData(Coordinates position, TripInstruction expectedInstruction, boolean isStartOfTrip, String message) {
-        this(position, expectedInstruction.build(), isStartOfTrip, message);
+    public TraceData withPosition(double lat, double lon) {
+        return withPosition(new Coordinates(lat, lon));
     }
 
-    public TraceData(Coordinates position, String expectedInstruction, String message) {
-        this(position, expectedInstruction, false, message);
+    public TraceData withExpectedInstruction(String instruction) {
+        this.expectedInstruction = instruction;
+        return this;
     }
 
-    public TraceData(Coordinates position, String expectedInstruction, Instant instant, String message) {
-        this(position, expectedInstruction, false, message);
-        this.instant = instant;
+    public TraceData withExpectedInstruction(TripInstruction instruction) {
+        return withExpectedInstruction(instruction.build());
     }
 
-    public TraceData(Coordinates position, String expectedInstruction, String message, boolean dismissIntermediateStops) {
-        this(position, expectedInstruction, false, message);
-        this.dismissIntermediateStops = dismissIntermediateStops;
-    }
-
-    public TraceData(Coordinates position, int speed, String expectedInstruction, String message) {
-        this(position, expectedInstruction, false, message);
+    public TraceData withSpeed(int speed) {
         this.speed = speed;
+        return this;
     }
 
-    public TraceData(TripStatus tripStatus, Coordinates position, String expectedInstruction, boolean isStartOfTrip, String message) {
+    public TraceData withInstant(Instant instant) {
+        this.instant = instant;
+        return this;
+    }
+
+    public TraceData withNullIntermediateStops() {
+        this.dismissIntermediateStops = true;
+        return this;
+    }
+
+    public TraceData withStartingTrip() {
+        this.isStartOfTrip = true;
+        return this;
+    }
+
+    public TraceData withTripStatus(TripStatus tripStatus) {
         this.tripStatus = tripStatus;
-        this.position = position;
-        this.expectedInstruction = expectedInstruction;
-        this.isStartOfTrip = isStartOfTrip;
-        this.message = message;
-    }
-
-    public TraceData(TripStatus tripStatus, Coordinates position, TripInstruction expectedInstruction, boolean isStartOfTrip, String message) {
-        this(tripStatus, position, expectedInstruction.build(), isStartOfTrip, message);
-    }
-
-    public TraceData(TripStatus tripStatus, Coordinates position, String expectedInstruction, String message) {
-        this(tripStatus, position, expectedInstruction, false, message);
+        return this;
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/triptracker/TraceData.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/TraceData.java
@@ -1,0 +1,63 @@
+package org.opentripplanner.middleware.triptracker;
+
+import org.opentripplanner.middleware.triptracker.instruction.TripInstruction;
+import org.opentripplanner.middleware.utils.Coordinates;
+
+import java.time.Instant;
+
+class TraceData {
+    TripStatus tripStatus = TripStatus.ON_SCHEDULE;
+    Coordinates position;
+    int speed;
+    String expectedInstruction;
+    boolean isStartOfTrip;
+    boolean dismissIntermediateStops;
+    Instant instant;
+    String message;
+
+    public TraceData(Coordinates position, String expectedInstruction, boolean isStartOfTrip, String message) {
+        this.position = position;
+        this.expectedInstruction = expectedInstruction;
+        this.isStartOfTrip = isStartOfTrip;
+        this.message = message;
+    }
+
+    public TraceData(Coordinates position, TripInstruction expectedInstruction, boolean isStartOfTrip, String message) {
+        this(position, expectedInstruction.build(), isStartOfTrip, message);
+    }
+
+    public TraceData(Coordinates position, String expectedInstruction, String message) {
+        this(position, expectedInstruction, false, message);
+    }
+
+    public TraceData(Coordinates position, String expectedInstruction, Instant instant, String message) {
+        this(position, expectedInstruction, false, message);
+        this.instant = instant;
+    }
+
+    public TraceData(Coordinates position, String expectedInstruction, String message, boolean dismissIntermediateStops) {
+        this(position, expectedInstruction, false, message);
+        this.dismissIntermediateStops = dismissIntermediateStops;
+    }
+
+    public TraceData(Coordinates position, int speed, String expectedInstruction, String message) {
+        this(position, expectedInstruction, false, message);
+        this.speed = speed;
+    }
+
+    public TraceData(TripStatus tripStatus, Coordinates position, String expectedInstruction, boolean isStartOfTrip, String message) {
+        this.tripStatus = tripStatus;
+        this.position = position;
+        this.expectedInstruction = expectedInstruction;
+        this.isStartOfTrip = isStartOfTrip;
+        this.message = message;
+    }
+
+    public TraceData(TripStatus tripStatus, Coordinates position, TripInstruction expectedInstruction, boolean isStartOfTrip, String message) {
+        this(tripStatus, position, expectedInstruction.build(), isStartOfTrip, message);
+    }
+
+    public TraceData(TripStatus tripStatus, Coordinates position, String expectedInstruction, String message) {
+        this(tripStatus, position, expectedInstruction, false, message);
+    }
+}

--- a/src/test/java/org/opentripplanner/middleware/triptracker/TravelerLocatorTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/TravelerLocatorTest.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opentripplanner.middleware.triptracker.TravelerPosition.isNearTransitLegOrigin;
 import static org.opentripplanner.middleware.triptracker.TravelerLocator.stopsUntilEndOfLeg;
 import static org.opentripplanner.middleware.utils.GeometryUtils.createPoint;
 
@@ -73,12 +72,12 @@ class TravelerLocatorTest {
             .setCurrentTime(Instant.now())
             .setCurrentPosition(userCoordinates)
             .build();
-        assertEquals(expectedValue, isNearTransitLegOrigin(position));
+        assertEquals(expectedValue, position.isNearTransitLegOrigin());
 
         // Swap the two legs - result should be the same.
         position.nextLeg = transitLeg;
         position.expectedLeg = otherTransitLeg;
-        assertEquals(expectedValue, isNearTransitLegOrigin(position));
+        assertEquals(expectedValue, position.isNearTransitLegOrigin());
     }
 
     static Stream<Arguments> createNearTransitLegOriginCases() {

--- a/src/test/java/org/opentripplanner/middleware/triptracker/TravelerLocatorTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/TravelerLocatorTest.java
@@ -46,7 +46,7 @@ class TravelerLocatorTest {
 
     @ParameterizedTest
     @MethodSource("createNearTransitLegOriginCases")
-    void testIsNearTransitLegOrigin(Coordinates stopCoordinates, Coordinates userCoordinates, boolean expectedValue) {
+    void testIsNearTransitLegOrigin(Coordinates stopCoordinates, Coordinates userCoordinates, boolean expectedLeg) {
         Leg transitLeg = new Leg();
         // Populating fields to avoid null pointer exceptions, but only 'transitLeg' and 'from' matter.
         transitLeg.transitLeg = true;
@@ -72,12 +72,12 @@ class TravelerLocatorTest {
             .setCurrentTime(Instant.now())
             .setCurrentPosition(userCoordinates)
             .build();
-        assertEquals(expectedValue, position.isNearTransitLegOrigin());
+        assertEquals(expectedLeg ? transitLeg : null, position.getTransitLegWithClosestUpcomingOrigin());
 
         // Swap the two legs - result should be the same.
         position.nextLeg = transitLeg;
         position.expectedLeg = otherTransitLeg;
-        assertEquals(expectedValue, position.isNearTransitLegOrigin());
+        assertEquals(expectedLeg ? transitLeg : null, position.getTransitLegWithClosestUpcomingOrigin());
     }
 
     static Stream<Arguments> createNearTransitLegOriginCases() {

--- a/src/test/java/org/opentripplanner/middleware/triptracker/TravelerLocatorTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/TravelerLocatorTest.java
@@ -1,13 +1,21 @@
 package org.opentripplanner.middleware.triptracker;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.Place;
+import org.opentripplanner.middleware.utils.Coordinates;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opentripplanner.middleware.triptracker.TravelerPosition.isNearTransitLegOrigin;
 import static org.opentripplanner.middleware.triptracker.TravelerLocator.stopsUntilEndOfLeg;
+import static org.opentripplanner.middleware.utils.GeometryUtils.createPoint;
 
 class TravelerLocatorTest {
     @Test
@@ -35,5 +43,52 @@ class TravelerLocatorTest {
         Place place = new Place();
         place.stopId = id;
         return place;
+    }
+
+    @ParameterizedTest
+    @MethodSource("createNearTransitLegOriginCases")
+    void testIsNearTransitLegOrigin(Coordinates stopCoordinates, Coordinates userCoordinates, boolean expectedValue) {
+        Leg transitLeg = new Leg();
+        // Populating fields to avoid null pointer exceptions, but only 'transitLeg' and 'from' matter.
+        transitLeg.transitLeg = true;
+        transitLeg.duration = 60.0;
+        transitLeg.from = createPlace("TransitLegOrigin");
+        transitLeg.from.lat = stopCoordinates.lat;
+        transitLeg.from.lon = stopCoordinates.lon;
+
+        // Other arbitrary transit leg with arbitrary 'from' location far from the above leg.
+        // This leg needs to be considered if traveler is on an itinerary with two transit legs back to back.
+        Leg otherTransitLeg = new Leg();
+        // Populating fields to avoid null pointer exceptions, but only 'transitLeg' and 'from' matter.
+        otherTransitLeg.transitLeg = true;
+        otherTransitLeg.duration = 60.0;
+        otherTransitLeg.from = createPlace("OtherTransitLegOrigin");
+        otherTransitLeg.from.lat = stopCoordinates.lat + 0.5;
+        otherTransitLeg.from.lon = stopCoordinates.lon - 0.5;
+
+        TravelerPosition position = new TravelerPosition.Builder()
+            .setExpectedLeg(transitLeg)
+            .setNextLeg(otherTransitLeg)
+            // Current time is needed to avoid null pointer exceptions
+            .setCurrentTime(Instant.now())
+            .setCurrentPosition(userCoordinates)
+            .build();
+        assertEquals(expectedValue, isNearTransitLegOrigin(position));
+
+        // Swap the two legs - result should be the same.
+        position.nextLeg = transitLeg;
+        position.expectedLeg = otherTransitLeg;
+        assertEquals(expectedValue, isNearTransitLegOrigin(position));
+    }
+
+    static Stream<Arguments> createNearTransitLegOriginCases() {
+        final int NORTH_EAST_BEARING = 45;
+        Coordinates stopCoordinates = new Coordinates(33.78645, -84.381713);
+
+        return Stream.of(
+            Arguments.of(stopCoordinates, stopCoordinates, true),
+            Arguments.of(stopCoordinates, createPoint(stopCoordinates, 4, NORTH_EAST_BEARING), true),
+            Arguments.of(stopCoordinates, createPoint(stopCoordinates, 30, NORTH_EAST_BEARING), false)
+        );
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR addresses instances when a traveler in the 'upcoming' range of a bus stop (or the departure point of an itinerary) would see a "Wait for bus" (or "upcoming" instruction) instruction and still be deemed deviated.
