### PR TITLE
Fix next trip day

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -340,13 +340,24 @@ public class CheckMonitoredTrip implements Runnable {
                     } else {
                         // Trip has not begun. Reset the target date to start of itinerary.
                         LOG.info("Matching itinerary has not started, finding the next possible trip date.");
-                        targetZonedDateTime = DateTimeUtils.makeOtpZonedDateTime(matchingItinerary.startTime);
+                        ZonedDateTime itinStart = ZonedDateTime.ofInstant(
+                            matchingItinerary.startTime.toInstant(),
+                            DateTimeUtils.getOtpZoneId()
+                        );
+                        targetZonedDateTime = DateTimeUtils.nowAsZonedDateTime(DateTimeUtils.getOtpZoneId())
+                            .withHour(itinStart.getHour())
+                            .withMinute(itinStart.getMinute())
+                            .withSecond(itinStart.getSecond());
                     }
+
                     advanceToNextActiveTripDate();
                     updateMonitoredTrip();
 
-                    // return false to indicate that no further checks for delays/alerts/etc should occur
-                    return false;
+                    if (matchingItinerary.hasEnded()) {
+                        // If today's itinerary has ended, return false to indicate that no further checks
+                        // for delays/alerts/etc should occur for today.
+                        return false;
+                    }
                 }
 
                 LOG.info("Trip status set to {}", journeyState.tripStatus);

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -688,12 +688,9 @@ public class CheckMonitoredTrip implements Runnable {
         // Get current time and trip time (with the time offset to today) for comparison.
         ZonedDateTime now = DateTimeUtils.nowAsZonedDateTime();
 
-        Instant tripStartInstant;
-        if (!trip.isOneTime() && !isPreviousTripOngoing()) {
-            tripStartInstant = findEarliestTargetDate(trip, now).toInstant();
-        } else {
-            tripStartInstant = matchingItinerary.startTime.toInstant();
-        }
+        Instant tripStartInstant = !trip.isOneTime() && !isPreviousTripOngoing()
+            ? findEarliestTargetDate(trip, now).toInstant()
+            : matchingItinerary.startTime.toInstant();
 
         return (tripStartInstant.getEpochSecond() - now.toEpochSecond()) / 60;
     }
@@ -872,8 +869,10 @@ public class CheckMonitoredTrip implements Runnable {
         return findNextMonitoredDay(trip, nextStartDay);
     }
 
