### PR TITLE
Correctly retrieve itinerary last leg for anonymized trips.

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/connecteddataplatform/AnonymizedTripRequest.java
+++ b/src/main/java/org/opentripplanner/middleware/connecteddataplatform/AnonymizedTripRequest.java
@@ -131,7 +131,7 @@ public class AnonymizedTripRequest {
      * If all first/last legs in all itineraries are transit, return true. If any first/last leg is non transit,
      * return false.
      */
-    private static boolean areAllFirstOrLastLegsTransit(List<Itinerary> itineraries, boolean isFirstLeg) {
+    static boolean areAllFirstOrLastLegsTransit(List<Itinerary> itineraries, boolean isFirstLeg) {
         if (itineraries == null) {
             // If no itineraries are provided assume non transit leg.
             return false;
@@ -143,7 +143,7 @@ public class AnonymizedTripRequest {
             if (legs != null && !legs.isEmpty()) {
                 isTransitLeg = (isFirstLeg)
                     ? legs.get(0).transitLeg
-                    : legs.get(itineraries.get(0).legs.size() - 1).transitLeg;
+                    : legs.get(legs.size() - 1).transitLeg;
                 if (!isTransitLeg) {
                     // If the leg is non transit there is no need to check the remaining itineraries.
                     break;

--- a/src/test/java/org/opentripplanner/middleware/connecteddataplatform/AnonymizedTripRequestTest.java
+++ b/src/test/java/org/opentripplanner/middleware/connecteddataplatform/AnonymizedTripRequestTest.java
@@ -1,0 +1,26 @@
+package org.opentripplanner.middleware.connecteddataplatform;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.middleware.otp.response.Itinerary;
+import org.opentripplanner.middleware.otp.response.Leg;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class AnonymizedTripRequestTest {
+    @Test
+    void canCheckAllLastLegsTransit() {
+        Leg transitLeg = new Leg();
+        transitLeg.transitLeg = true;
+        Leg walkLeg = new Leg();
+        walkLeg.transitLeg = false;
+
+        Itinerary itin1 = new Itinerary();
+        itin1.legs = List.of(walkLeg);
+        Itinerary itin2 = new Itinerary();
+        itin2.legs = List.of(transitLeg, walkLeg);
+
+        assertFalse(AnonymizedTripRequest.areAllFirstOrLastLegsTransit(List.of(itin1, itin2), false));
+    }
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR addresses a crash that may occur when anonymizing itineraries (CDP feature) and the itineraries are in an order such that an itinerary with fewest legs is first.
