### PR TITLE
Add "continue riding" instruction

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -5,6 +5,7 @@ import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.Place;
 import org.opentripplanner.middleware.otp.response.Step;
 import org.opentripplanner.middleware.triptracker.instruction.ContinueInstruction;
+import org.opentripplanner.middleware.triptracker.instruction.ContinueRidingTransitInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.DeviatedInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.GetOffHereTransitInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.GetOffNextStopTransitInstruction;
@@ -332,7 +333,12 @@ public class TravelerLocator {
                 stopsRemaining == expectedLeg.intermediateStops.size() &&
                 travelerPosition.speed >= MIN_TRANSIT_VEHICLE_SPEED
             ) {
+                // When on board, after the transit vehicle departs the boarding stop, announce how long to ride
+                // (similar to the itinerary narrative in OTP-react-redux),
                 return new TransitLegSummaryInstruction(expectedLeg, locale);
+            } else {
+                // While far from the exiting stop, simply announce "Continue riding the bus."
+                return new ContinueRidingTransitInstruction();
             }
         }
         return null;

--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/ContinueRidingTransitInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/ContinueRidingTransitInstruction.java
@@ -1,0 +1,12 @@
+package org.opentripplanner.middleware.triptracker.instruction;
+
+/**
+ * Instruction that summarizes a transit leg, emitted typically after getting onboard a transit vehicle.
+ */
+public class ContinueRidingTransitInstruction extends TransitLegInstruction {
+    @Override
+    public String build() {
+        // TODO: i18n and various transit modes (trains, subways...)
+        return "Continue riding the bus.";
+    }
+}

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -488,7 +488,7 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                     )
             ),
             Arguments.of(
-                "On transit leg away from the boarding location (or walked past the bus stop). No specific instruction to give.",
+                "On transit leg away from the boarding location (or walked past the bus stop). Instruct to continue riding.",
                 firstLegBusTransit,
                 0,
                 new TraceData()

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -597,10 +597,10 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                     .withExpectedInstruction(String.format("Ride 4 min / 8 stops to %s", destinationName))
             ),
             Arguments.of(
-                "On the transit segment, but far from the arrival stop, so no instruction is given.",
+                "On the transit segment, but far from the arrival stop, an instruction to continue riding is given.",
                 new TraceData()
                     .withPosition(33.78792, -84.37776)
-                    .withExpectedInstruction(NO_INSTRUCTION)
+                    .withExpectedInstruction("Continue riding the bus.")
             ),
             Arguments.of(
                 "Upcoming arrival stop instruction.",

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -18,6 +18,7 @@ import org.opentripplanner.middleware.otp.response.Step;
 import org.opentripplanner.middleware.testutils.CommonTestUtils;
 import org.opentripplanner.middleware.testutils.OtpMiddlewareTestEnvironment;
 import org.opentripplanner.middleware.triptracker.instruction.ContinueInstruction;
+import org.opentripplanner.middleware.triptracker.instruction.ContinueRidingTransitInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.DeviatedInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.OnTrackInstruction;
 import org.opentripplanner.middleware.triptracker.instruction.TripInstruction;
@@ -492,7 +493,7 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                 0,
                 new TraceData()
                     .withPosition(33.916779, -84.226556)
-                    .withExpectedInstruction(NO_INSTRUCTION)
+                    .withExpectedInstruction(new ContinueRidingTransitInstruction())
             ),
             Arguments.of(
                 "Start live tracking well after bus departure. Issue wait instruction (indicate past departure).",


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected => this is also in the `gmap-pending-fixes` branch _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR replaces the "no instruction" announcement with a "Continue riding the bus" when still far from the destination stop.