+    /**
+     * Advance the target date/time until a day is found when the trip is active.
+     */
     private static ZonedDateTime findNextMonitoredDay(MonitoredTrip trip, ZonedDateTime startingDay) {
-        // Advance the target date/time until a day is found when the trip is active.
         ZonedDateTime nextMonitoredDay = startingDay;
         if (!trip.isOneTime()) {
             while (!trip.isActiveOnDate(nextMonitoredDay)) {

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -341,7 +341,7 @@ public class CheckMonitoredTrip implements Runnable {
                         // Trip has not begun. Reset the target date to the start time of itinerary "today".
                         LOG.info("Matching itinerary has not started, finding the next possible trip date.");
                         targetZonedDateTime = DateTimeUtils.makeOtpZonedDateTime(
-                            DateTimeUtils.nowAsZonedDateTime(DateTimeUtils.getOtpZoneId()),
+                            DateTimeUtils.nowAsZonedDateTime(),
                             matchingItinerary.startTime.toInstant()
                         );
                     }
@@ -685,18 +685,15 @@ public class CheckMonitoredTrip implements Runnable {
      * is unlikely to be defined in which case use the original trip start time instead.
      */
     private long getMinutesUntilTrip() {
-        // get the configured timezone that OTP is using to parse dates and times
-        ZoneId targetZoneId = DateTimeUtils.getOtpZoneId();
+        // Get current time and trip time (with the time offset to today) for comparison.
+        ZonedDateTime now = DateTimeUtils.nowAsZonedDateTime();
 
         Instant tripStartInstant;
         if (!trip.isOneTime() && !isPreviousTripOngoing()) {
-            tripStartInstant = findEarliestTargetDate(trip, DateTimeUtils.nowAsZonedDateTime(DateTimeUtils.getOtpZoneId())).toInstant();
+            tripStartInstant = findEarliestTargetDate(trip, now).toInstant();
         } else {
             tripStartInstant = matchingItinerary.startTime.toInstant();
         }
-
-        // Get current time and trip time (with the time offset to today) for comparison.
-        ZonedDateTime now = DateTimeUtils.nowAsZonedDateTime(targetZoneId);
 
         return (tripStartInstant.getEpochSecond() - now.toEpochSecond()) / 60;
     }
@@ -1098,7 +1095,7 @@ public class CheckMonitoredTrip implements Runnable {
             .withMinute(0)
             .withSecond(0);
 
-        ZonedDateTime now = DateTimeUtils.nowAsZonedDateTime(otpZoneId);
+        ZonedDateTime now = DateTimeUtils.nowAsZonedDateTime();
         // Include equal or after midnight as true.
         return !now.isBefore(midnightAfterLastChecked);
     }

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -860,17 +860,29 @@ public class CheckMonitoredTrip implements Runnable {
     }
 
     /**
+     * Find, starting from the given date, the earliest target date for a monitored trip using monitored days.
+     * (Itinerary existence is not being checked, assuming that clients prevent monitoring days when a trip deosn't exist.)
+     */
+    public static ZonedDateTime findEarliestTargetDate(MonitoredTrip trip, ZonedDateTime fromDateTime) {
+        // TODO refactor zoneid in this call
+        ZonedDateTime nextStartDay = fromDateTime; // DateTimeUtils.nowAsZonedDateTime(DateTimeUtils.getOtpZoneId());
+
+        // Advance the target date/time until a day is found when the trip is active.
+        // TODO: refactpr this while loop (with advance...)
+        if (!trip.isOneTime()) {
+            while (!trip.isActiveOnDate(nextStartDay)) {
+                nextStartDay = nextStartDay.plusDays(1);
+            }
+        }
+
+        return nextStartDay;
+    }
+
+    /**
      * Is a one-off trip which has already happened.
      */
     private boolean isOneTimeTripInPast() {
         return trip.isOneTime() && previousJourneyState.tripStatus == TripStatus.PAST_TRIP;
-    }
-
-    /** Check if the matching itinerary start time is in the future */
-    private boolean isMatchingItineraryStartTimeInTheFuture() {
-        Instant tripStartInstant = matchingItinerary.startTime.toInstant();
-
-        return tripStartInstant.isAfter(Instant.ofEpochMilli(DateTimeUtils.currentTimeMillis()));
     }
 
     /** Check if previous matching itinerary day is still valid */

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -333,8 +333,15 @@ public class CheckMonitoredTrip implements Runnable {
                 // If the matching itinerary is in the future,
                 // make sure that the target date reflects that.
                 if (journeyState.tripStatus == TripStatus.TRIP_UPCOMING && (!matchingItinerary.isActive())) {
-                    LOG.info("Matching Itinerary has concluded, advancing to next possible trip date.");
-                    targetZonedDateTime = targetZonedDateTime.plusDays(1);
+                    if (matchingItinerary.hasEnded()) {
+                        // Trip has ended. Find the next target date starting from "tomorrow".
+                        LOG.info("Matching itinerary has concluded, advancing to next possible trip date.");
+                        targetZonedDateTime = targetZonedDateTime.plusDays(1);
+                    } else {
+                        // Trip has not begun. Reset the target date to start of itinerary.
+                        LOG.info("Matching itinerary has not started, finding the next possible trip date.");
+                        targetZonedDateTime = DateTimeUtils.makeOtpZonedDateTime(matchingItinerary.startTime);
+                    }
                     advanceToNextActiveTripDate();
                     updateMonitoredTrip();
 

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -29,6 +29,7 @@ import org.slf4j.MDC;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -760,7 +761,9 @@ public class CheckMonitoredTrip implements Runnable {
             }
         }
 
-        if (isPrevMatchingItineraryNotConcluded() && isPrevMatchingItineraryDayValid()) {
+
+        boolean isPreviousTripOngoing = isPrevMatchingItineraryNotConcluded() && isPrevMatchingItineraryDayValid();
+        if (isPreviousTripOngoing) {
             // Skip checking the trip the rest of the time that it is active if the trip was deemed not possible for the
             // next possible time during a previous query to find candidate itinerary matches.
             if (previousJourneyState.tripStatus == TripStatus.NEXT_TRIP_NOT_POSSIBLE) {
@@ -805,18 +808,26 @@ public class CheckMonitoredTrip implements Runnable {
             }
         }
 
-        Instant tripStartInstant = matchingItinerary.startTime.toInstant();
+        Instant tripStartInstant;
+        if (!trip.isOneTime() && !isPreviousTripOngoing) {
+            // Compute/adjust next matching itinerary start day/time from "now" using the monitored days.
+            tripStartInstant = findEarliestTargetDate(trip, DateTimeUtils.nowAsZonedDateTime(DateTimeUtils.getOtpZoneId())).toInstant();
+        } else {
+            tripStartInstant = matchingItinerary.startTime.toInstant();
+        }
 
         // Get current time and trip time (with the time offset to today) for comparison.
         ZonedDateTime now = DateTimeUtils.nowAsZonedDateTime(targetZoneId);
 
         // TODO: Change log level.
-        LOG.info("Trip starts at {} (now={})", tripStartInstant.toString(), now.toString());
+        LOG.info("Trip starts at {} (now={})", tripStartInstant, now);
 
         // If last check was more than an hour ago and trip doesn't occur until an hour from now, check trip.
         long minutesSinceLastCheck = getMinutesSinceLastCheck();
         LOG.info("{} minutes since last checking trip", minutesSinceLastCheck);
-        long minutesUntilTrip = getMinutesUntilTrip();
+        // long minutesUntilTrip = getMinutesUntilTrip();
+        long minutesUntilTrip = (tripStartInstant.getEpochSecond() - now.toEpochSecond()) / 60;
+
         LOG.info("Trip starts in {} minutes", minutesUntilTrip);
         // skip check if the time until the next trip starts is longer than the requested lead time
         if (minutesUntilTrip > trip.leadTimeInMinutes) {
@@ -860,12 +871,25 @@ public class CheckMonitoredTrip implements Runnable {
     }
 
     /**
-     * Find, starting from the given date, the earliest target date for a monitored trip using monitored days.
-     * (Itinerary existence is not being checked, assuming that clients prevent monitoring days when a trip deosn't exist.)
+     * Find, starting from the given date, the earliest target date for a monitored trip,
+     * using the trip start time and the monitored days.
+     * (Itinerary existence is not being checked, assuming that clients prevent monitoring days when a trip doesn't exist.)
      */
     public static ZonedDateTime findEarliestTargetDate(MonitoredTrip trip, ZonedDateTime fromDateTime) {
-        // TODO refactor zoneid in this call
-        ZonedDateTime nextStartDay = fromDateTime; // DateTimeUtils.nowAsZonedDateTime(DateTimeUtils.getOtpZoneId());
+        ZoneId zoneId = DateTimeUtils.getOtpZoneId();
+        ZonedDateTime itineraryEndTimeToday = ZonedDateTime.of(
+            fromDateTime.toLocalDate(),
+            LocalTime.ofInstant(trip.itinerary.endTime.toInstant(), zoneId),
+            zoneId
+        );
+
+        int daysToAdd = fromDateTime.toInstant().isAfter(itineraryEndTimeToday.toInstant()) ? 1 : 0;
+
+        ZonedDateTime nextStartDay = ZonedDateTime.of(
+            fromDateTime.toLocalDate().plusDays(daysToAdd),
+            LocalTime.ofInstant(trip.itinerary.startTime.toInstant(), zoneId),
+            zoneId
+        );
 
         // Advance the target date/time until a day is found when the trip is active.
         // TODO: refactpr this while loop (with advance...)
@@ -953,7 +977,8 @@ public class CheckMonitoredTrip implements Runnable {
     /** Check if the previous matching itinerary was null or if it has already concluded */
     private boolean isPrevMatchingItineraryNotConcluded() {
         return previousMatchingItinerary != null &&
-            previousMatchingItinerary.endTime.after(new Date(previousJourneyState.lastCheckedEpochMillis));
+            previousMatchingItinerary.endTime.after(new Date(previousJourneyState.lastCheckedEpochMillis)) &&
+            previousMatchingItinerary.startTime.before(new Date(previousJourneyState.lastCheckedEpochMillis));
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -329,8 +329,10 @@ public class CheckMonitoredTrip implements Runnable {
 
                 // If the updated trip status is upcoming and the end time of the current matching itinerary is in the
                 // past, this means the trip has completed and the next possible time the trip occurs should be
-                // calculated
-                if (journeyState.tripStatus == TripStatus.TRIP_UPCOMING && matchingItinerary.hasEnded()) {
+                // calculated.
+                // If the matching itinerary is in the future,
+                // make sure that the target date reflects that.
+                if (journeyState.tripStatus == TripStatus.TRIP_UPCOMING && (!matchingItinerary.isActive())) {
                     LOG.info("Matching Itinerary has concluded, advancing to next possible trip date.");
                     targetZonedDateTime = targetZonedDateTime.plusDays(1);
                     advanceToNextActiveTripDate();

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -331,24 +331,19 @@ public class CheckMonitoredTrip implements Runnable {
                 // If the updated trip status is upcoming and the end time of the current matching itinerary is in the
                 // past, this means the trip has completed and the next possible time the trip occurs should be
                 // calculated.
-                // If the matching itinerary is in the future,
-                // make sure that the target date reflects that.
+                // If the matching itinerary is in the future, make sure that the target date reflects that.
                 if (journeyState.tripStatus == TripStatus.TRIP_UPCOMING && (!matchingItinerary.isActive())) {
                     if (matchingItinerary.hasEnded()) {
                         // Trip has ended. Find the next target date starting from "tomorrow".
                         LOG.info("Matching itinerary has concluded, advancing to next possible trip date.");
                         targetZonedDateTime = targetZonedDateTime.plusDays(1);
                     } else {
-                        // Trip has not begun. Reset the target date to start of itinerary.
+                        // Trip has not begun. Reset the target date to the start time of itinerary "today".
                         LOG.info("Matching itinerary has not started, finding the next possible trip date.");
-                        ZonedDateTime itinStart = ZonedDateTime.ofInstant(
-                            matchingItinerary.startTime.toInstant(),
-                            DateTimeUtils.getOtpZoneId()
+                        targetZonedDateTime = DateTimeUtils.makeOtpZonedDateTime(
+                            DateTimeUtils.nowAsZonedDateTime(DateTimeUtils.getOtpZoneId()),
+                            matchingItinerary.startTime.toInstant()
                         );
-                        targetZonedDateTime = DateTimeUtils.nowAsZonedDateTime(DateTimeUtils.getOtpZoneId())
-                            .withHour(itinStart.getHour())
-                            .withMinute(itinStart.getMinute())
-                            .withSecond(itinStart.getSecond());
                     }
 
                     advanceToNextActiveTripDate();
@@ -966,9 +961,10 @@ public class CheckMonitoredTrip implements Runnable {
 
     /** Check if the previous matching itinerary was null or if it has already concluded */
     private boolean isPrevMatchingItineraryNotConcluded() {
-        return previousMatchingItinerary != null &&
-            previousMatchingItinerary.endTime.after(new Date(previousJourneyState.lastCheckedEpochMillis)) &&
-            previousMatchingItinerary.startTime.before(new Date(previousJourneyState.lastCheckedEpochMillis));
+        if (previousMatchingItinerary == null) return false;
+        Date lastCheckedDate = new Date(previousJourneyState.lastCheckedEpochMillis);
+        return previousMatchingItinerary.endTime.after(lastCheckedDate) &&
+            previousMatchingItinerary.startTime.before(lastCheckedDate);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -793,7 +793,7 @@ public class CheckMonitoredTrip implements Runnable {
 
             // Attempt to advance to the next monitored day, except for one-time trips
             // or if tracking is ongoing or if the matching itinerary is still valid.
-            if (!trip.isOneTime() && !isTrackingOngoing()) {
+            if (!trip.isOneTime() && trip.journeyState.tripStatus != TripStatus.TRIP_ACTIVE && !isTrackingOngoing()) {
                 advanceToNextMonitoredDay();
             }
 

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -692,7 +692,13 @@ public class CheckMonitoredTrip implements Runnable {
     private long getMinutesUntilTrip() {
         // get the configured timezone that OTP is using to parse dates and times
         ZoneId targetZoneId = DateTimeUtils.getOtpZoneId();
-        Instant tripStartInstant = matchingItinerary.startTime.toInstant();
+
+        Instant tripStartInstant;
+        if (!trip.isOneTime() && !isPreviousTripOngoing()) {
+            tripStartInstant = findEarliestTargetDate(trip, DateTimeUtils.nowAsZonedDateTime(DateTimeUtils.getOtpZoneId())).toInstant();
+        } else {
+            tripStartInstant = matchingItinerary.startTime.toInstant();
+        }
 
         // Get current time and trip time (with the time offset to today) for comparison.
         ZonedDateTime now = DateTimeUtils.nowAsZonedDateTime(targetZoneId);
@@ -727,9 +733,6 @@ public class CheckMonitoredTrip implements Runnable {
             return true;
         }
 
-        // get the configured timezone that OTP is using to parse dates and times
-        ZoneId targetZoneId = DateTimeUtils.getOtpZoneId();
-
         // If trip is no longer possible, no further checking is needed. The itinerary existence data should not be
         // checked here to avoid incorrectly skipping trips that are monitored on a single day of the week, but which
         // may have not had a matching itinerary on that day for one week (even though the trip could be possible the
@@ -761,9 +764,7 @@ public class CheckMonitoredTrip implements Runnable {
             }
         }
 
-
-        boolean isPreviousTripOngoing = isPrevMatchingItineraryNotConcluded() && isPrevMatchingItineraryDayValid();
-        if (isPreviousTripOngoing) {
+        if (isPreviousTripOngoing()) {
             // Skip checking the trip the rest of the time that it is active if the trip was deemed not possible for the
             // next possible time during a previous query to find candidate itinerary matches.
             if (previousJourneyState.tripStatus == TripStatus.NEXT_TRIP_NOT_POSSIBLE) {
@@ -808,26 +809,10 @@ public class CheckMonitoredTrip implements Runnable {
             }
         }
 
-        Instant tripStartInstant;
-        if (!trip.isOneTime() && !isPreviousTripOngoing) {
-            // Compute/adjust next matching itinerary start day/time from "now" using the monitored days.
-            tripStartInstant = findEarliestTargetDate(trip, DateTimeUtils.nowAsZonedDateTime(DateTimeUtils.getOtpZoneId())).toInstant();
-        } else {
-            tripStartInstant = matchingItinerary.startTime.toInstant();
-        }
-
-        // Get current time and trip time (with the time offset to today) for comparison.
-        ZonedDateTime now = DateTimeUtils.nowAsZonedDateTime(targetZoneId);
-
-        // TODO: Change log level.
-        LOG.info("Trip starts at {} (now={})", tripStartInstant, now);
-
         // If last check was more than an hour ago and trip doesn't occur until an hour from now, check trip.
         long minutesSinceLastCheck = getMinutesSinceLastCheck();
         LOG.info("{} minutes since last checking trip", minutesSinceLastCheck);
-        // long minutesUntilTrip = getMinutesUntilTrip();
-        long minutesUntilTrip = (tripStartInstant.getEpochSecond() - now.toEpochSecond()) / 60;
-
+        long minutesUntilTrip = getMinutesUntilTrip();
         LOG.info("Trip starts in {} minutes", minutesUntilTrip);
         // skip check if the time until the next trip starts is longer than the requested lead time
         if (minutesUntilTrip > trip.leadTimeInMinutes) {
@@ -868,6 +853,10 @@ public class CheckMonitoredTrip implements Runnable {
         // TODO: Change log level.
         LOG.info("Trip criteria not met to check. Skipping.");
         return true;
+    }
+
+    private boolean isPreviousTripOngoing() {
+        return isPrevMatchingItineraryNotConcluded() && isPrevMatchingItineraryDayValid();
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -29,7 +29,6 @@ import org.slf4j.MDC;
 
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -47,6 +46,7 @@ import java.util.function.Supplier;
 
 import static org.opentripplanner.middleware.models.LegTransitionNotification.getLegTransitionNotifyUsers;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.diffInMinutes;
+import static org.opentripplanner.middleware.utils.DateTimeUtils.makeOtpZonedDateTime;
 
 /**
  * This job handles the primary functions for checking a {@link MonitoredTrip}, including:
@@ -865,30 +865,31 @@ public class CheckMonitoredTrip implements Runnable {
      * (Itinerary existence is not being checked, assuming that clients prevent monitoring days when a trip doesn't exist.)
      */
     public static ZonedDateTime findEarliestTargetDate(MonitoredTrip trip, ZonedDateTime fromDateTime) {
-        ZoneId zoneId = DateTimeUtils.getOtpZoneId();
-        ZonedDateTime itineraryEndTimeToday = ZonedDateTime.of(
-            fromDateTime.toLocalDate(),
-            LocalTime.ofInstant(trip.itinerary.endTime.toInstant(), zoneId),
-            zoneId
+        ZonedDateTime itineraryEndTimeToday = makeOtpZonedDateTime(
+            fromDateTime,
+            trip.itinerary.endTime.toInstant()
         );
 
         int daysToAdd = fromDateTime.toInstant().isAfter(itineraryEndTimeToday.toInstant()) ? 1 : 0;
 
-        ZonedDateTime nextStartDay = ZonedDateTime.of(
-            fromDateTime.toLocalDate().plusDays(daysToAdd),
-            LocalTime.ofInstant(trip.itinerary.startTime.toInstant(), zoneId),
-            zoneId
+        ZonedDateTime nextStartDay = makeOtpZonedDateTime(
+            fromDateTime.plusDays(daysToAdd),
+            trip.itinerary.startTime.toInstant()
         );
 
+        return findNextMonitoredDay(trip, nextStartDay);
+    }
+
+    private static ZonedDateTime findNextMonitoredDay(MonitoredTrip trip, ZonedDateTime startingDay) {
         // Advance the target date/time until a day is found when the trip is active.
-        // TODO: refactpr this while loop (with advance...)
+        ZonedDateTime nextMonitoredDay = startingDay;
         if (!trip.isOneTime()) {
-            while (!trip.isActiveOnDate(nextStartDay)) {
-                nextStartDay = nextStartDay.plusDays(1);
+            while (!trip.isActiveOnDate(nextMonitoredDay)) {
+                nextMonitoredDay = nextMonitoredDay.plusDays(1);
             }
         }
 
-        return nextStartDay;
+        return nextMonitoredDay;
     }
 
     /**
@@ -971,47 +972,25 @@ public class CheckMonitoredTrip implements Runnable {
     }
 
     /**
-     * Advance the journey state data to point to the next actively monitored date and time that the scheduled itinerary
-     * could occur. This does not make a request to the trip planner, instead it will offset the matching itinerary and
-     * journey state data the appropriate number of days and then recalculate the new scheduled time based on the
-     * updated time in the updated itinerary.
+     * Advance (or set) the journey state data to point to the next actively monitored date and time that the scheduled
+     * itinerary could occur. This does not make a request to the trip planner, instead it will offset the matching
+     * itinerary and journey state data the appropriate number of days and then recalculate the new scheduled time
+     * based on the updated time in the updated itinerary.
      */
     private void advanceToNextActiveTripDate() {
-        // Advance the target date/time until a day is found when the trip is active.
-        while (!trip.isOneTime() && !trip.isActiveOnDate(targetZonedDateTime)) {
-            targetZonedDateTime = targetZonedDateTime.plusDays(1);
-        }
+        targetZonedDateTime = findNextMonitoredDay(trip, targetZonedDateTime);
 
         LOG.info("Next itinerary happening on {}.", targetZonedDateTime);
 
-        ZonedDateTime scheduledTime;
-        if (trip.arriveBy) {
-            // For arrive by trips, increment the matching itinerary end time as long as it does not exceed the target
-            // zoned date time.
-            //
-            // Example: The new target time is June 15 at 9am and the previous matching itinerary ended on June 13 at
-            // 8:50am. In this case, the matching itinerary will be incremented two days so the updated matching
-            // itinerary ends at 8:50am on June 15.
-            scheduledTime = DateTimeUtils.makeOtpZonedDateTime(
-                new Date(matchingItinerary.getScheduledEndTimeEpochMillis())
-            );
-            while (scheduledTime.plusDays(1).isBefore(targetZonedDateTime)) {
-                scheduledTime = scheduledTime.plusDays(1);
-            }
-        } else {
-            // For depart at trips, increment the matching itinerary start time until it occurs after the target zoned
-            // date time.
-            //
-            // Example: The new target time is June 15 at 5pm and the previous matching itinerary began on June 13 at
-            // 5:08pm. In this case, the matching itinerary will be incremented two days so the updated matching
-            // itinerary begins at 5:08pm on June 15.
-            scheduledTime = DateTimeUtils.makeOtpZonedDateTime(
-                new Date(matchingItinerary.getScheduledStartTimeEpochMillis())
-            );
-            while (scheduledTime.isBefore(targetZonedDateTime)) {
-                scheduledTime = scheduledTime.plusDays(1);
-            }
-        }
+        ZonedDateTime scheduledTime = makeOtpZonedDateTime(
+            targetZonedDateTime,
+            Instant.ofEpochMilli(
+                trip.arriveBy
+                    ? matchingItinerary.getScheduledEndTimeEpochMillis()
+                    : matchingItinerary.getScheduledStartTimeEpochMillis()
+            )
+        );
+
         applyDelayOffset(scheduledTime);
     }
 

--- a/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
@@ -136,6 +136,13 @@ public class DateTimeUtils {
     }
 
     /**
+     * Returns the current time as a ZonedDateTime instance in the configured timezone
+     */
+    public static ZonedDateTime nowAsZonedDateTime() {
+        return ZonedDateTime.now(clock);
+    }
+
+    /**
      * Returns the current time in milliseconds according to the current set Clock.
      */
     public static long currentTimeMillis() {

--- a/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
@@ -229,6 +229,19 @@ public class DateTimeUtils {
         );
     }
 
+    /**
+     * Makes a {@link ZonedDateTime} object from a {@link ZonedDateTime} for the date portion,
+     * and a {@link Instant} for the time portion. The result is expressed in the configured OTP time zone.
+     */
+    public static ZonedDateTime makeOtpZonedDateTime(ZonedDateTime datePortion, Instant timePortion) {
+        ZoneId zoneId = getOtpZoneId();
+        return ZonedDateTime.of(
+            datePortion.toLocalDate(),
+            LocalTime.ofInstant(timePortion, zoneId),
+            zoneId
+        );
+    }
+
     public static ZonedDateTime makeOtpZonedDateTime(Date date) {
         return ZonedDateTime.ofInstant(date.toInstant(), getOtpZoneId());
     }

--- a/src/main/java/org/opentripplanner/middleware/utils/Scheduler.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/Scheduler.java
@@ -31,7 +31,7 @@ public class Scheduler {
      */
     public static long getInitialDelayMillis(String startTime) throws DateTimeParseException {
         var timeOfDay = LocalTime.parse(startTime);
-        var now = DateTimeUtils.nowAsZonedDateTime(DateTimeUtils.getOtpZoneId());
+        var now = DateTimeUtils.nowAsZonedDateTime();
         var startAt = DateTimeUtils.getNextTimeFrom(timeOfDay, now);
         var duration = Duration.between(now, startAt);
         return duration.isNegative() ? 0L : duration.toMillis();

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -672,7 +672,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
 
         // Check that matching itinerary time corresponds to "today".
         assertEquals(
-            DateTimeUtils.nowAsZonedDateTime(DateTimeUtils.getOtpZoneId()).toLocalDate(),
+            DateTimeUtils.nowAsZonedDateTime().toLocalDate(),
             ZonedDateTime.ofInstant(resetTrip.journeyState.matchingItinerary.startTime.toInstant(), DateTimeUtils.getOtpZoneId()).toLocalDate()
         );
 

--- a/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
@@ -212,23 +212,24 @@ public class OtpTestUtils {
         );
     }
 
+    private static Itinerary getFirstItinerary(OtpResponse response) {
+        return response.plan.itineraries.get(0);
+    }
+
     public static Itinerary createDefaultItinerary() throws Exception {
-        return OTP2_DISPATCHER_PLAN_RESPONSE.clone().getResponse().plan.itineraries.get(0);
+        return getFirstItinerary(OTP2_DISPATCHER_PLAN_RESPONSE.clone().getResponse());
     }
 
     public static JourneyState createDefaultJourneyState() throws Exception {
-        JourneyState journeyState = new JourneyState();
-        Itinerary defaultItinerary = createDefaultItinerary();
-        journeyState.scheduledArrivalTimeEpochMillis = defaultItinerary.endTime.getTime();
-        journeyState.scheduledDepartureTimeEpochMillis = defaultItinerary.startTime.getTime();
-        journeyState.baselineArrivalTimeEpochMillis = defaultItinerary.endTime.getTime();
-        journeyState.baselineDepartureTimeEpochMillis = defaultItinerary.startTime.getTime();
-        return journeyState;
+        return  createDefaultJourneyState(createDefaultItinerary());
     }
 
     public static JourneyState createDefaultJourneyState(Supplier<OtpResponse> otpResponseProvider) {
+        return createDefaultJourneyState(getFirstItinerary(otpResponseProvider.get()));
+    }
+
+    private static JourneyState createDefaultJourneyState(Itinerary defaultItinerary) {
         JourneyState journeyState = new JourneyState();
-        Itinerary defaultItinerary = otpResponseProvider.get().plan.itineraries.get(0);
         journeyState.scheduledArrivalTimeEpochMillis = defaultItinerary.endTime.getTime();
         journeyState.scheduledDepartureTimeEpochMillis = defaultItinerary.startTime.getTime();
         journeyState.baselineArrivalTimeEpochMillis = defaultItinerary.endTime.getTime();

--- a/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
@@ -212,6 +212,17 @@ public class OtpTestUtils {
         );
     }
 
+    /**
+     * Offsets all times in the given itinerary so that the itinerary starts at the same time
+     * but on the specified day of month.
+     */
+    public static void setItineraryDay(Itinerary mockItinerary, int dayOfMonth) {
+        updateBaseItineraryTime(
+            mockItinerary,
+            DateTimeUtils.makeOtpZonedDateTime(mockItinerary.startTime).withDayOfMonth(dayOfMonth)
+        );
+    }
+
     public static Itinerary firstItinerary(OtpResponse response) {
         return response.plan.itineraries.get(0);
     }

--- a/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
@@ -212,12 +212,12 @@ public class OtpTestUtils {
         );
     }
 
-    private static Itinerary getFirstItinerary(OtpResponse response) {
+    public static Itinerary firstItinerary(OtpResponse response) {
         return response.plan.itineraries.get(0);
     }
 
     public static Itinerary createDefaultItinerary() throws Exception {
-        return getFirstItinerary(OTP2_DISPATCHER_PLAN_RESPONSE.clone().getResponse());
+        return firstItinerary(OTP2_DISPATCHER_PLAN_RESPONSE.clone().getResponse());
     }
 
     public static JourneyState createDefaultJourneyState() throws Exception {
@@ -225,7 +225,7 @@ public class OtpTestUtils {
     }
 
     public static JourneyState createDefaultJourneyState(Supplier<OtpResponse> otpResponseProvider) {
-        return createDefaultJourneyState(getFirstItinerary(otpResponseProvider.get()));
+        return createDefaultJourneyState(firstItinerary(otpResponseProvider.get()));
     }
 
     private static JourneyState createDefaultJourneyState(Itinerary defaultItinerary) {

--- a/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.opentripplanner.middleware.otp.OtpDispatcher.OTP_GRAPHQL_ENDPOINT;
@@ -218,6 +219,16 @@ public class OtpTestUtils {
     public static JourneyState createDefaultJourneyState() throws Exception {
         JourneyState journeyState = new JourneyState();
         Itinerary defaultItinerary = createDefaultItinerary();
+        journeyState.scheduledArrivalTimeEpochMillis = defaultItinerary.endTime.getTime();
+        journeyState.scheduledDepartureTimeEpochMillis = defaultItinerary.startTime.getTime();
+        journeyState.baselineArrivalTimeEpochMillis = defaultItinerary.endTime.getTime();
+        journeyState.baselineDepartureTimeEpochMillis = defaultItinerary.startTime.getTime();
+        return journeyState;
+    }
+
+    public static JourneyState createDefaultJourneyState(Supplier<OtpResponse> otpResponseProvider) {
+        JourneyState journeyState = new JourneyState();
+        Itinerary defaultItinerary = otpResponseProvider.get().plan.itineraries.get(0);
         journeyState.scheduledArrivalTimeEpochMillis = defaultItinerary.endTime.getTime();
         journeyState.scheduledDepartureTimeEpochMillis = defaultItinerary.startTime.getTime();
         journeyState.baselineArrivalTimeEpochMillis = defaultItinerary.endTime.getTime();

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.middleware.tripmonitor.jobs;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.middleware.models.ItineraryExistence;
@@ -11,6 +12,7 @@ import org.opentripplanner.middleware.utils.DateTimeUtils;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
@@ -120,5 +122,20 @@ class CheckMonitoredTripBasicTest {
         trip.tripTime = DateTimeUtils.makeOtpZonedDateTime(start).format(DateTimeFormatter.ISO_LOCAL_TIME);
         trip.leadTimeInMinutes = 30;
         return trip;
+    }
+
+    @Test
+    void canFindEarliestTargetDate() {
+        // Wednesday, April 9, 2025
+        ZonedDateTime fromDateTime = ZonedDateTime.of(2025, 4, 9, 10, 25, 0, 0, DateTimeUtils.getOtpZoneId());
+
+        // Monday, April 14, 2025
+        ZonedDateTime expectedDateTime = fromDateTime.plusDays(5);
+
+        MonitoredTrip trip = new MonitoredTrip();
+        trip.updateAllDaysOfWeek(false);
+        trip.monday = true;
+
+        assertEquals(expectedDateTime, CheckMonitoredTrip.findEarliestTargetDate(trip, fromDateTime));
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.middleware.tripmonitor.jobs;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.middleware.models.ItineraryExistence;
 import org.opentripplanner.middleware.models.MonitoredTrip;
@@ -12,6 +12,8 @@ import org.opentripplanner.middleware.utils.DateTimeUtils;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
@@ -124,18 +126,36 @@ class CheckMonitoredTripBasicTest {
         return trip;
     }
 
-    @Test
-    void canFindEarliestTargetDate() {
-        // Wednesday, April 9, 2025
-        ZonedDateTime fromDateTime = ZonedDateTime.of(2025, 4, 9, 10, 25, 0, 0, DateTimeUtils.getOtpZoneId());
+    @ParameterizedTest
+    @MethodSource("createFindEarliestTargetDateTime")
+    void canFindEarliestTargetDateTime(int fromDay, int expectedDay, String message) {
+        ZoneId zoneId = DateTimeUtils.getOtpZoneId();
+        ZonedDateTime fromDateTime = ZonedDateTime.of(2025, 4, fromDay, 10, 25, 0, 0, zoneId);
+        // Simulate a matching itinerary on a different day
+        Instant itineraryStartInstant = fromDateTime.plusDays(1).withHour(9).withMinute(0).toInstant();
 
         // Monday, April 14, 2025
-        ZonedDateTime expectedDateTime = fromDateTime.plusDays(5);
+        LocalDate expectedDate = fromDateTime.withDayOfMonth(expectedDay).toLocalDate();
 
-        MonitoredTrip trip = new MonitoredTrip();
+        MonitoredTrip trip = makeMonitoredTripFromNow(300, 600);
+        // Set the itinerary start time to be before the 'from' time above.
+        trip.tripTime = "09:00";
+        trip.itinerary.startTime = Date.from(itineraryStartInstant);
+        trip.itinerary.endTime = Date.from(itineraryStartInstant.plusSeconds(300));
         trip.updateAllDaysOfWeek(false);
         trip.monday = true;
 
-        assertEquals(expectedDateTime, CheckMonitoredTrip.findEarliestTargetDate(trip, fromDateTime));
+        assertEquals(
+            ZonedDateTime.of(expectedDate, LocalTime.parse(trip.tripTime, DateTimeFormatter.ISO_LOCAL_TIME), zoneId),
+            CheckMonitoredTrip.findEarliestTargetDate(trip, fromDateTime),
+            message
+        );
+    }
+
+    private static Stream<Arguments> createFindEarliestTargetDateTime() {
+        return Stream.of(
+            Arguments.of(9, 14, "Wed Apr 9, 2025 should result in Monday Apr 14"),
+            Arguments.of(14, 21, "Mon Apr 14, 2025 10am is after the trip and should result in next Monday")
+        );
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -130,21 +130,19 @@ class CheckMonitoredTripBasicTest {
     @MethodSource("createFindEarliestTargetDateTime")
     void canFindEarliestTargetDateTime(int fromDay, int expectedDay, String message) {
         ZoneId zoneId = DateTimeUtils.getOtpZoneId();
+        // 10:25 am on some specified day in April 2025.
         ZonedDateTime fromDateTime = ZonedDateTime.of(2025, 4, fromDay, 10, 25, 0, 0, zoneId);
-        // Simulate a matching itinerary on a different day
-        Instant itineraryStartInstant = fromDateTime.plusDays(1).withHour(9).withMinute(0).toInstant();
-
-        // Monday, April 14, 2025
-        LocalDate expectedDate = fromDateTime.withDayOfMonth(expectedDay).toLocalDate();
 
         MonitoredTrip trip = makeMonitoredTripFromNow(300, 600);
-        // Set the itinerary start time to be before the 'from' time above.
+        // Set the itinerary start time to 09:00 am, before the 'from' time above, on a different day (e.g. fromDay + 1).
+        Instant itineraryStartInstant = fromDateTime.plusDays(1).withHour(9).withMinute(0).toInstant();
         trip.tripTime = "09:00";
         trip.itinerary.startTime = Date.from(itineraryStartInstant);
         trip.itinerary.endTime = Date.from(itineraryStartInstant.plusSeconds(300));
         trip.updateAllDaysOfWeek(false);
         trip.monday = true;
 
+        LocalDate expectedDate = fromDateTime.withDayOfMonth(expectedDay).toLocalDate();
         assertEquals(
             ZonedDateTime.of(expectedDate, LocalTime.parse(trip.tripTime, DateTimeFormatter.ISO_LOCAL_TIME), zoneId),
             CheckMonitoredTrip.findEarliestTargetDate(trip, fromDateTime),

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -718,175 +718,29 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     /**
      * Tests whether the journey state is updated after monitored days are changed.
      */
-    @Test
-    void canUpdateJourneyStateAfterChangingMonitoredDays() throws Exception {
-        // Create an OTP mock to return, with a modified itinerary start date.
+    @ParameterizedTest
+    @MethodSource("casesForChangingMonitoredDays")
+    void canHandleChangingMonitoredDays(
+        ZonedDateTime nowTime,
+        int previousTargetDay,
+        String currentTargetDate,
+        String expectedTargetDate,
+        TripStatus tripStatus,
+        boolean skipMondayTuesday
+    ) throws Exception {
+        DateTimeUtils.useFixedClockAt(nowTime);
+
+        // Create an OTP mock to return, with itinerary start on Monday June 8, 2020.
         OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
-        Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
+        Itinerary originalItinerary = firstItinerary(mockWeekdayResponse);
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
         OtpTestUtils.updateBaseItineraryTime(
-            mockMondayJune15Itinerary,
-            DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime)
-                .withDayOfMonth(8)
-        );
-        // Create a mock monitored trip and CheckMonitorTrip instance.
-        // Note that the response below gets modified from the original mockOtpPlanResponse.
-        CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip(() -> mockWeekdayResponse);
-        MonitoredTrip mockTrip = mockCheckMonitoredTrip.trip;
-
-        // All days are initially monitored, remove Monday and Tuesday, so that the next trip date is Wednesday.
-        mockTrip.monday = false;
-        mockTrip.tuesday = false;
-
-        // Create mock itinerary existence for trip, with trip existing Monday and Tuesday.
-        mockTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
-        mockTrip.itineraryExistence.tuesday = new ItineraryExistence.ItineraryExistenceResult();
-        mockTrip.itineraryExistence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
-
-        // Use a previously computed trip status to be upcoming on Monday.
-        // Copy those journey state params to the CheckMonitoredTrip object too.
-        mockTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
-        mockTrip.journeyState.targetDate = "2020-06-08";
-        mockCheckMonitoredTrip.previousJourneyState = new JourneyState();
-        mockCheckMonitoredTrip.previousJourneyState.targetDate = mockTrip.journeyState.targetDate;
-        mockCheckMonitoredTrip.previousJourneyState.tripStatus = mockTrip.journeyState.tripStatus;
-
-        // update the target date to be an upcoming Monday within the CheckMonitoredTrip
-        mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
-            .withDayOfMonth(8)
-            .withHour(8)
-            .withMinute(35);
-
-        Persistence.monitoredTrips.create(mockTrip);
-
-        // mock the current time same day of itinerary just before the start time.
-        DateTimeUtils.useFixedClockAt(
-            noonMonday8June2020
-                .withDayOfMonth(8)
-                .withHour(8)
-                .withMinute(30)
-        );
-
-        // Perform the skip check (this populates some internal states)
-        assertTrue(mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
-
-        // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
-        assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
-
-        // fetch updated trip from persistence
-        MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(mockTrip.id);
-
-        assertEquals(
-            TRIP_UPCOMING,
-            updatedTrip.journeyState.tripStatus,
-            "Trip state should remain in future."
-        );
-
-        assertEquals(
-            "2020-06-10",
-            updatedTrip.journeyState.targetDate,
-            "Trip target date should have been changed according to monitored days."
-        );
-    }
-
-    /**
-     * Tests whether the journey state is updated after monitored days are changed.
-     */
-    @Test
-    void canUpdateJourneyStateAfterChangingMonitoredDays1b() throws Exception {
-        // Create an OTP mock to return, with a modified itinerary start date.
-        OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
-        Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
-        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
-        OtpTestUtils.updateBaseItineraryTime(
-            mockMondayJune15Itinerary,
-            DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime)
-                .withDayOfMonth(8)
-        );
-        // Create a mock monitored trip and CheckMonitorTrip instance.
-        // Note that the response below gets modified from the original mockOtpPlanResponse.
-        CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip(() -> mockWeekdayResponse);
-        MonitoredTrip mockTrip = mockCheckMonitoredTrip.trip;
-
-        // All days are initially monitored, remove Monday and Tuesday, so that the next trip date is Wednesday.
-        mockTrip.monday = false;
-        mockTrip.tuesday = false;
-
-        // Create mock itinerary existence for trip, with trip existing Monday and Tuesday.
-        mockTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
-        mockTrip.itineraryExistence.tuesday = new ItineraryExistence.ItineraryExistenceResult();
-        mockTrip.itineraryExistence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
-
-        // Use a previously computed trip status to be active on Monday.
-        // Copy those journey state params to the CheckMonitoredTrip object too.
-        mockTrip.journeyState.tripStatus = TripStatus.TRIP_ACTIVE;
-        mockTrip.journeyState.targetDate = "2020-06-08";
-        mockCheckMonitoredTrip.previousJourneyState = new JourneyState();
-        mockCheckMonitoredTrip.previousJourneyState.targetDate = mockTrip.journeyState.targetDate;
-        mockCheckMonitoredTrip.previousJourneyState.tripStatus = mockTrip.journeyState.tripStatus;
-
-        // update the target date to be an upcoming Monday within the CheckMonitoredTrip
-        mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
-            .withDayOfMonth(8)
-            .withHour(8)
-            .withMinute(35);
-
-        Persistence.monitoredTrips.create(mockTrip);
-
-        // mock the current time same day of itinerary and between start and end time.
-        DateTimeUtils.useFixedClockAt(
-            noonMonday8June2020
-                .withDayOfMonth(8)
-                .withHour(8)
-                .withMinute(50)
-        );
-
-        // Perform the skip check (this populates some internal states)
-        assertTrue(mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
-
-        // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
-        assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
-
-        // fetch updated trip from persistence
-        MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(mockTrip.id);
-
-        assertEquals(
-            TRIP_ACTIVE,
-            updatedTrip.journeyState.tripStatus,
-            "Active trips will continue to be monitored until they end."
-        );
-
-        assertEquals(
-            "2020-06-08",
-            updatedTrip.journeyState.targetDate,
-            "Trip target date should not change when a trip is ongoing."
-        );
-    }
-
-    /**
-     * Tests whether the journey state is updated after monitored days are changed.
-     */
-    @Test
-    void canUpdateJourneyStateAfterChangingMonitoredDays2() throws Exception {
-        // mock the current time to Monday, right before the start time of the trip.
-        DateTimeUtils.useFixedClockAt(
-            noonMonday8June2020
-                .withDayOfMonth(8)
-                .withHour(8)
-                .withMinute(30)
-        );
-
-        // Create an OTP mock to return, with a modified itinerary start date.
-        OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
-        Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
-        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
-        OtpTestUtils.updateBaseItineraryTime(
-            mockMondayJune15Itinerary,
-            DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime)
+            originalItinerary,
+            DateTimeUtils.makeOtpZonedDateTime(originalItinerary.startTime)
                 .withDayOfMonth(8)
         );
 
-        Date originalStartTime = mockMondayJune15Itinerary.startTime;
+        Date originalStartTime = originalItinerary.startTime;
 
         OtpResponse mockPreviousWeekdayResponse = mockOtpPlanResponse();
         Itinerary mockPreviousItinerary = firstItinerary(mockPreviousWeekdayResponse);
@@ -897,21 +751,29 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 .withDayOfMonth(9)
         );
 
-        assertEquals(originalStartTime, mockMondayJune15Itinerary.startTime);
+        // Make sure that the start time on the original trip was not changed.
+        assertEquals(originalStartTime, originalItinerary.startTime);
 
         // Create a mock monitored trip and CheckMonitorTrip instance.
         // Note that the response below gets modified from the original mockOtpPlanResponse.
         CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip(() -> mockWeekdayResponse);
         MonitoredTrip mockTrip = mockCheckMonitoredTrip.trip;
 
+        // All days are initially monitored, remove Monday and Tuesday, so that the next trip date is Wednesday.
+        if (skipMondayTuesday) {
+            mockTrip.monday = false;
+            mockTrip.tuesday = false;
+        }
+
         // Create mock itinerary existence for trip, with trip existing Monday and Tuesday.
         mockTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
         mockTrip.itineraryExistence.tuesday = new ItineraryExistence.ItineraryExistenceResult();
+        mockTrip.itineraryExistence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
 
         // Use a previously computed trip status to be upcoming on Tuesday.
         // Copy those journey state params to the CheckMonitoredTrip object too.
-        mockTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
-        mockTrip.journeyState.targetDate = "2020-06-09";
+        mockTrip.journeyState.tripStatus = tripStatus;
+        mockTrip.journeyState.targetDate = currentTargetDate;
         mockTrip.journeyState.matchingItinerary = mockPreviousItinerary;
         mockCheckMonitoredTrip.previousJourneyState = new JourneyState();
         mockCheckMonitoredTrip.previousJourneyState.targetDate = mockTrip.journeyState.targetDate;
@@ -921,7 +783,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         // update the target date to be an upcoming Tuesday within the CheckMonitoredTrip
         mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
-            .withDayOfMonth(9)
+            .withDayOfMonth(previousTargetDay)
             .withHour(8)
             .withMinute(35);
 
@@ -929,7 +791,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         // Perform the skip check (this populates some internal states)
         // This trip should not be skipped because it occurs within minutes of the mocked system time.
-        assertFalse(mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
+        assertEquals(skipMondayTuesday, mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
         // (should hit the "no additional checks needed" because the next trip is in the future.)
@@ -938,18 +800,62 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // fetch updated trip from persistence
         MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(mockTrip.id);
 
-        assertTrue(updatedTrip.monday);
+        if (!skipMondayTuesday) {
+            assertTrue(updatedTrip.monday);
+        }
 
         assertEquals(
-            TRIP_UPCOMING,
+            tripStatus,
             updatedTrip.journeyState.tripStatus,
-            "Trip state should remain in future."
+             tripStatus == TRIP_UPCOMING
+                 ? "Trip state should remain in future."
+                 : "Active trips will continue to be monitored until they end."
         );
 
         assertEquals(
-            "2020-06-08",
+            expectedTargetDate,
             updatedTrip.journeyState.targetDate,
             "Trip target date should have been changed according to monitored days."
+        );
+    }
+
+    private static Stream<Arguments> casesForChangingMonitoredDays() {
+        return Stream.of(
+            Arguments.of(
+                noonMonday8June2020
+                    .withDayOfMonth(8)
+                    .withHour(8)
+                    .withMinute(30),
+                8,
+                "2020-06-08",
+                "2020-06-10",
+                TRIP_UPCOMING,
+                true
+            ),
+            Arguments.of(
+                // mock the current time same day of itinerary and between start and end time.
+                noonMonday8June2020
+                    .withDayOfMonth(8)
+                    .withHour(8)
+                    .withMinute(50),
+                8,
+                "2020-06-08",
+                "2020-06-08",
+                TRIP_ACTIVE,
+                true
+            ),
+            Arguments.of(
+                noonMonday8June2020
+                    .withDayOfMonth(8)
+                    .withHour(8)
+                    .withMinute(30),
+                9,
+                "2020-06-09",
+                "2020-06-08",
+                TRIP_UPCOMING,
+                // This trip should not be skipped because it occurs within minutes of the mocked system time.
+                false
+            )
         );
     }
 

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -867,6 +867,14 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      */
     @Test
     void canUpdateJourneyStateAfterChangingMonitoredDays2() throws Exception {
+        // mock the current time to Monday, right before the start time of the trip.
+        DateTimeUtils.useFixedClockAt(
+            noonMonday8June2020
+                .withDayOfMonth(8)
+                .withHour(8)
+                .withMinute(30)
+        );
+
         // Create an OTP mock to return, with a modified itinerary start date.
         OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
         Itinerary mockMondayJune15Itinerary = mockWeekdayResponse.plan.itineraries.get(0);
@@ -876,6 +884,19 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime)
                 .withDayOfMonth(8)
         );
+
+        Date originalStartTime = mockMondayJune15Itinerary.startTime;
+
+        OtpResponse mockPreviousWeekdayResponse = mockOtpPlanResponse();
+        Itinerary mockPreviousItinerary = mockPreviousWeekdayResponse.plan.itineraries.get(0);
+        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
+        OtpTestUtils.updateBaseItineraryTime(
+            mockPreviousItinerary,
+            DateTimeUtils.makeOtpZonedDateTime(mockPreviousItinerary.startTime)
+                .withDayOfMonth(9)
+        );
+
+        assertEquals(originalStartTime, mockMondayJune15Itinerary.startTime);
 
         // Create a mock monitored trip and CheckMonitorTrip instance.
         // Note that the response below gets modified from the original mockOtpPlanResponse.
@@ -890,9 +911,12 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // Copy those journey state params to the CheckMonitoredTrip object too.
         mockTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
         mockTrip.journeyState.targetDate = "2020-06-09";
+        mockTrip.journeyState.matchingItinerary = mockPreviousItinerary;
         mockCheckMonitoredTrip.previousJourneyState = new JourneyState();
         mockCheckMonitoredTrip.previousJourneyState.targetDate = mockTrip.journeyState.targetDate;
         mockCheckMonitoredTrip.previousJourneyState.tripStatus = mockTrip.journeyState.tripStatus;
+        mockCheckMonitoredTrip.previousJourneyState.matchingItinerary = mockPreviousItinerary;
+        mockCheckMonitoredTrip.previousMatchingItinerary = mockPreviousItinerary;
 
         // update the target date to be an upcoming Tuesday within the CheckMonitoredTrip
         mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
@@ -902,16 +926,9 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         Persistence.monitoredTrips.create(mockTrip);
 
-        // mock the current time to Monday, right before the start time of the trip.
-        DateTimeUtils.useFixedClockAt(
-            noonMonday8June2020
-                .withDayOfMonth(8)
-                .withHour(8)
-                .withMinute(30)
-        );
-
         // Perform the skip check (this populates some internal states)
-        assertTrue(mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
+        // This trip should not be skipped because it occurs within minutes of the mocked system time.
+        assertFalse(mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
         // (should hit the "no additional checks needed" because the next trip is in the future.)
@@ -1269,5 +1286,4 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // Clear the created trip.
         PersistenceTestUtils.deleteMonitoredTrip(monitoredTrip);
     }
-
 }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -730,10 +730,9 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     ) throws Exception {
         DateTimeUtils.useFixedClockAt(nowTime);
 
-        // Create an OTP mock to return, with itinerary start on Monday June 8, 2020.
+        // Create an OTP mock to return, with itinerary start on Monday, June 8, 2020.
         OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
         Itinerary originalItinerary = firstItinerary(mockWeekdayResponse);
-        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
         OtpTestUtils.updateBaseItineraryTime(
             originalItinerary,
             DateTimeUtils.makeOtpZonedDateTime(originalItinerary.startTime)
@@ -742,36 +741,37 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         Date originalStartTime = originalItinerary.startTime;
 
+        // Create an OTP mock to return, with itinerary start on Tuesday, June 9, 2020.
         OtpResponse mockPreviousWeekdayResponse = mockOtpPlanResponse();
         Itinerary mockPreviousItinerary = firstItinerary(mockPreviousWeekdayResponse);
-        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
         OtpTestUtils.updateBaseItineraryTime(
             mockPreviousItinerary,
             DateTimeUtils.makeOtpZonedDateTime(mockPreviousItinerary.startTime)
                 .withDayOfMonth(9)
         );
 
-        // Make sure that the start time on the original trip was not changed.
+        // Make sure that the start time on the original trip was not changed inadvertently.
         assertEquals(originalStartTime, originalItinerary.startTime);
 
         // Create a mock monitored trip and CheckMonitorTrip instance.
-        // Note that the response below gets modified from the original mockOtpPlanResponse.
+        // Note that the response below includes changes above to the itinerary times.
         CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip(() -> mockWeekdayResponse);
         MonitoredTrip mockTrip = mockCheckMonitoredTrip.trip;
 
-        // All days are initially monitored, remove Monday and Tuesday, so that the next trip date is Wednesday.
         if (skipMondayTuesday) {
+            // All days are initially monitored.
+            // For some cases, un-monitor Monday and Tuesday, so that the next trip date is Wednesday.
             mockTrip.monday = false;
             mockTrip.tuesday = false;
         }
 
-        // Create mock itinerary existence for trip, with trip existing Monday and Tuesday.
+        // The trip exists Monday, Tuesday, and Wednesday.
         mockTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
         mockTrip.itineraryExistence.tuesday = new ItineraryExistence.ItineraryExistenceResult();
         mockTrip.itineraryExistence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
 
-        // Use a previously computed trip status to be upcoming on Tuesday.
-        // Copy those journey state params to the CheckMonitoredTrip object too.
+        // Use a previously computed trip status with the specified currentTargetDate.
+        // Copy those journey state params, including to the CheckMonitoredTrip object too.
         mockTrip.journeyState.tripStatus = tripStatus;
         mockTrip.journeyState.targetDate = currentTargetDate;
         mockTrip.journeyState.matchingItinerary = mockPreviousItinerary;
@@ -781,7 +781,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         mockCheckMonitoredTrip.previousJourneyState.matchingItinerary = mockPreviousItinerary;
         mockCheckMonitoredTrip.previousMatchingItinerary = mockPreviousItinerary;
 
-        // update the target date to be an upcoming Tuesday within the CheckMonitoredTrip
+        // Set the current target date/time.
         mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
             .withDayOfMonth(previousTargetDay)
             .withHour(8)
@@ -789,15 +789,15 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         Persistence.monitoredTrips.create(mockTrip);
 
-        // Perform the skip check (this populates some internal states)
-        // This trip should not be skipped because it occurs within minutes of the mocked system time.
+        // Perform the skip check (this populates some internal states).
+        // This trip should not be skipped if Monday and Tuesday are monitored because,
+        // for those cases, the trip occurs within minutes of the mocked system time.
         assertEquals(skipMondayTuesday, mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
 
-        // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
-        // (should hit the "no additional checks needed" because the next trip is in the future.)
+        // Execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome.
         assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
 
-        // fetch updated trip from persistence
+        // Fetch updated trip from persistence and check the trip status and target date.
         MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(mockTrip.id);
 
         if (!skipMondayTuesday) {
@@ -820,12 +820,13 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     }
 
     private static Stream<Arguments> casesForChangingMonitoredDays() {
+        ZonedDateTime monday20200608T0830 = noonMonday8June2020
+            .withDayOfMonth(8)
+            .withHour(8)
+            .withMinute(30);
         return Stream.of(
             Arguments.of(
-                noonMonday8June2020
-                    .withDayOfMonth(8)
-                    .withHour(8)
-                    .withMinute(30),
+                monday20200608T0830,
                 8,
                 "2020-06-08",
                 "2020-06-10",
@@ -833,11 +834,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 true
             ),
             Arguments.of(
-                // mock the current time same day of itinerary and between start and end time.
-                noonMonday8June2020
-                    .withDayOfMonth(8)
-                    .withHour(8)
-                    .withMinute(50),
+                // Mock the current time to same day of itinerary, between itinerary start and end time.
+                monday20200608T0830.withMinute(50),
                 8,
                 "2020-06-08",
                 "2020-06-08",
@@ -845,10 +843,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 true
             ),
             Arguments.of(
-                noonMonday8June2020
-                    .withDayOfMonth(8)
-                    .withHour(8)
-                    .withMinute(30),
+                monday20200608T0830,
                 9,
                 "2020-06-09",
                 "2020-06-08",

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -771,13 +771,80 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         assertEquals(
             TRIP_UPCOMING,
             updatedTrip.journeyState.tripStatus,
-            "Trip state should remain in future and active."
+            "Trip state should remain in future."
         );
 
         assertEquals(
             "2020-06-10",
             updatedTrip.journeyState.targetDate,
             "Trip target date should have been changed according to monitored days."
+        );
+    }
+
+    /**
+     * Tests whether the journey state is updated after monitored days are changed.
+     */
+    @Test
+    void canUpdateJourneyStateAfterChangingMonitoredDays1b() throws Exception {
+        // Create an OTP mock to return, with a modified itinerary start date.
+        OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
+        Itinerary mockMondayJune15Itinerary = mockWeekdayResponse.plan.itineraries.get(0);
+        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
+        OtpTestUtils.updateBaseItineraryTime(
+            mockMondayJune15Itinerary,
+            DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime)
+                .withDayOfMonth(8)
+        );
+        // Create a mock monitored trip and CheckMonitorTrip instance.
+        // Note that the response below gets modified from the original mockOtpPlanResponse.
+        CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip(() -> mockWeekdayResponse);
+        MonitoredTrip mockTrip = mockCheckMonitoredTrip.trip;
+
+        // All days are initially monitored, remove Monday and Tuesday, so that the next trip date is Wednesday.
+        mockTrip.monday = false;
+        mockTrip.tuesday = false;
+
+        // Create mock itinerary existence for trip, with trip existing Monday and Tuesday.
+        mockTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
+        mockTrip.itineraryExistence.tuesday = new ItineraryExistence.ItineraryExistenceResult();
+        mockTrip.itineraryExistence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
+
+        // Use a previously computed trip status to be active on Monday.
+        mockTrip.journeyState.tripStatus = TripStatus.TRIP_ACTIVE;
+        mockTrip.journeyState.targetDate = "2020-06-08";
+
+        // update the target date to be an upcoming Monday within the CheckMonitoredTrip
+        mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
+            .withDayOfMonth(8)
+            .withHour(8)
+            .withMinute(35);
+
+        Persistence.monitoredTrips.create(mockTrip);
+
+        // mock the current time same day of itinerary and between start and end time.
+        DateTimeUtils.useFixedClockAt(
+            noonMonday8June2020
+                .withDayOfMonth(8)
+                .withHour(8)
+                .withMinute(50)
+        );
+
+        // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
+        assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
+
+        // fetch updated trip from persistence
+        MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(mockTrip.id);
+
+        assertEquals(
+            TRIP_ACTIVE,
+            updatedTrip.journeyState.tripStatus,
+            "Active trips will continue to be monitored until they end."
+        );
+
+        assertEquals(
+            "2020-06-08",
+            updatedTrip.journeyState.targetDate,
+            "Trip target date should not change when a trip is ongoing."
         );
     }
 
@@ -837,7 +904,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         assertEquals(
             TRIP_UPCOMING,
             updatedTrip.journeyState.tripStatus,
-            "Trip state should remain in future and active."
+            "Trip state should remain in future."
         );
 
         assertEquals(

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.middleware.tripmonitor.jobs;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import jersey.repackaged.com.google.common.collect.Lists;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -119,20 +120,12 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         LOG.info("Created trip {}", monitoredTrip.id);
 
         // Setup an OTP mock response in order to trigger some of the monitor checks.
-        OtpResponse mockResponse = mockOtpPlanResponse();
-        Itinerary mockMondayJune15Itinerary = firstItinerary(mockResponse);
-
-        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15
-        OtpTestUtils.updateBaseItineraryTime(
-            mockMondayJune15Itinerary,
-            DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime)
-                .withDayOfMonth(15)
-        );
+        OtpResponse mockResponse = getMockOtpResponseJune15();
 
         // Add fake alerts to simulated itinerary.
         ArrayList<LocalizedAlert> fakeAlerts = new ArrayList<>();
         fakeAlerts.add(new LocalizedAlert());
-        mockMondayJune15Itinerary.legs.get(1).alerts = fakeAlerts;
+        firstItinerary(mockResponse).legs.get(1).alerts = fakeAlerts;
 
         // mock the current time to be 8:45am on Monday, June 15
         DateTimeUtils.useFixedClockAt(
@@ -174,19 +167,10 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         OtpResponse mockResponse = mockOtpPlanResponse();
         Itinerary mockTuesdayJune9Itinerary = firstItinerary(mockResponse);
-
-        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15
-        ZonedDateTime mockItineraryDate = DateTimeUtils.makeOtpZonedDateTime(mockTuesdayJune9Itinerary.startTime)
-            .withDayOfMonth(9);
-        OtpTestUtils.updateBaseItineraryTime(
-            mockTuesdayJune9Itinerary,
-            mockItineraryDate
-        );
+        OtpTestUtils.setItineraryDay(mockTuesdayJune9Itinerary, 9);
 
         // Add fake alerts to simulated itinerary.
-        ArrayList<LocalizedAlert> fakeAlerts = new ArrayList<>();
-        fakeAlerts.add(new LocalizedAlert());
-        mockTuesdayJune9Itinerary.legs.get(1).alerts = fakeAlerts;
+        mockTuesdayJune9Itinerary.legs.get(1).alerts = Lists.newArrayList(new LocalizedAlert());
 
         // The trip is set to be monitored Monday to Friday.
         // Mock time to be 7:30am on Tuesday, June 9 before the trip start.
@@ -213,17 +197,6 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
     @Test
     void sendInitialReminderNotificationForOneTimeTrip() throws Exception {
-        OtpResponse mockResponse = mockOtpPlanResponse();
-        Itinerary mockMondayJune15Itinerary = firstItinerary(mockResponse);
-
-        // Parse original itinerary date/time and then update mock itinerary to occur on Monday June 15.
-        OtpTestUtils.updateBaseItineraryTime(
-            mockMondayJune15Itinerary,
-            DateTimeUtils
-                .makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime)
-                .withDayOfMonth(15)
-        );
-
         MonitoredTrip monitoredTrip = PersistenceTestUtils.createMonitoredTrip(
             user.id,
             OtpTestUtils.OTP2_DISPATCHER_PLAN_RESPONSE.clone(),
@@ -233,7 +206,6 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         // Set one time trip state.
         monitoredTrip.updateAllDaysOfWeek(false);
-        monitoredTrip.itinerary = mockMondayJune15Itinerary;
         monitoredTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
         Persistence.monitoredTrips.create(monitoredTrip);
 
@@ -244,7 +216,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 .withMinute(45)
         );
 
-        CheckMonitoredTrip checkMonitoredTrip = new CheckMonitoredTrip(monitoredTrip, () -> mockResponse);
+        CheckMonitoredTrip checkMonitoredTrip = new CheckMonitoredTrip(monitoredTrip, this::getMockOtpResponseJune15);
         checkMonitoredTrip.run();
         // Assert that the initial reminder has been generated.
         Assertions.assertNotNull(checkMonitoredTrip.initialReminderNotification);
@@ -500,11 +472,9 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      */
     @Test
     void canMakeOTPRequestAndUpdateMatchingItineraryForPreviouslyUnmatchedItinerary() throws Exception {
-        // create an OTP mock to return
-        OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
         // create a mock monitored trip and CheckMonitorTrip instance.
         // Note that the response below gets modified from the original mockOtpPlanResponse.
-        CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip(() -> mockWeekdayResponse);
+        CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip(this::getMockOtpResponseJune15);
         MonitoredTrip mockTrip = mockCheckMonitoredTrip.trip;
         Persistence.monitoredTrips.create(mockTrip);
 
@@ -522,14 +492,6 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             .withDayOfMonth(15)
             .withHour(8)
             .withMinute(35);
-
-        Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
-        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15
-        OtpTestUtils.updateBaseItineraryTime(
-            mockMondayJune15Itinerary,
-            DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime)
-                .withDayOfMonth(15)
-        );
 
         // mock the current time to be 8:45am on Monday, June 15
         DateTimeUtils.useFixedClockAt(
@@ -733,22 +695,14 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // Create an OTP mock to return, with itinerary start on Monday, June 8, 2020.
         OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
         Itinerary originalItinerary = firstItinerary(mockWeekdayResponse);
-        OtpTestUtils.updateBaseItineraryTime(
-            originalItinerary,
-            DateTimeUtils.makeOtpZonedDateTime(originalItinerary.startTime)
-                .withDayOfMonth(8)
-        );
+        OtpTestUtils.setItineraryDay(originalItinerary, 8);
 
         Date originalStartTime = originalItinerary.startTime;
 
         // Create an OTP mock to return, with itinerary start on Tuesday, June 9, 2020.
         OtpResponse mockPreviousWeekdayResponse = mockOtpPlanResponse();
         Itinerary mockPreviousItinerary = firstItinerary(mockPreviousWeekdayResponse);
-        OtpTestUtils.updateBaseItineraryTime(
-            mockPreviousItinerary,
-            DateTimeUtils.makeOtpZonedDateTime(mockPreviousItinerary.startTime)
-                .withDayOfMonth(9)
-        );
+        OtpTestUtils.setItineraryDay(mockPreviousItinerary, 9);
 
         // Make sure that the start time on the original trip was not changed inadvertently.
         assertEquals(originalStartTime, originalItinerary.startTime);
@@ -946,8 +900,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
         Persistence.monitoredTrips.create(monitoredTrip);
 
-        OtpResponse expectedResponse = getMockOtpResponse();
-        OtpResponse unexpectedResponse = getMockOtpResponse();
+        OtpResponse expectedResponse = getMockOtpResponseJune15();
+        OtpResponse unexpectedResponse = getMockOtpResponseJune15();
         // Remove the final itinerary leg so that the matching itineraries check fails.
         firstItinerary(unexpectedResponse).legs.remove(2);
 
@@ -996,14 +950,10 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     /**
      * Create mock OTP response and set the base times of the first itinerary to Monday, June 15, 2020.
      */
-    private OtpResponse getMockOtpResponse() {
+    private OtpResponse getMockOtpResponseJune15() {
         OtpResponse mockResponse = mockOtpPlanResponse();
         Itinerary mockMondayJune15Itinerary = firstItinerary(mockResponse);
-        OtpTestUtils.updateBaseItineraryTime(
-            mockMondayJune15Itinerary,
-            DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime)
-                .withDayOfMonth(15)
-        );
+        OtpTestUtils.setItineraryDay(mockMondayJune15Itinerary, 15);
         return mockResponse;
     }
 

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -56,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.middleware.models.TripMonitorNotification.STOPWATCH_ICON;
+import static org.opentripplanner.middleware.testutils.OtpTestUtils.firstItinerary;
 import static org.opentripplanner.middleware.tripmonitor.TripStatus.NEXT_TRIP_NOT_POSSIBLE;
 import static org.opentripplanner.middleware.tripmonitor.TripStatus.TRIP_ACTIVE;
 import static org.opentripplanner.middleware.tripmonitor.TripStatus.TRIP_UPCOMING;
@@ -119,7 +120,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         // Setup an OTP mock response in order to trigger some of the monitor checks.
         OtpResponse mockResponse = mockOtpPlanResponse();
-        Itinerary mockMondayJune15Itinerary = mockResponse.plan.itineraries.get(0);
+        Itinerary mockMondayJune15Itinerary = firstItinerary(mockResponse);
 
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15
         OtpTestUtils.updateBaseItineraryTime(
@@ -172,7 +173,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
 
         OtpResponse mockResponse = mockOtpPlanResponse();
-        Itinerary mockTuesdayJune9Itinerary = mockResponse.plan.itineraries.get(0);
+        Itinerary mockTuesdayJune9Itinerary = firstItinerary(mockResponse);
 
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15
         ZonedDateTime mockItineraryDate = DateTimeUtils.makeOtpZonedDateTime(mockTuesdayJune9Itinerary.startTime)
@@ -213,7 +214,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     @Test
     void sendInitialReminderNotificationForOneTimeTrip() throws Exception {
         OtpResponse mockResponse = mockOtpPlanResponse();
-        Itinerary mockMondayJune15Itinerary = mockResponse.plan.itineraries.get(0);
+        Itinerary mockMondayJune15Itinerary = firstItinerary(mockResponse);
 
         // Parse original itinerary date/time and then update mock itinerary to occur on Monday June 15.
         OtpTestUtils.updateBaseItineraryTime(
@@ -522,7 +523,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             .withHour(8)
             .withMinute(35);
 
-        Itinerary mockMondayJune15Itinerary = mockWeekdayResponse.plan.itineraries.get(0);
+        Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15
         OtpTestUtils.updateBaseItineraryTime(
             mockMondayJune15Itinerary,
@@ -585,7 +586,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             .withHour(8)
             .withMinute(35);
 
-        Itinerary mockMondayJune15Itinerary = mockWeekdayResponse.plan.itineraries.get(0);
+        Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15, but at a time
         // that does not match the previous itinerary
         OtpTestUtils.updateBaseItineraryTime(
@@ -664,7 +665,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             .withHour(8)
             .withMinute(35);
 
-        Itinerary mockMondayJune15Itinerary = mockWeekdayResponse.plan.itineraries.get(0);
+        Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15, but at a time
         // that does not match the previous itinerary
         OtpTestUtils.updateBaseItineraryTime(
@@ -721,7 +722,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     void canUpdateJourneyStateAfterChangingMonitoredDays() throws Exception {
         // Create an OTP mock to return, with a modified itinerary start date.
         OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
-        Itinerary mockMondayJune15Itinerary = mockWeekdayResponse.plan.itineraries.get(0);
+        Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
         OtpTestUtils.updateBaseItineraryTime(
             mockMondayJune15Itinerary,
@@ -795,7 +796,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     void canUpdateJourneyStateAfterChangingMonitoredDays1b() throws Exception {
         // Create an OTP mock to return, with a modified itinerary start date.
         OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
-        Itinerary mockMondayJune15Itinerary = mockWeekdayResponse.plan.itineraries.get(0);
+        Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
         OtpTestUtils.updateBaseItineraryTime(
             mockMondayJune15Itinerary,
@@ -877,7 +878,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         // Create an OTP mock to return, with a modified itinerary start date.
         OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
-        Itinerary mockMondayJune15Itinerary = mockWeekdayResponse.plan.itineraries.get(0);
+        Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
         OtpTestUtils.updateBaseItineraryTime(
             mockMondayJune15Itinerary,
@@ -888,7 +889,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         Date originalStartTime = mockMondayJune15Itinerary.startTime;
 
         OtpResponse mockPreviousWeekdayResponse = mockOtpPlanResponse();
-        Itinerary mockPreviousItinerary = mockPreviousWeekdayResponse.plan.itineraries.get(0);
+        Itinerary mockPreviousItinerary = firstItinerary(mockPreviousWeekdayResponse);
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
         OtpTestUtils.updateBaseItineraryTime(
             mockPreviousItinerary,
@@ -1047,7 +1048,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         OtpResponse expectedResponse = getMockOtpResponse();
         OtpResponse unexpectedResponse = getMockOtpResponse();
         // Remove the final itinerary leg so that the matching itineraries check fails.
-        unexpectedResponse.plan.itineraries.get(0).legs.remove(2);
+        firstItinerary(unexpectedResponse).legs.remove(2);
 
         // Mock the current time to be 8:45am on Monday, June 15, 2020.
         DateTimeUtils.useFixedClockAt(
@@ -1096,7 +1097,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      */
     private OtpResponse getMockOtpResponse() {
         OtpResponse mockResponse = mockOtpPlanResponse();
-        Itinerary mockMondayJune15Itinerary = mockResponse.plan.itineraries.get(0);
+        Itinerary mockMondayJune15Itinerary = firstItinerary(mockResponse);
         OtpTestUtils.updateBaseItineraryTime(
             mockMondayJune15Itinerary,
             DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime)
@@ -1255,7 +1256,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         // Set up an OTP mock response in order to trigger some of the monitor checks.
         OtpResponse mockResponse = mockOtpPlanResponse();
-        Itinerary mockTuesdayJune09Itinerary = mockResponse.plan.itineraries.get(0);
+        Itinerary mockTuesdayJune09Itinerary = firstItinerary(mockResponse);
 
         // itinerary start time = 1:30AM UTC or 5:30PM PST
         OtpTestUtils.updateBaseItineraryTime(

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -742,14 +742,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             .withDayOfMonth(8)
             .withHour(8)
             .withMinute(35);
-/*
-        Itinerary mockMondayJune15Itinerary = mockWeekdayResponse.plan.itineraries.get(0);
-        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15
-        OtpTestUtils.updateBaseItineraryTime(
-            mockMondayJune15Itinerary,
-            DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime).withDayOfMonth(15)
-        );
-*/
+
         Persistence.monitoredTrips.create(mockTrip);
 
         // mock the current time to be 8:45am on Monday, June 8, 2020
@@ -775,6 +768,72 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         assertEquals(
             "2020-06-10",
+            updatedTrip.journeyState.targetDate,
+            "Trip target date should have been changed according to monitored days."
+        );
+    }
+
+    /**
+     * Tests whether the journey state is updated after monitored days are changed.
+     */
+    @Test
+    void canUpdateJourneyStateAfterChangingMonitoredDays2() throws Exception {
+        // Create an OTP mock to return, with a modified itinerary start date.
+        OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
+        Itinerary mockMondayJune15Itinerary = mockWeekdayResponse.plan.itineraries.get(0);
+        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
+        OtpTestUtils.updateBaseItineraryTime(
+            mockMondayJune15Itinerary,
+            DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime)
+                .withDayOfMonth(8)
+        );
+
+        // Create a mock monitored trip and CheckMonitorTrip instance.
+        // Note that the response below gets modified from the original mockOtpPlanResponse.
+        CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip(() -> mockWeekdayResponse);
+        MonitoredTrip mockTrip = mockCheckMonitoredTrip.trip;
+
+        // Create mock itinerary existence for trip, with trip existing Monday and Tuesday.
+        mockTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
+        mockTrip.itineraryExistence.tuesday = new ItineraryExistence.ItineraryExistenceResult();
+
+        // Use a previously computed trip status to be upcoming on Monday.
+        mockTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
+        mockTrip.journeyState.targetDate = "2020-06-09";
+
+        // update the target date to be an upcoming Tuesday within the CheckMonitoredTrip
+        mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
+            .withDayOfMonth(9)
+            .withHour(8)
+            .withMinute(35);
+
+        Persistence.monitoredTrips.create(mockTrip);
+
+        // mock the current time to be 8:45am on Monday, June 8, 2020
+        DateTimeUtils.useFixedClockAt(
+            noonMonday8June2020
+                .withDayOfMonth(8)
+                .withHour(8)
+                .withMinute(30)
+        );
+
+        // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
+        // (should hit the "no additional checks needed" because the next trip is in the future.)
+        assertFalse(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
+
+        // fetch updated trip from persistence
+        MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(mockTrip.id);
+
+        assertTrue(updatedTrip.monday);
+
+        assertEquals(
+            TRIP_UPCOMING,
+            updatedTrip.journeyState.tripStatus,
+            "Trip state should remain in future and active."
+        );
+
+        assertEquals(
+            "2020-06-08",
             updatedTrip.journeyState.targetDate,
             "Trip target date should have been changed according to monitored days."
         );

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -72,12 +72,17 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     private static OtpUser user;
 
     // this is initialized in the setup method after the OTP_TIMEZONE config value is known.
-    private static final ZonedDateTime noonMonday8June2020 = DateTimeUtils.makeOtpZonedDateTime(new Date())
+    private static final ZonedDateTime MONDAY_20200608_NOON = DateTimeUtils.makeOtpZonedDateTime(new Date())
         .withYear(2020)
         .withMonth(6)
         .withDayOfMonth(8)
         .withHour(12)
         .withMinute(0);
+    private static final ZonedDateTime MONDAY_20200615_0845 = MONDAY_20200608_NOON
+        .withDayOfMonth(15)
+        .withHour(8)
+        .withMinute(45);
+    private static final ZonedDateTime MONDAY_20200615_0835 = MONDAY_20200615_0845.withMinute(35);
 
     @BeforeAll
     public static void setup() {
@@ -128,12 +133,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         firstItinerary(mockResponse).legs.get(1).alerts = fakeAlerts;
 
         // mock the current time to be 8:45am on Monday, June 15
-        DateTimeUtils.useFixedClockAt(
-            noonMonday8June2020
-                .withDayOfMonth(15)
-                .withHour(8)
-                .withMinute(45)
-        );
+        DateTimeUtils.useFixedClockAt(MONDAY_20200615_0845);
 
         // Next, run a monitor trip check from the new monitored trip using the simulated response.
         CheckMonitoredTrip checkMonitoredTrip = new CheckMonitoredTrip(monitoredTrip, () -> mockResponse);
@@ -175,7 +175,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // The trip is set to be monitored Monday to Friday.
         // Mock time to be 7:30am on Tuesday, June 9 before the trip start.
         DateTimeUtils.useFixedClockAt(
-            noonMonday8June2020
+            MONDAY_20200608_NOON
                 .withDayOfMonth(9)
                 .withHour(7)
                 .withMinute(30)
@@ -209,12 +209,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
         Persistence.monitoredTrips.create(monitoredTrip);
 
-        DateTimeUtils.useFixedClockAt(
-            noonMonday8June2020
-                .withDayOfMonth(15)
-                .withHour(8)
-                .withMinute(45)
-        );
+        DateTimeUtils.useFixedClockAt(MONDAY_20200615_0845);
 
         CheckMonitoredTrip checkMonitoredTrip = new CheckMonitoredTrip(monitoredTrip, this::getMockOtpResponseJune15);
         checkMonitoredTrip.run();
@@ -378,7 +373,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         ShouldSkipTripTestCase weekendTripOnWeekdayTestCase = new ShouldSkipTripTestCase(
             "should return true for a weekend trip when current time is on a weekday",
-            noonMonday8June2020, // mock time: June 8, 2020 (Wednesday)
+            MONDAY_20200608_NOON,
             true
         );
         weekendTripOnWeekdayTestCase.trip = weekendTrip;
@@ -387,81 +382,81 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // - Return true for weekday trip when current time is on a weekend.
         testCases.add(new ShouldSkipTripTestCase(
             "should return true for weekday trip when current time is on a weekend",
-            noonMonday8June2020.withDayOfMonth(6), // mock time: June 6, 2020 (Saturday)
+            MONDAY_20200608_NOON.withDayOfMonth(6), // mock time: June 6, 2020 (Saturday)
             true
         ));
 
         // - Return true if trip is starting today, but before lead time
         ShouldSkipTripTestCase weekdayTripBeforeLeadTimeTestCase = new ShouldSkipTripTestCase(
             "should return true if trip is starting today, but current time is before lead time",
-            noonMonday8June2020.withHour(3).withMinute(0), // mock time: 3am,
+            MONDAY_20200608_NOON.withHour(3).withMinute(0), // mock time: 3am,
             true
         );
-        weekdayTripBeforeLeadTimeTestCase.lastCheckedTime = noonMonday8June2020.withHour(2).withMinute(0);
+        weekdayTripBeforeLeadTimeTestCase.lastCheckedTime = MONDAY_20200608_NOON.withHour(2).withMinute(0);
         testCases.add(weekdayTripBeforeLeadTimeTestCase);
 
         // - Return false if trip is starting in greater than 1 hr, but the last time checked was 2 hours ago
         ShouldSkipTripTestCase weekdayTripChecked2HoursAgoTestCase = new ShouldSkipTripTestCase(
             "should return false if trip is starting in greater than 1 hr, but the last time checked was 2 hours ago",
-            noonMonday8June2020.withHour(6).withMinute(0), // mock time: 6am
+            MONDAY_20200608_NOON.withHour(6).withMinute(0), // mock time: 6am
             false
         );
-        weekdayTripChecked2HoursAgoTestCase.lastCheckedTime = noonMonday8June2020.withHour(4).withMinute(0);
+        weekdayTripChecked2HoursAgoTestCase.lastCheckedTime = MONDAY_20200608_NOON.withHour(4).withMinute(0);
         testCases.add(weekdayTripChecked2HoursAgoTestCase);
 
         // - Return true if trip is starting in greater than 1 hr, but the last time checked was 2 minutes ago
         ShouldSkipTripTestCase weekdayTripIn1HourChecked2MinutesAgoTestCase = new ShouldSkipTripTestCase(
             "should return true if trip is starting in greater than 1 hr, but the last time checked was 2 minutes ago",
-            noonMonday8June2020.withHour(3).withMinute(0), // mock time: 3am
+            MONDAY_20200608_NOON.withHour(3).withMinute(0), // mock time: 3am
             true
         );
-        weekdayTripIn1HourChecked2MinutesAgoTestCase.lastCheckedTime = noonMonday8June2020.withHour(2).withMinute(58);
+        weekdayTripIn1HourChecked2MinutesAgoTestCase.lastCheckedTime = MONDAY_20200608_NOON.withHour(2).withMinute(58);
         testCases.add(weekdayTripIn1HourChecked2MinutesAgoTestCase);
 
         // - Return false if trip is starting in 45 minutes and the last time checked was 20 minutes ago
         ShouldSkipTripTestCase weekdayTripIn45MinutesChecked20MinutesAgoTestCase = new ShouldSkipTripTestCase(
             "should return false if trip is starting in 45 minutes and the last time checked was 20 minutes ago",
-            noonMonday8June2020.withHour(7).withMinute(55), // mock time: 7:55am
+            MONDAY_20200608_NOON.withHour(7).withMinute(55), // mock time: 7:55am
             false
         );
-        weekdayTripIn45MinutesChecked20MinutesAgoTestCase.lastCheckedTime = noonMonday8June2020.withHour(7).withMinute(35);
+        weekdayTripIn45MinutesChecked20MinutesAgoTestCase.lastCheckedTime = MONDAY_20200608_NOON.withHour(7).withMinute(35);
         testCases.add(weekdayTripIn45MinutesChecked20MinutesAgoTestCase);
 
         // - Return true if trip is starting in 45 minutes and the last time checked was 2 minutes ago
         ShouldSkipTripTestCase weekdayTripIn45MinutesChecked2MinutesAgoTestCase = new ShouldSkipTripTestCase(
             "should return true if trip is starting in 45 minutes and the last time checked was 2 minutes ago",
-            noonMonday8June2020.withHour(7).withMinute(55), // mock time: 7:55am
+            MONDAY_20200608_NOON.withHour(7).withMinute(55), // mock time: 7:55am
             true
         );
-        weekdayTripIn45MinutesChecked2MinutesAgoTestCase.lastCheckedTime = noonMonday8June2020.withHour(7).withMinute(53);
+        weekdayTripIn45MinutesChecked2MinutesAgoTestCase.lastCheckedTime = MONDAY_20200608_NOON.withHour(7).withMinute(53);
         testCases.add(weekdayTripIn45MinutesChecked2MinutesAgoTestCase);
 
         // - Return false if trip is starting in 10 minutes and the last time checked was 2 minutes ago
         ShouldSkipTripTestCase weekdayTripIn10MinutesChecked2MinutesAgoTestCase = new ShouldSkipTripTestCase(
             "should return false if trip is starting in 10 minutes and the last time checked was 2 minutes ago",
-            noonMonday8June2020.withHour(8).withMinute(30), // mock time: 8:30am
+            MONDAY_20200608_NOON.withHour(8).withMinute(30), // mock time: 8:30am
             false
         );
-        weekdayTripIn10MinutesChecked2MinutesAgoTestCase.lastCheckedTime = noonMonday8June2020.withHour(8).withMinute(28);
+        weekdayTripIn10MinutesChecked2MinutesAgoTestCase.lastCheckedTime = MONDAY_20200608_NOON.withHour(8).withMinute(28);
         testCases.add(weekdayTripIn10MinutesChecked2MinutesAgoTestCase);
 
         // - Returns false if trip still hadn't ended prior to the last checked time even though the current time is
         //   after the last known end time of the trip
         ShouldSkipTripTestCase weekdayTripNotYetEndedTestCase = new ShouldSkipTripTestCase(
             "should return false if trip hadn't ended the last time it was checked despite it being after the last known end time",
-            noonMonday8June2020.withHour(8).withMinute(59), // mock time: 8:59am
+            MONDAY_20200608_NOON.withHour(8).withMinute(59), // mock time: 8:59am
             false
         );
-        weekdayTripNotYetEndedTestCase.lastCheckedTime = noonMonday8June2020.withHour(8).withMinute(58).withSecond(0);
+        weekdayTripNotYetEndedTestCase.lastCheckedTime = MONDAY_20200608_NOON.withHour(8).withMinute(58).withSecond(0);
         testCases.add(weekdayTripNotYetEndedTestCase);
 
         // - Return true if trip has ended as of the last check 3 minutes ago
         ShouldSkipTripTestCase weekdayTripEndedTestCase = new ShouldSkipTripTestCase(
             "should return true if trip has ended as of the last check",
-            noonMonday8June2020.withHour(9).withMinute(0), // mock time: 9:00am
+            MONDAY_20200608_NOON.withHour(9).withMinute(0), // mock time: 9:00am
             true
         );
-        weekdayTripEndedTestCase.lastCheckedTime = noonMonday8June2020.withHour(8).withMinute(59);
+        weekdayTripEndedTestCase.lastCheckedTime = MONDAY_20200608_NOON.withHour(8).withMinute(59);
         testCases.add(weekdayTripEndedTestCase);
 
         return testCases;
@@ -488,18 +483,10 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         mockTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
 
         // update the target date to be an upcoming Monday within the CheckMonitoredTrip
-        mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
-            .withDayOfMonth(15)
-            .withHour(8)
-            .withMinute(35);
+        mockCheckMonitoredTrip.targetZonedDateTime = MONDAY_20200615_0835;
 
         // mock the current time to be 8:45am on Monday, June 15
-        DateTimeUtils.useFixedClockAt(
-            noonMonday8June2020
-                .withDayOfMonth(15)
-                .withHour(8)
-                .withMinute(45)
-        );
+        DateTimeUtils.useFixedClockAt(MONDAY_20200615_0845);
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
         assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
@@ -543,10 +530,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         mockTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
 
         // update the target date to be an upcoming Monday within the CheckMonitoredTrip
-        mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
-            .withDayOfMonth(15)
-            .withHour(8)
-            .withMinute(35);
+        mockCheckMonitoredTrip.targetZonedDateTime = MONDAY_20200615_0835;
 
         Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15, but at a time
@@ -559,12 +543,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         );
 
         // mock the current time to be 8:45am on Monday, June 15
-        DateTimeUtils.useFixedClockAt(
-            noonMonday8June2020
-                .withDayOfMonth(15)
-                .withHour(8)
-                .withMinute(45)
-        );
+        DateTimeUtils.useFixedClockAt(MONDAY_20200615_0845);
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
         assertFalse(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
@@ -622,10 +601,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         mockTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
 
         // update the target date to be an upcoming Monday within the CheckMonitoredTrip
-        mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
-            .withDayOfMonth(15)
-            .withHour(8)
-            .withMinute(35);
+        mockCheckMonitoredTrip.targetZonedDateTime = MONDAY_20200615_0835;
 
         Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15, but at a time
@@ -638,12 +614,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         );
 
         // mock the current time to be 8:45am on Monday, June 15
-        DateTimeUtils.useFixedClockAt(
-            noonMonday8June2020
-                .withDayOfMonth(15)
-                .withHour(8)
-                .withMinute(45)
-        );
+        DateTimeUtils.useFixedClockAt(MONDAY_20200615_0845);
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
         assertFalse(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
@@ -736,10 +707,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         mockCheckMonitoredTrip.previousMatchingItinerary = mockPreviousItinerary;
 
         // Set the current target date/time.
-        mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
-            .withDayOfMonth(previousTargetDay)
-            .withHour(8)
-            .withMinute(35);
+        mockCheckMonitoredTrip.targetZonedDateTime = MONDAY_20200615_0835.withDayOfMonth(previousTargetDay);
 
         Persistence.monitoredTrips.create(mockTrip);
 
@@ -774,13 +742,12 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     }
 
     private static Stream<Arguments> casesForChangingMonitoredDays() {
-        ZonedDateTime monday20200608T0830 = noonMonday8June2020
-            .withDayOfMonth(8)
+        ZonedDateTime monday0830 = MONDAY_20200608_NOON
             .withHour(8)
             .withMinute(30);
         return Stream.of(
             Arguments.of(
-                monday20200608T0830,
+                monday0830,
                 8,
                 "2020-06-08",
                 "2020-06-10",
@@ -789,7 +756,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             ),
             Arguments.of(
                 // Mock the current time to same day of itinerary, between itinerary start and end time.
-                monday20200608T0830.withMinute(50),
+                monday0830.withMinute(50),
                 8,
                 "2020-06-08",
                 "2020-06-08",
@@ -797,7 +764,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 true
             ),
             Arguments.of(
-                monday20200608T0830,
+                monday0830,
                 9,
                 "2020-06-09",
                 "2020-06-08",
@@ -906,12 +873,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         firstItinerary(unexpectedResponse).legs.remove(2);
 
         // Mock the current time to be 8:45am on Monday, June 15, 2020.
-        DateTimeUtils.useFixedClockAt(
-            noonMonday8June2020
-                .withDayOfMonth(15)
-                .withHour(8)
-                .withMinute(45)
-        );
+        DateTimeUtils.useFixedClockAt(MONDAY_20200615_0845);
 
         // Match on first attempts.
         assertCheckMonitoredTrip(monitoredTrip, expectedResponse, true, 0, TRIP_ACTIVE);
@@ -1019,7 +981,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
     private static Stream<Arguments> createCanUnsnoozeTripCases() {
         // (Trips for these tests start on Tuesday, June 9, 2020 at 8:40am and ends at 8:58am.)
-        ZonedDateTime tuesday = noonMonday8June2020.withDayOfMonth(9).withHour(0).withMinute(0).withSecond(0);
+        ZonedDateTime tuesday = MONDAY_20200608_NOON.withDayOfMonth(9).withHour(0).withMinute(0).withSecond(0);
         ZonedDateTime wednesday = tuesday.withDayOfMonth(10);
 
         return Stream.of(
@@ -1030,7 +992,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             Arguments.of(tuesday.withHour(8), wednesday, true),
             // Trip snoozed on Monday, June 8, 2020 (a day before the trip starts), should unsnooze at 12:00am (midnight)
             // on Tuesday, June 9, 2020.
-            Arguments.of(noonMonday8June2020, tuesday, true)
+            Arguments.of(MONDAY_20200608_NOON, tuesday, true)
         );
     }
 
@@ -1121,7 +1083,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // change "now" time after initial check to be within 30 min lead
         // 1:00AM UTC or 5:00PM PST
         DateTimeUtils.useFixedClockAt(
-            noonMonday8June2020
+            MONDAY_20200608_NOON
                 .withDayOfMonth(9)
                 .withHour(17)
                 .withMinute(0)

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -719,19 +719,28 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      */
     @Test
     void canUpdateJourneyStateAfterChangingMonitoredDays() throws Exception {
-        // create an OTP mock to return
+        // Create an OTP mock to return, with a modified itinerary start date.
         OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
+        Itinerary mockMondayJune15Itinerary = mockWeekdayResponse.plan.itineraries.get(0);
+        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 8, 2020
+        OtpTestUtils.updateBaseItineraryTime(
+            mockMondayJune15Itinerary,
+            DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime)
+                .withDayOfMonth(8)
+        );
         // Create a mock monitored trip and CheckMonitorTrip instance.
         // Note that the response below gets modified from the original mockOtpPlanResponse.
         CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip(() -> mockWeekdayResponse);
         MonitoredTrip mockTrip = mockCheckMonitoredTrip.trip;
 
-        // All days are initially monitored, remove Tuesday.
+        // All days are initially monitored, remove Monday and Tuesday, so that the next trip date is Wednesday.
+        mockTrip.monday = false;
         mockTrip.tuesday = false;
 
         // Create mock itinerary existence for trip, with trip existing Monday and Tuesday.
         mockTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
         mockTrip.itineraryExistence.tuesday = new ItineraryExistence.ItineraryExistenceResult();
+        mockTrip.itineraryExistence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
 
         // Use a previously computed trip status to be upcoming on Monday.
         mockTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
@@ -745,17 +754,16 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         Persistence.monitoredTrips.create(mockTrip);
 
-        // mock the current time to be 8:45am on Monday, June 8, 2020
+        // mock the current time same day of itinerary but after it's end time (8:58 am Pacific).
         DateTimeUtils.useFixedClockAt(
             noonMonday8June2020
                 .withDayOfMonth(8)
-                .withHour(8)
-                .withMinute(30)
+                .withHour(9)
+                .withMinute(45)
         );
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
-        // (should hit the "no additional checks needed" because the next trip is in the future.)
-        assertFalse(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
+        assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
 
         // fetch updated trip from persistence
         MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(mockTrip.id);
@@ -809,7 +817,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         Persistence.monitoredTrips.create(mockTrip);
 
-        // mock the current time to be 8:45am on Monday, June 8, 2020
+        // mock the current time to Monday, right before the start time of the trip.
         DateTimeUtils.useFixedClockAt(
             noonMonday8June2020
                 .withDayOfMonth(8)
@@ -819,7 +827,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
         // (should hit the "no additional checks needed" because the next trip is in the future.)
-        assertFalse(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
+        assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
 
         // fetch updated trip from persistence
         MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(mockTrip.id);

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -817,8 +817,12 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         mockTrip.itineraryExistence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
 
         // Use a previously computed trip status to be active on Monday.
+        // Copy those journey state params to the CheckMonitoredTrip object too.
         mockTrip.journeyState.tripStatus = TripStatus.TRIP_ACTIVE;
         mockTrip.journeyState.targetDate = "2020-06-08";
+        mockCheckMonitoredTrip.previousJourneyState = new JourneyState();
+        mockCheckMonitoredTrip.previousJourneyState.targetDate = mockTrip.journeyState.targetDate;
+        mockCheckMonitoredTrip.previousJourneyState.tripStatus = mockTrip.journeyState.tripStatus;
 
         // update the target date to be an upcoming Monday within the CheckMonitoredTrip
         mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
@@ -835,6 +839,9 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 .withHour(8)
                 .withMinute(50)
         );
+
+        // Perform the skip check (this populates some internal states)
+        assertTrue(mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
         assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
@@ -879,9 +886,13 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         mockTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
         mockTrip.itineraryExistence.tuesday = new ItineraryExistence.ItineraryExistenceResult();
 
-        // Use a previously computed trip status to be upcoming on Monday.
+        // Use a previously computed trip status to be upcoming on Tuesday.
+        // Copy those journey state params to the CheckMonitoredTrip object too.
         mockTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
         mockTrip.journeyState.targetDate = "2020-06-09";
+        mockCheckMonitoredTrip.previousJourneyState = new JourneyState();
+        mockCheckMonitoredTrip.previousJourneyState.targetDate = mockTrip.journeyState.targetDate;
+        mockCheckMonitoredTrip.previousJourneyState.tripStatus = mockTrip.journeyState.tripStatus;
 
         // update the target date to be an upcoming Tuesday within the CheckMonitoredTrip
         mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
@@ -898,6 +909,9 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 .withHour(8)
                 .withMinute(30)
         );
+
+        // Perform the skip check (this populates some internal states)
+        assertTrue(mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
         // (should hit the "no additional checks needed" because the next trip is in the future.)

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -355,7 +355,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      * Convenience method for creating a CheckMonitoredTrip instance with the default journey state.
      */
     private static CheckMonitoredTrip createCheckMonitoredTrip(Supplier<OtpResponse> otpResponseProvider) throws Exception {
-        return createCheckMonitoredTrip(OtpTestUtils.createDefaultJourneyState(), otpResponseProvider);
+        return createCheckMonitoredTrip(OtpTestUtils.createDefaultJourneyState(otpResponseProvider), otpResponseProvider);
     }
 
     /**
@@ -743,8 +743,12 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         mockTrip.itineraryExistence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
 
         // Use a previously computed trip status to be upcoming on Monday.
+        // Copy those journey state params to the CheckMonitoredTrip object too.
         mockTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
         mockTrip.journeyState.targetDate = "2020-06-08";
+        mockCheckMonitoredTrip.previousJourneyState = new JourneyState();
+        mockCheckMonitoredTrip.previousJourneyState.targetDate = mockTrip.journeyState.targetDate;
+        mockCheckMonitoredTrip.previousJourneyState.tripStatus = mockTrip.journeyState.tripStatus;
 
         // update the target date to be an upcoming Monday within the CheckMonitoredTrip
         mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
@@ -754,13 +758,16 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         Persistence.monitoredTrips.create(mockTrip);
 
-        // mock the current time same day of itinerary but after it's end time (8:58 am Pacific).
+        // mock the current time same day of itinerary just before the start time.
         DateTimeUtils.useFixedClockAt(
             noonMonday8June2020
                 .withDayOfMonth(8)
-                .withHour(9)
-                .withMinute(45)
+                .withHour(8)
+                .withMinute(30)
         );
+
+        // Perform the skip check (this populates some internal states)
+        assertTrue(mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
 
         // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
         assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -58,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.middleware.models.TripMonitorNotification.STOPWATCH_ICON;
 import static org.opentripplanner.middleware.tripmonitor.TripStatus.NEXT_TRIP_NOT_POSSIBLE;
 import static org.opentripplanner.middleware.tripmonitor.TripStatus.TRIP_ACTIVE;
+import static org.opentripplanner.middleware.tripmonitor.TripStatus.TRIP_UPCOMING;
 import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTripBasicTest.makeMonitoredTripFromNow;
 import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTripBasicTest.setRecurringTodayAndTomorrow;
 
@@ -710,6 +711,72 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             "Your itinerary is no longer possible on any monitored day of the week. Please plan and save a new trip.",
             mockCheckMonitoredTrip.notifications.iterator().next().body,
             "The notification should have the appropriate message when the trip is no longer possible"
+        );
+    }
+
+    /**
+     * Tests whether the journey state is updated after monitored days are changed.
+     */
+    @Test
+    void canUpdateJourneyStateAfterChangingMonitoredDays() throws Exception {
+        // create an OTP mock to return
+        OtpResponse mockWeekdayResponse = mockOtpPlanResponse();
+        // Create a mock monitored trip and CheckMonitorTrip instance.
+        // Note that the response below gets modified from the original mockOtpPlanResponse.
+        CheckMonitoredTrip mockCheckMonitoredTrip = createCheckMonitoredTrip(() -> mockWeekdayResponse);
+        MonitoredTrip mockTrip = mockCheckMonitoredTrip.trip;
+
+        // All days are initially monitored, remove Tuesday.
+        mockTrip.tuesday = false;
+
+        // Create mock itinerary existence for trip, with trip existing Monday and Tuesday.
+        mockTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
+        mockTrip.itineraryExistence.tuesday = new ItineraryExistence.ItineraryExistenceResult();
+
+        // Use a previously computed trip status to be upcoming on Monday.
+        mockTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
+        mockTrip.journeyState.targetDate = "2020-06-08";
+
+        // update the target date to be an upcoming Monday within the CheckMonitoredTrip
+        mockCheckMonitoredTrip.targetZonedDateTime = noonMonday8June2020
+            .withDayOfMonth(8)
+            .withHour(8)
+            .withMinute(35);
+/*
+        Itinerary mockMondayJune15Itinerary = mockWeekdayResponse.plan.itineraries.get(0);
+        // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15
+        OtpTestUtils.updateBaseItineraryTime(
+            mockMondayJune15Itinerary,
+            DateTimeUtils.makeOtpZonedDateTime(mockMondayJune15Itinerary.startTime).withDayOfMonth(15)
+        );
+*/
+        Persistence.monitoredTrips.create(mockTrip);
+
+        // mock the current time to be 8:45am on Monday, June 8, 2020
+        DateTimeUtils.useFixedClockAt(
+            noonMonday8June2020
+                .withDayOfMonth(8)
+                .withHour(8)
+                .withMinute(30)
+        );
+
+        // execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome
+        // (should hit the "no additional checks needed" because the next trip is in the future.)
+        assertFalse(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
+
+        // fetch updated trip from persistence
+        MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(mockTrip.id);
+
+        assertEquals(
+            TRIP_UPCOMING,
+            updatedTrip.journeyState.tripStatus,
+            "Trip state should remain in future and active."
+        );
+
+        assertEquals(
+            "2020-06-10",
+            updatedTrip.journeyState.targetDate,
+            "Trip target date should have been changed according to monitored days."
         );
     }
 

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/ShouldSkipTripTestCase.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/ShouldSkipTripTestCase.java
@@ -3,7 +3,6 @@ package org.opentripplanner.middleware.tripmonitor.jobs;
 import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.otp.response.Itinerary;
-import org.opentripplanner.middleware.otp.response.OtpResponse;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.testutils.OtpTestUtils;
 import org.opentripplanner.middleware.testutils.PersistenceTestUtils;
@@ -50,8 +49,7 @@ class ShouldSkipTripTestCase {
 
     public CheckMonitoredTrip generateCheckMonitoredTrip(OtpUser user) throws Exception {
         // create a mock OTP response for planning a trip on a weekday target datetime
-        OtpResponse mockWeekdayResponse = OtpTestUtils.OTP2_DISPATCHER_PLAN_RESPONSE.getResponse();
-        Itinerary mockWeekdayItinerary = mockWeekdayResponse.plan.itineraries.get(0);
+        Itinerary mockWeekdayItinerary = OtpTestUtils.createDefaultItinerary();
         OtpTestUtils.updateBaseItineraryTime(
             mockWeekdayItinerary,
             mockTime.withYear(2020).withMonth(6).withDayOfMonth(8).withHour(8).withMinute(40).withSecond(10)

--- a/src/test/java/org/opentripplanner/middleware/utils/ItineraryUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/ItineraryUtilsTest.java
@@ -40,6 +40,8 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.middleware.testutils.OtpTestUtils.createDefaultItinerary;
+import static org.opentripplanner.middleware.testutils.OtpTestUtils.firstItinerary;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.otpDateTimeAsEpochMillis;
 
 public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
@@ -92,11 +94,6 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
         2020, 8, 14, 3, 0, 0
     );
 
-    /** Contains the verified itinerary set for a trip upon persisting. */
-    public static Itinerary getDefaultItinerary() throws Exception {
-        return OtpTestUtils.OTP2_DISPATCHER_PLAN_RESPONSE.getResponse().plan.itineraries.get(0);
-    }
-
     /**
      * Test that itineraries exist and result.allCheckedDatesAreValid are as expected.
      */
@@ -117,7 +114,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
         MockOtpResponseProvider mockResponses = new MockOtpResponseProvider(mockOtpResponses);
 
         // Also set trip itinerary to the template itinerary for easy/lazy match.
-        Itinerary expectedItinerary = mockOtpResponses.get(DayOfWeek.THURSDAY).plan.itineraries.get(0);
+        Itinerary expectedItinerary = firstItinerary(mockOtpResponses.get(DayOfWeek.THURSDAY));
         trip.itinerary = expectedItinerary;
 
         trip.checkItineraryExistence(false, mockResponses::getMockResponse);
@@ -251,7 +248,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
         testCases.add(
             new ItineraryMatchTestCase(
                 "Should be equal with same data",
-                getDefaultItinerary().clone(),
+                createDefaultItinerary(),
                 true
             )
         );
@@ -259,7 +256,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
         // should not be equal with a different amount of legs
         Leg extraBikeLeg = new Leg();
         extraBikeLeg.mode = "BICYCLE";
-        Itinerary itineraryWithMoreLegs = getDefaultItinerary().clone();
+        Itinerary itineraryWithMoreLegs = createDefaultItinerary();
         itineraryWithMoreLegs.legs.add(extraBikeLeg);
         testCases.add(
             new ItineraryMatchTestCase(
@@ -270,7 +267,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
         );
 
         // should be equal with realtime data on transit leg (same day)
-        Itinerary itineraryWithRealtimeTransit = getDefaultItinerary().clone();
+        Itinerary itineraryWithRealtimeTransit = createDefaultItinerary();
         Leg transitLeg = itineraryWithRealtimeTransit.legs.get(1);
         int secondsOfDelay = 120;
         transitLeg.startTime = new Date(transitLeg.startTime.getTime() + secondsOfDelay * 1000);
@@ -286,7 +283,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
         );
 
         // should be equal with scheduled data on transit leg (future date)
-        Itinerary itineraryOnFutureDate = getDefaultItinerary().clone();
+        Itinerary itineraryOnFutureDate = createDefaultItinerary();
         Leg transitLeg2 = itineraryOnFutureDate.legs.get(1);
         transitLeg2.startTime = Date.from(transitLeg2.startTime.toInstant().plus(7, ChronoUnit.DAYS));
         transitLeg2.endTime = Date.from(transitLeg2.endTime.toInstant().plus(7, ChronoUnit.DAYS));
@@ -387,7 +384,7 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
             if (previousItinerary != null) {
                 this.previousItinerary = previousItinerary;
             } else {
-                this.previousItinerary = getDefaultItinerary();
+                this.previousItinerary = createDefaultItinerary();
             }
             this.newItinerary = newItinerary;
             this.shouldMatch = shouldMatch;


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes an incorrect calculation for the next monitored trip start time when monitored days are changed.
Behind the scenes, itinerary date/time helper methods and itinerary mock responses are refactored for brevity.
