### PR TITLE
fix(ConnectedDataManager): Fix job interval unit.

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/connecteddataplatform/ConnectedDataManager.java
+++ b/src/main/java/org/opentripplanner/middleware/connecteddataplatform/ConnectedDataManager.java
@@ -141,7 +141,7 @@ public class ConnectedDataManager implements RecurringJobScheduler {
             Scheduler.scheduleJob(
                 new TripHistoryUploadJob(),
                 initialDelayMillis,
-                CONNECTED_DATA_PLATFORM_TRIP_HISTORY_UPLOAD_JOB_FREQUENCY_IN_MINUTES,
+                CONNECTED_DATA_PLATFORM_TRIP_HISTORY_UPLOAD_JOB_FREQUENCY_IN_MINUTES * 60000L, // milliseconds
                 TimeUnit.MILLISECONDS);
         }
     }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Setting `CONNECTED_DATA_PLATFORM_TRIP_HISTORY_UPLOAD_JOB_FREQUENCY_IN_MINUTES` to 5 "minutes" is resulting in the trip upload job to run every 5 milliseconds!! This PR fixes that.
