### PR TITLE
Fix condition for advancing to next day.

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -25,6 +25,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -556,5 +557,19 @@ public class MonitoredTrip extends Model {
             default:
                 return false;
         }
+    }
+
+    /**
+     * Determines whether the trip target date is consistent with the matching itinerary.
+     */
+    public boolean tripTargetDateIsConsistentWithMatchingItinerary() {
+        if (journeyState == null || journeyState.targetDate == null) return false;
+        Itinerary matchingItinerary = journeyState.matchingItinerary;
+        return journeyState.targetDate.equals(
+            DateTimeUtils.getStringFromDate(
+                DateTimeUtils.makeOtpZonedDateTime(matchingItinerary.startTime).toLocalDate(),
+                DateTimeUtils.DEFAULT_DATE_FORMAT_PATTERN
+            )
+        );
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -539,4 +539,22 @@ public class MonitoredTrip extends Model {
             companion != null &&
             tripOwner.email.equalsIgnoreCase(companion.email);
     }
+
+    /**
+     * Determines whether the trip status is consistent with the matching itinerary.
+     */
+    public boolean tripStateIsConsistentWithMatchingItinerary() {
+        if (journeyState == null) return false;
+        Itinerary matchingItinerary = journeyState.matchingItinerary;
+        switch (journeyState.tripStatus) {
+            case PAST_TRIP:
+                return isOneTime() && matchingItinerary.hasEnded();
+            case TRIP_UPCOMING:
+                return !matchingItinerary.isActive();
+            case TRIP_ACTIVE:
+                return matchingItinerary.isActive();
+            default:
+                return false;
+        }
+    }
 }

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -544,7 +544,7 @@ public class MonitoredTrip extends Model {
      * Determines whether the trip status is consistent with the matching itinerary.
      */
     public boolean tripStateIsConsistentWithMatchingItinerary() {
-        if (journeyState == null) return false;
+        if (journeyState == null || journeyState.tripStatus == null) return false;
         Itinerary matchingItinerary = journeyState.matchingItinerary;
         switch (journeyState.tripStatus) {
             case PAST_TRIP:

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -165,7 +165,12 @@ public class CheckMonitoredTrip implements Runnable {
         LOG.info("Begin checking trip.");
         // Check if the trip check should be skipped (based on time, day of week, etc.)
         try {
-            if (shouldSkipMonitoredTripCheck()) {
+            if (
+                shouldSkipMonitoredTripCheck() &&
+                // Perform the check if the journey state or target date is not consistent with the matching itinerary.
+                trip.tripStateIsConsistentWithMatchingItinerary() &&
+                trip.tripTargetDateIsConsistentWithMatchingItinerary()
+            ) {
                 LOG.debug("Skipping check for trip");
                 return;
             }
@@ -798,11 +803,6 @@ public class CheckMonitoredTrip implements Runnable {
             }
         }
 
-        // Perform the check if the journey state or target date is incorrect vs the matching itinerary.
-        if (!trip.tripStateIsConsistentWithMatchingItinerary() || !trip.tripTargetDateIsConsistentWithMatchingItinerary()) {
-            return false;
-        }
-
         // If last check was more than an hour ago and trip doesn't occur until an hour from now, check trip.
         long minutesSinceLastCheck = getMinutesSinceLastCheck();
         LOG.info("{} minutes since last checking trip", minutesSinceLastCheck);
@@ -853,7 +853,14 @@ public class CheckMonitoredTrip implements Runnable {
      * Whether to advance to the next monitored day.
      */
     public boolean shouldAdvanceToNextDay() {
-        return !trip.isOneTime() && !matchingItinerary.isActive() && !isTrackingOngoing();
+        boolean sameDayAsItinerary = DateTimeUtils.nowAsZonedDateTime().toLocalDate().equals(
+            DateTimeUtils.makeOtpZonedDateTime(matchingItinerary.startTime).toLocalDate()
+        );
+        return
+            !trip.isOneTime() &&
+            !matchingItinerary.isActive() &&
+            !isTrackingOngoing() &&
+            !(sameDayAsItinerary && !matchingItinerary.hasEnded());
     }
 
     private boolean isPreviousTripOngoing() {

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -798,8 +798,8 @@ public class CheckMonitoredTrip implements Runnable {
             }
         }
 
-        // Perform the check if the journey state is incorrect vs the matching itinerary.
-        if (!trip.tripStateIsConsistentWithMatchingItinerary()) {
+        // Perform the check if the journey state or target date is incorrect vs the matching itinerary.
+        if (!trip.tripStateIsConsistentWithMatchingItinerary() || !trip.tripTargetDateIsConsistentWithMatchingItinerary()) {
             return false;
         }
 

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -848,7 +848,7 @@ public class CheckMonitoredTrip implements Runnable {
      * Whether to advance to the next monitored day.
      */
     public boolean shouldAdvanceToNextDay() {
-        return !trip.isOneTime() && journeyState.tripStatus == TripStatus.TRIP_UPCOMING && matchingItinerary.hasEnded() && !isTrackingOngoing();
+        return !trip.isOneTime() && matchingItinerary.hasEnded() && !isTrackingOngoing();
     }
 
     private boolean isPreviousTripOngoing() {

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -798,6 +798,11 @@ public class CheckMonitoredTrip implements Runnable {
             }
         }
 
+        // Perform the check if the journey state is incorrect vs the matching itinerary.
+        if (!trip.tripStateIsConsistentWithMatchingItinerary()) {
+            return false;
+        }
+
         // If last check was more than an hour ago and trip doesn't occur until an hour from now, check trip.
         long minutesSinceLastCheck = getMinutesSinceLastCheck();
         LOG.info("{} minutes since last checking trip", minutesSinceLastCheck);

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -853,7 +853,7 @@ public class CheckMonitoredTrip implements Runnable {
      * Whether to advance to the next monitored day.
      */
     public boolean shouldAdvanceToNextDay() {
-        return !trip.isOneTime() && matchingItinerary.hasEnded() && !isTrackingOngoing();
+        return !trip.isOneTime() && !matchingItinerary.isActive() && !isTrackingOngoing();
     }
 
     private boolean isPreviousTripOngoing() {

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -786,7 +786,7 @@ public class CheckMonitoredTrip implements Runnable {
 
             // Attempt to advance to the next monitored day, except for one-time trips
             // or if tracking is ongoing or if the matching itinerary is still valid.
-            if (!trip.isOneTime() && trip.journeyState.tripStatus != TripStatus.TRIP_ACTIVE && !isTrackingOngoing()) {
+            if (shouldAdvanceToNextDay()) {
                 advanceToNextMonitoredDay();
             }
 
@@ -842,6 +842,13 @@ public class CheckMonitoredTrip implements Runnable {
         // TODO: Change log level.
         LOG.info("Trip criteria not met to check. Skipping.");
         return true;
+    }
+
+    /**
+     * Whether to advance to the next monitored day.
+     */
+    public boolean shouldAdvanceToNextDay() {
+        return !trip.isOneTime() && journeyState.tripStatus == TripStatus.TRIP_UPCOMING && matchingItinerary.hasEnded() && !isTrackingOngoing();
     }
 
     private boolean isPreviousTripOngoing() {

--- a/src/test/java/org/opentripplanner/middleware/models/MonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/models/MonitoredTripTest.java
@@ -9,6 +9,7 @@ import org.opentripplanner.middleware.otp.OtpGraphQLVariables;
 import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.Place;
+import org.opentripplanner.middleware.tripmonitor.TripStatus;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +19,8 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.middleware.models.RelatedUser.RelatedUserStatus.CONFIRMED;
 import static org.opentripplanner.middleware.models.RelatedUser.RelatedUserStatus.PENDING;
+import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTripBasicTest.makeMonitoredTripFromNow;
+import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTripBasicTest.setRecurringTodayAndTomorrow;
 
 class MonitoredTripTest {
     @Test
@@ -180,6 +183,40 @@ class MonitoredTripTest {
                 creatorId,
                 "Should return the id of the user that created the trip if primary is null."
             )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("createTripStateVsMatchingItineraryCases")
+    void testCheckTripStateVsMatchingItinerary(int offsetSeconds, TripStatus tripStatus, boolean expected, String whenIsTrip) throws Exception {
+        MonitoredTrip trip = makeMonitoredTripFromNow(offsetSeconds, offsetSeconds + 300);
+        if (tripStatus != TripStatus.PAST_TRIP) {
+            setRecurringTodayAndTomorrow(trip);
+        }
+        trip.journeyState.tripStatus = tripStatus;
+        trip.journeyState.matchingItinerary = trip.itinerary;
+
+        assertEquals(
+            expected,
+            trip.tripStateIsConsistentWithMatchingItinerary(),
+            String.format("%s + trip %s is %sconsistent", tripStatus, whenIsTrip, expected ? "" : "not ")
+        );
+    }
+
+    private static Stream<Arguments> createTripStateVsMatchingItineraryCases() {
+        final int ONE_HOURS_IN_SECS = 3600;
+        final int TWO_MINUTES_IN_SECS = 120;
+        return Stream.of(
+            Arguments.of(ONE_HOURS_IN_SECS, TripStatus.TRIP_UPCOMING, true, "in near future"),
+            Arguments.of(ONE_HOURS_IN_SECS, TripStatus.TRIP_ACTIVE, false, "in near future"),
+            Arguments.of(ONE_HOURS_IN_SECS, TripStatus.PAST_TRIP, false, "in near future"),
+            Arguments.of(-TWO_MINUTES_IN_SECS, TripStatus.TRIP_ACTIVE, true, "ongoing"),
+            Arguments.of(-TWO_MINUTES_IN_SECS, TripStatus.TRIP_UPCOMING, false, "ongoing"),
+            Arguments.of(-TWO_MINUTES_IN_SECS, TripStatus.PAST_TRIP, false, "ongoing"),
+            Arguments.of(-ONE_HOURS_IN_SECS, TripStatus.PAST_TRIP, true, "ended"),
+            Arguments.of(-ONE_HOURS_IN_SECS, TripStatus.TRIP_ACTIVE, false, "ended"),
+            // For recurring trips, the state below is actually consistent.
+            Arguments.of(-ONE_HOURS_IN_SECS, TripStatus.TRIP_UPCOMING, true, "ended")
         );
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/models/MonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/models/MonitoredTripTest.java
@@ -10,7 +10,9 @@ import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.Place;
 import org.opentripplanner.middleware.tripmonitor.TripStatus;
+import org.opentripplanner.middleware.utils.DateTimeUtils;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -188,7 +190,7 @@ class MonitoredTripTest {
 
     @ParameterizedTest
     @MethodSource("createTripStateVsMatchingItineraryCases")
-    void testCheckTripStateVsMatchingItinerary(int offsetSeconds, TripStatus tripStatus, boolean expected, String whenIsTrip) throws Exception {
+    void testCheckTripStateVsMatchingItinerary(int offsetSeconds, TripStatus tripStatus, boolean expected, String whenIsTrip) {
         MonitoredTrip trip = makeMonitoredTripFromNow(offsetSeconds, offsetSeconds + 300);
         if (tripStatus != TripStatus.PAST_TRIP) {
             setRecurringTodayAndTomorrow(trip);
@@ -217,6 +219,29 @@ class MonitoredTripTest {
             Arguments.of(-ONE_HOURS_IN_SECS, TripStatus.TRIP_ACTIVE, false, "ended"),
             // For recurring trips, the state below is actually consistent.
             Arguments.of(-ONE_HOURS_IN_SECS, TripStatus.TRIP_UPCOMING, true, "ended")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("createTripTargetDateVsMatchingItineraryCases")
+    void testCheckTripDateVsMatchingItinerary(ZonedDateTime targetDate, boolean expected) {
+        MonitoredTrip trip = makeMonitoredTripFromNow(0, 300);
+        setRecurringTodayAndTomorrow(trip);
+        trip.journeyState.matchingItinerary = trip.itinerary;
+        trip.journeyState.targetDate = DateTimeUtils.getStringFromDate(targetDate.toLocalDate(), DateTimeUtils.DEFAULT_DATE_FORMAT_PATTERN);
+
+        assertEquals(
+            expected,
+            trip.tripTargetDateIsConsistentWithMatchingItinerary(),
+            String.format("%s and %s is %sconsistent", trip.itinerary.startTime, targetDate, expected ? "" : "not ")
+        );
+    }
+
+    private static Stream<Arguments> createTripTargetDateVsMatchingItineraryCases() {
+        ZonedDateTime now = DateTimeUtils.nowAsZonedDateTime();
+        return Stream.of(
+            Arguments.of(now, true),
+            Arguments.of(now.plusDays(1), false)
         );
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
@@ -9,6 +9,7 @@ import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.otp.response.OtpResponse;
 import org.opentripplanner.middleware.otp.response.OtpResponseGraphQLWrapper;
 import org.opentripplanner.middleware.tripmonitor.JourneyState;
+import org.opentripplanner.middleware.tripmonitor.TripStatus;
 import org.opentripplanner.middleware.utils.DateTimeUtils;
 import org.opentripplanner.middleware.utils.ItineraryUtils;
 import org.opentripplanner.middleware.utils.ItineraryUtilsTest;
@@ -245,6 +246,11 @@ public class OtpTestUtils {
         journeyState.scheduledDepartureTimeEpochMillis = defaultItinerary.startTime.getTime();
         journeyState.baselineArrivalTimeEpochMillis = defaultItinerary.endTime.getTime();
         journeyState.baselineDepartureTimeEpochMillis = defaultItinerary.startTime.getTime();
+        journeyState.tripStatus = defaultItinerary.isActive()
+            ? TripStatus.TRIP_ACTIVE
+            : TripStatus.TRIP_UPCOMING;
+        journeyState.matchingItinerary = defaultItinerary;
+
         return journeyState;
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -156,4 +156,32 @@ class CheckMonitoredTripBasicTest {
             Arguments.of(14, 21, "Mon Apr 14, 2025 10am is after the trip and should result in next Monday")
         );
     }
+
+    @ParameterizedTest
+    @MethodSource("createShouldAdvanceToNextDayCases")
+    void testShouldAdvanceToNextDay(int offsetSeconds, boolean expected, String message) throws Exception {
+        MonitoredTrip trip = makeMonitoredTripFromNow(offsetSeconds, offsetSeconds + 300);
+        setRecurringTodayAndTomorrow(trip);
+        trip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
+        trip.journeyState.matchingItinerary = trip.itinerary;
+
+        CheckMonitoredTrip check = new CheckMonitoredTrip(trip);
+        check.shouldSkipMonitoredTripCheck(false);
+        assertEquals(
+            expected,
+            check.shouldAdvanceToNextDay(),
+            message
+        );
+    }
+
+    private static Stream<Arguments> createShouldAdvanceToNextDayCases() {
+        final int ONE_HOURS_IN_SECS = 3600;
+        final int TWO_MINUTES_IN_SECS = 120;
+        return Stream.of(
+            Arguments.of(ONE_HOURS_IN_SECS, false, "Should not advance monitored day if trip in near future"),
+            Arguments.of(TWO_MINUTES_IN_SECS, false, "Should not advance monitored day if trip is ongoing"),
+            Arguments.of(-ONE_HOURS_IN_SECS, true, "Should advance monitored day if trip is past.")
+        );
+    }
+
 }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * This class contains tests for {@link CheckMonitoredTrip} that don't require database or OTP queries.
  */
-class CheckMonitoredTripBasicTest {
+public class CheckMonitoredTripBasicTest {
     private static final int ONE_DAY_IN_SECONDS = 3600 * 24;
 
     @ParameterizedTest
@@ -65,7 +65,7 @@ class CheckMonitoredTripBasicTest {
     }
 
     /** Add the day-of-week of the itinerary start time as the recurring day, and the next day too. */
-    static void setRecurringTodayAndTomorrow(MonitoredTrip trip) {
+    public static void setRecurringTodayAndTomorrow(MonitoredTrip trip) {
         DayOfWeek dayOfWeek = DayOfWeek.of(LocalDate.ofInstant(
             trip.itinerary.startTime.toInstant(),
             DateTimeUtils.getOtpZoneId()).get(ChronoField.DAY_OF_WEEK
@@ -110,7 +110,7 @@ class CheckMonitoredTripBasicTest {
         }
     }
 
-    static MonitoredTrip makeMonitoredTripFromNow(int startOffsetSecs, int endOffsetSecs) {
+    public static MonitoredTrip makeMonitoredTripFromNow(int startOffsetSecs, int endOffsetSecs) {
         Instant now = Instant.now();
         Date start = Date.from(now.plusSeconds(startOffsetSecs));
 
@@ -183,5 +183,4 @@ class CheckMonitoredTripBasicTest {
             Arguments.of(-ONE_HOURS_IN_SECS, true, "Should advance monitored day if trip is past.")
         );
     }
-
 }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -123,12 +123,6 @@ public class CheckMonitoredTripBasicTest {
         trip.itinerary = itinerary;
         trip.tripTime = DateTimeUtils.makeOtpZonedDateTime(start).format(DateTimeFormatter.ISO_LOCAL_TIME);
         trip.leadTimeInMinutes = 30;
-
-        trip.journeyState.tripStatus = endOffsetSecs >= 0 && startOffsetSecs <= 0
-            ? TripStatus.TRIP_ACTIVE
-            : TripStatus.TRIP_UPCOMING;
-        trip.journeyState.matchingItinerary = itinerary;
-
         return trip;
     }
 
@@ -168,11 +162,9 @@ public class CheckMonitoredTripBasicTest {
     void testShouldAdvanceToNextDay(int offsetSeconds, boolean expected, String message) throws Exception {
         MonitoredTrip trip = makeMonitoredTripFromNow(offsetSeconds, offsetSeconds + 300);
         setRecurringTodayAndTomorrow(trip);
-        trip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
-        trip.journeyState.matchingItinerary = trip.itinerary;
 
         CheckMonitoredTrip check = new CheckMonitoredTrip(trip);
-        check.shouldSkipMonitoredTripCheck(false);
+        check.matchingItinerary = trip.itinerary;
         assertEquals(
             expected,
             check.shouldAdvanceToNextDay(),

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -123,6 +123,12 @@ public class CheckMonitoredTripBasicTest {
         trip.itinerary = itinerary;
         trip.tripTime = DateTimeUtils.makeOtpZonedDateTime(start).format(DateTimeFormatter.ISO_LOCAL_TIME);
         trip.leadTimeInMinutes = 30;
+
+        trip.journeyState.tripStatus = endOffsetSecs >= 0 && startOffsetSecs <= 0
+            ? TripStatus.TRIP_ACTIVE
+            : TripStatus.TRIP_UPCOMING;
+        trip.journeyState.matchingItinerary = itinerary;
+
         return trip;
     }
 

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -718,7 +718,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // Perform the skip check (this populates some internal states).
         // This trip should not be skipped if Monday and Tuesday are monitored because,
         // for those cases, the trip occurs within minutes of the mocked system time.
-        assertEquals(skipMondayTuesday, mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
+        // If the trip is active, the check can be skipped.
+        assertEquals(skipMondayTuesday && tripStatus != TRIP_ACTIVE, mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
 
         // Execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome.
         assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
@@ -1004,7 +1005,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
     @ParameterizedTest
     @MethodSource("createUpdateTripStuckInActiveStateCases")
-    void canUpdateTripStuckInActiveState(ZonedDateTime clockTime, TripStatus tripStatus) throws Exception {
+    void canUpdateTripStuckInActiveState(ZonedDateTime clockTime, TripStatus tripStatus, String message) throws Exception {
         MonitoredTrip monitoredTrip = PersistenceTestUtils.createMonitoredTrip(
             user.id,
             OtpTestUtils.OTP2_DISPATCHER_PLAN_RESPONSE.clone(),
@@ -1029,7 +1030,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         check.run();
 
         MonitoredTrip modifiedTrip = Persistence.monitoredTrips.getById(monitoredTrip.id);
-        assertEquals(tripStatus, modifiedTrip.journeyState.tripStatus);
+        assertEquals(tripStatus, modifiedTrip.journeyState.tripStatus, message);
 
         // Clear the created trip.
         PersistenceTestUtils.deleteMonitoredTrip(modifiedTrip);
@@ -1037,13 +1038,14 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
     private static Stream<Arguments> createUpdateTripStuckInActiveStateCases() {
         // (Trips for these tests start on Tuesday, June 9, 2020 at 8:40am and ends at 8:58am.)
+        // The initial state for the trip is TRIP_ACTIVE.
         ZonedDateTime tuesday = MONDAY_20200608_NOON.withDayOfMonth(9).withHour(0).withMinute(0).withSecond(0);
 
         return Stream.of(
-            // During trip (before 8:58 am), state should remain active.
-            Arguments.of(tuesday.withHour(8).withMinute(50), TRIP_ACTIVE),
-            // After trip is done (after 9am), state should change to upcoming (for recurring trip).
-            Arguments.of(tuesday.withHour(10), TRIP_UPCOMING)
+            Arguments.of(tuesday.withHour(8).withMinute(50), TRIP_ACTIVE, " During trip (before 8:58 am), state should remain active."),
+            Arguments.of(tuesday.withHour(10), TRIP_UPCOMING, "After trip (after 9am), state should change to upcoming (for recurring trip)."),
+            Arguments.of(tuesday.withHour(8), TRIP_UPCOMING, "Shortly before trip starts, state should change to upcoming."),
+            Arguments.of(tuesday.withHour(4), TRIP_UPCOMING, "Long before trip starts, state should change to upcoming.")
         );
     }
 

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -114,6 +114,10 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
     @Test
     void canMonitorOngoingTrip() throws Exception {
+        // Setup an OTP mock response in order to trigger some of the monitor checks.
+        OtpResponse mockResponse = getMockOtpResponseJune15();
+        Itinerary itinerary = firstItinerary(mockResponse);
+
         MonitoredTrip monitoredTrip = PersistenceTestUtils.createMonitoredTrip(
             user.id,
             OtpTestUtils.OTP2_DISPATCHER_PLAN_RESPONSE.clone(),
@@ -121,16 +125,16 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             null
         );
         monitoredTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
+        // For an ongoing trip, assume the journey state has been initialized.
+        monitoredTrip.journeyState.baselineDepartureTimeEpochMillis = itinerary.startTime.getTime();
+        monitoredTrip.journeyState.baselineArrivalTimeEpochMillis = itinerary.endTime.getTime();
         Persistence.monitoredTrips.create(monitoredTrip);
         LOG.info("Created trip {}", monitoredTrip.id);
-
-        // Setup an OTP mock response in order to trigger some of the monitor checks.
-        OtpResponse mockResponse = getMockOtpResponseJune15();
 
         // Add fake alerts to simulated itinerary.
         ArrayList<LocalizedAlert> fakeAlerts = new ArrayList<>();
         fakeAlerts.add(new LocalizedAlert());
-        firstItinerary(mockResponse).legs.get(1).alerts = fakeAlerts;
+        itinerary.legs.get(1).alerts = fakeAlerts;
 
         // mock the current time to be 8:45am on Monday, June 15
         DateTimeUtils.useFixedClockAt(MONDAY_20200615_0845);

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -834,8 +834,10 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         // Note that the response below gets modified from the original mockOtpPlanResponse.
         CheckMonitoredTrip check = new CheckMonitoredTrip(trip, () -> otpResponse);
-        check.shouldSkipMonitoredTripCheck(false);
-        check.checkOtpAndUpdateTripStatus();
+        // Trip is advanced to next monitored day because "today"'s trip instance has ended.
+        // As a result, trip status is set to upcoming, checkOtpAndUpdateTripStatus is skipped. .
+        assertTrue(check.shouldSkipMonitoredTripCheck());
+        assertEquals(TripStatus.TRIP_UPCOMING, check.journeyState.tripStatus);
         assertEquals(TripStatus.TRIP_UPCOMING, trip.journeyState.tripStatus);
         assertEquals(getShiftedDay(trip.itinerary.startTime, 1), trip.journeyState.targetDate);
     }
@@ -997,6 +999,51 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             // Trip snoozed on Monday, June 8, 2020 (a day before the trip starts), should unsnooze at 12:00am (midnight)
             // on Tuesday, June 9, 2020.
             Arguments.of(MONDAY_20200608_NOON, tuesday, true)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("createUpdateTripStuckInActiveStateCases")
+    void canUpdateTripStuckInActiveState(ZonedDateTime clockTime, TripStatus tripStatus) throws Exception {
+        MonitoredTrip monitoredTrip = PersistenceTestUtils.createMonitoredTrip(
+            user.id,
+            OtpTestUtils.OTP2_DISPATCHER_PLAN_RESPONSE.clone(),
+            false,
+            OtpTestUtils.createDefaultJourneyState()
+        );
+        monitoredTrip.id = UUID.randomUUID().toString();
+        // Set monitored days to Tuesday only.
+        monitoredTrip.monday = false;
+        monitoredTrip.tuesday = true;
+        monitoredTrip.journeyState.targetDate = "2020-06-09";
+        monitoredTrip.journeyState.tripStatus = TRIP_ACTIVE;
+
+        Persistence.monitoredTrips.create(monitoredTrip);
+
+        // Mock the current time
+        DateTimeUtils.useFixedClockAt(clockTime);
+
+        // After trip has completed, check that trip status has been updated.
+        CheckMonitoredTrip check = new CheckMonitoredTrip(monitoredTrip, this::mockOtpPlanResponse);
+
+        check.run();
+
+        MonitoredTrip modifiedTrip = Persistence.monitoredTrips.getById(monitoredTrip.id);
+        assertEquals(tripStatus, modifiedTrip.journeyState.tripStatus);
+
+        // Clear the created trip.
+        PersistenceTestUtils.deleteMonitoredTrip(modifiedTrip);
+    }
+
+    private static Stream<Arguments> createUpdateTripStuckInActiveStateCases() {
+        // (Trips for these tests start on Tuesday, June 9, 2020 at 8:40am and ends at 8:58am.)
+        ZonedDateTime tuesday = MONDAY_20200608_NOON.withDayOfMonth(9).withHour(0).withMinute(0).withSecond(0);
+
+        return Stream.of(
+            // During trip (before 8:58 am), state should remain active.
+            Arguments.of(tuesday.withHour(8).withMinute(50), TRIP_ACTIVE),
+            // After trip is done (after 9am), state should change to upcoming (for recurring trip).
+            Arguments.of(tuesday.withHour(10), TRIP_UPCOMING)
         );
     }
 

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -69,6 +69,7 @@ import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTrip
  */
 public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     private static final Logger LOG = LoggerFactory.getLogger(CheckMonitoredTripTest.class);
+    public static final int ONE_DAY_IN_MILLIS = 24 * 3600000;
     private static OtpUser user;
 
     // this is initialized in the setup method after the OTP_TIMEZONE config value is known.
@@ -680,7 +681,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         OtpTestUtils.setItineraryDay(mockPreviousItinerary, 9);
         if (tripStatus == TRIP_ACTIVE) {
             // If the trip is active, set the trip day to Monday when that case applies.
-            mockPreviousItinerary.offsetTimes(-24 * 3600000);
+            mockPreviousItinerary.offsetTimes(-ONE_DAY_IN_MILLIS);
         }
 
         // Make sure that the start time on the original trip was not changed inadvertently.
@@ -788,7 +789,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
      * This test also involves a matching itinerary a day ahead of the days to monitor.
      */
     @Test
-    void canHandleChangingMonitoredDays2() throws Exception {
+    void canUpdateTargetDate() throws Exception {
         // Create a check with a mock OTP response itinerary for Tuesday 09 June 2020 08:40.
         CheckMonitoredTrip check = createCheckMonitoredTrip(this::mockOtpPlanResponse);
         MonitoredTrip trip = check.trip;
@@ -806,8 +807,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         // Set the matching itinerary and previous matching itinerary to Wednesday
         trip.journeyState.matchingItinerary = firstItinerary(mockOtpPlanResponse());
-        trip.journeyState.matchingItinerary.offsetTimes(24 * 3600 * 1000);
-        check.previousMatchingItinerary.offsetTimes(24 * 3600 * 1000);
+        trip.journeyState.matchingItinerary.offsetTimes(ONE_DAY_IN_MILLIS);
+        check.previousMatchingItinerary.offsetTimes(ONE_DAY_IN_MILLIS);
         assertEquals(
             "2020-06-10",
             DateTimeUtils.getStringFromDate(
@@ -897,7 +898,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // Note that the response below gets modified from the original mockOtpPlanResponse.
         CheckMonitoredTrip check = new CheckMonitoredTrip(trip, () -> otpResponse);
         // Trip is advanced to next monitored day because "today"'s trip instance has ended.
-        // As a result, trip status is set to upcoming, checkOtpAndUpdateTripStatus is skipped. .
+        // As a result, trip status is set to upcoming, checkOtpAndUpdateTripStatus is skipped.
         assertTrue(check.shouldSkipMonitoredTripCheck());
         assertEquals(TripStatus.TRIP_UPCOMING, check.journeyState.tripStatus);
         assertEquals(TripStatus.TRIP_UPCOMING, trip.journeyState.tripStatus);

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -378,7 +378,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         ShouldSkipTripTestCase weekendTripOnWeekdayTestCase = new ShouldSkipTripTestCase(
             "should return true for a weekend trip when current time is on a weekday",
             MONDAY_20200608_NOON,
-            true
+            false // FIXME: Was true. False means extra checks will be done for the same outcome.
         );
         weekendTripOnWeekdayTestCase.trip = weekendTrip;
         testCases.add(weekendTripOnWeekdayTestCase);
@@ -387,7 +387,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         testCases.add(new ShouldSkipTripTestCase(
             "should return true for weekday trip when current time is on a weekend",
             MONDAY_20200608_NOON.withDayOfMonth(6), // mock time: June 6, 2020 (Saturday)
-            true
+            false // FIXME: Was true. False means extra checks will be done for the same outcome.
         ));
 
         // - Return true if trip is starting today, but before lead time
@@ -663,7 +663,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         String currentTargetDate,
         String expectedTargetDate,
         TripStatus tripStatus,
-        boolean skipMondayTuesday
+        boolean skipMondayTuesday,
+        boolean skipCheck
     ) throws Exception {
         DateTimeUtils.useFixedClockAt(nowTime);
 
@@ -718,8 +719,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // Perform the skip check (this populates some internal states).
         // This trip should not be skipped if Monday and Tuesday are monitored because,
         // for those cases, the trip occurs within minutes of the mocked system time.
-        // If the trip is active, the check can be skipped.
-        assertEquals(skipMondayTuesday && tripStatus != TRIP_ACTIVE, mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
+        assertEquals(skipCheck, mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
 
         // Execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome.
         assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
@@ -757,7 +757,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 "2020-06-08",
                 "2020-06-10",
                 TRIP_UPCOMING,
-                true
+                true,
+                false
             ),
             Arguments.of(
                 // Mock the current time to same day of itinerary, between itinerary start and end time.
@@ -766,7 +767,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 "2020-06-08",
                 "2020-06-08",
                 TRIP_ACTIVE,
-                true
+                true,
+                false // If the trip is active, the check should not be skipped.
             ),
             Arguments.of(
                 monday0830,
@@ -775,7 +777,66 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 "2020-06-08",
                 TRIP_UPCOMING,
                 // This trip should not be skipped because it occurs within minutes of the mocked system time.
+                false,
                 false
+            )
+        );
+    }
+
+    /**
+     * Tests whether the journey state is updated after monitored days are changed.
+     * This test also involves a matching itinerary a day ahead of the days to monitor.
+     */
+    @Test
+    void canHandleChangingMonitoredDays2() throws Exception {
+        // Create a check with a mock OTP response itinerary for Tuesday 09 June 2020 08:40.
+        CheckMonitoredTrip check = createCheckMonitoredTrip(this::mockOtpPlanResponse);
+        MonitoredTrip trip = check.trip;
+
+        trip.wednesday = true;
+        trip.tuesday = true;
+        // Set the clock to Tuesday before trip start.
+        ZonedDateTime tuesdayBeforeTripStarts = MONDAY_20200608_NOON.withDayOfMonth(9).withHour(7);
+        DateTimeUtils.useFixedClockAt(tuesdayBeforeTripStarts);
+
+        // The trip exists Monday, Tuesday, and Wednesday.
+        trip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
+        trip.itineraryExistence.tuesday = new ItineraryExistence.ItineraryExistenceResult();
+        trip.itineraryExistence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
+
+        // Set the matching itinerary and previous matching itinerary to Wednesday
+        trip.journeyState.matchingItinerary = firstItinerary(mockOtpPlanResponse());
+        trip.journeyState.matchingItinerary.offsetTimes(24 * 3600 * 1000);
+        check.previousMatchingItinerary.offsetTimes(24 * 3600 * 1000);
+        assertEquals(
+            "2020-06-10",
+            DateTimeUtils.getStringFromDate(
+                DateTimeUtils.makeOtpZonedDateTime(trip.journeyState.matchingItinerary.startTime).toLocalDate(),
+                DateTimeUtils.DEFAULT_DATE_FORMAT_PATTERN
+            )
+        );
+
+        trip.journeyState.lastCheckedEpochMillis = DateTimeUtils.nowAsZonedDateTime().minusMinutes(30).toInstant().toEpochMilli();
+
+        // Set target date to Wednesday
+        trip.journeyState.targetDate = "2020-06-10";
+
+        Persistence.monitoredTrips.create(trip);
+
+        // Run the checks. Test the new target date
+        check.run();
+
+        MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(trip.id);
+
+        assertEquals(
+            "2020-06-09",
+            updatedTrip.journeyState.targetDate
+        );
+        assertEquals(
+            "2020-06-09",
+            DateTimeUtils.getStringFromDate(
+                DateTimeUtils.makeOtpZonedDateTime(updatedTrip.journeyState.matchingItinerary.startTime).toLocalDate(),
+                DateTimeUtils.DEFAULT_DATE_FORMAT_PATTERN
             )
         );
     }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -378,7 +378,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         ShouldSkipTripTestCase weekendTripOnWeekdayTestCase = new ShouldSkipTripTestCase(
             "should return true for a weekend trip when current time is on a weekday",
             MONDAY_20200608_NOON,
-            false // FIXME: Was true. False means extra checks will be done for the same outcome.
+            true
         );
         weekendTripOnWeekdayTestCase.trip = weekendTrip;
         testCases.add(weekendTripOnWeekdayTestCase);
@@ -387,7 +387,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         testCases.add(new ShouldSkipTripTestCase(
             "should return true for weekday trip when current time is on a weekend",
             MONDAY_20200608_NOON.withDayOfMonth(6), // mock time: June 6, 2020 (Saturday)
-            false // FIXME: Was true. False means extra checks will be done for the same outcome.
+            true
         ));
 
         // - Return true if trip is starting today, but before lead time
@@ -663,8 +663,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         String currentTargetDate,
         String expectedTargetDate,
         TripStatus tripStatus,
-        boolean skipMondayTuesday,
-        boolean skipCheck
+        boolean skipMondayTuesday
     ) throws Exception {
         DateTimeUtils.useFixedClockAt(nowTime);
 
@@ -679,6 +678,10 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         OtpResponse mockPreviousWeekdayResponse = mockOtpPlanResponse();
         Itinerary mockPreviousItinerary = firstItinerary(mockPreviousWeekdayResponse);
         OtpTestUtils.setItineraryDay(mockPreviousItinerary, 9);
+        if (tripStatus == TRIP_ACTIVE) {
+            // If the trip is active, set the trip day to Monday when that case applies.
+            mockPreviousItinerary.offsetTimes(-24 * 3600000);
+        }
 
         // Make sure that the start time on the original trip was not changed inadvertently.
         assertEquals(originalStartTime, originalItinerary.startTime);
@@ -719,7 +722,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // Perform the skip check (this populates some internal states).
         // This trip should not be skipped if Monday and Tuesday are monitored because,
         // for those cases, the trip occurs within minutes of the mocked system time.
-        assertEquals(skipCheck, mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
+        assertEquals(skipMondayTuesday, mockCheckMonitoredTrip.shouldSkipMonitoredTripCheck());
 
         // Execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome.
         assertTrue(mockCheckMonitoredTrip.checkOtpAndUpdateTripStatus());
@@ -757,8 +760,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 "2020-06-08",
                 "2020-06-10",
                 TRIP_UPCOMING,
-                true,
-                false
+                true
             ),
             Arguments.of(
                 // Mock the current time to same day of itinerary, between itinerary start and end time.
@@ -767,8 +769,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 "2020-06-08",
                 "2020-06-08",
                 TRIP_ACTIVE,
-                true,
-                false // If the trip is active, the check should not be skipped.
+                true
             ),
             Arguments.of(
                 monday0830,
@@ -777,7 +778,6 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 "2020-06-08",
                 TRIP_UPCOMING,
                 // This trip should not be skipped because it occurs within minutes of the mocked system time.
-                false,
                 false
             )
         );


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Quick fix for the situation where:
- the trip status is stuck in "ACTIVE" ("Trip is ongoing" on the web UI)
- a race condition causes the incorrect trip day to be temporarily shown to clients.
