### PR TITLE
Remove monitored trip duplicate (OTP1) fields

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -191,12 +191,10 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
             monitoredTrip.itinerary = preExisting.itinerary;
             monitoredTrip.journeyState = preExisting.journeyState;
             monitoredTrip.itineraryExistence = preExisting.itineraryExistence;
-            monitoredTrip.tripTime = preExisting.tripTime;
-            monitoredTrip.queryParams = preExisting.queryParams;
+            monitoredTrip.otp2QueryParams = preExisting.otp2QueryParams;
             monitoredTrip.userId = preExisting.userId;
             monitoredTrip.from = preExisting.from;
             monitoredTrip.to = preExisting.to;
-            monitoredTrip.arriveBy = preExisting.arriveBy;
 
             // TODO: Update itinerary existence record when updating a trip?
             //   (Currently, we let web requests change the monitored days regardless of existence.)

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -25,7 +25,6 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -55,24 +54,10 @@ public class MonitoredTrip extends Model {
     public String tripName;
 
     /**
-     * The time at which the trip takes place. This will be in the format HH:mm and is extracted (or provided
-     * separately) to the date and time within the query parameters. The reasoning is so that it doesn't have to be
-     * extracted every time the trip requires checking.
-     */
-    @JsonIgnore
-    public String tripTime;
-
-    /**
      * From and to locations for the stored trip.
      */
     public Place from;
     public Place to;
-
-    /**
-     * whether the trip is an arriveBy trip
-     */
-    @JsonIgnore
-    public boolean arriveBy;
 
     /**
      * The number of minutes prior to a trip taking place that the status should be checked.
@@ -130,12 +115,6 @@ public class MonitoredTrip extends Model {
      * CheckMonitoredTrip job.
      */
     public boolean snoozed = false;
-
-    /**
-     * Query params. Query parameters influencing trip.
-     */
-    // TODO: Remove
-    public String queryParams;
 
     /**
      * GraphQL query parameters for OTP.
@@ -215,7 +194,7 @@ public class MonitoredTrip extends Model {
     ) {
         // Get queries to execute by date.
         List<OtpRequest> queriesByDate = getItineraryExistenceQueries();
-        itineraryExistence = new ItineraryExistence(queriesByDate, itinerary, arriveBy, otpResponseProvider);
+        itineraryExistence = new ItineraryExistence(queriesByDate, itinerary, otp2QueryParams.arriveBy, otpResponseProvider);
         itineraryExistence.checkExistence(this);
         boolean itineraryExists = itineraryExistence.allMonitoredDaysAreValid(this);
         // If itinerary should be replaced, do so if all checked days are valid.
@@ -287,14 +266,11 @@ public class MonitoredTrip extends Model {
         from = itinerary.legs.get(0).from;
         to = itinerary.legs.get(lastLegIndex).to;
         this.otp2QueryParams = graphQLVariables;
-        this.arriveBy = graphQLVariables.arriveBy;
 
         // Ensure the itinerary we store does not contain any realtime info.
         clearRealtimeInfo();
 
-        // set the trip time by parsing the query params
-        tripTime = graphQLVariables.time;
-        if (tripTime == null) {
+        if (graphQLVariables.time == null) {
             throw new IllegalArgumentException("A monitored trip must have a time set in the query params!");
         }
     }
@@ -413,7 +389,7 @@ public class MonitoredTrip extends Model {
      * Returns the target hour of the day that the trip is either departing at or arriving by
      */
     public int tripTimeHour() {
-        return Integer.valueOf(tripTime.split(":")[0]);
+        return Integer.parseInt(otp2QueryParams.time.split(":")[0]);
     }
 
     /**
@@ -429,7 +405,7 @@ public class MonitoredTrip extends Model {
      * Returns the target minute of the hour that the trip is either departing at or arriving by
      */
     public int tripTimeMinute() {
-        return Integer.valueOf(tripTime.split(":")[1]);
+        return Integer.parseInt(otp2QueryParams.time.split(":")[1]);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -775,7 +775,7 @@ public class CheckMonitoredTrip implements Runnable {
 
         if (isPreviousTripOngoingAtLastCheck()) {
             matchingItinerary = previousMatchingItinerary;
-            targetZonedDateTime = DateTimeUtils.makeOtpZonedDateTime(previousJourneyState.targetDate, trip.tripTime);
+            targetZonedDateTime = DateTimeUtils.makeOtpZonedDateTime(previousJourneyState.targetDate, trip.otp2QueryParams.time);
 
             // Skip checking the trip the rest of the time that it is active if the trip was deemed not possible for the
             // next possible time during a previous query to find candidate itinerary matches.
@@ -982,7 +982,7 @@ public class CheckMonitoredTrip implements Runnable {
         if (
             previousMatchingItinerary == null &&
             trip.itinerary.endTime.before(DateTimeUtils.nowAsDate()) &&
-            ItineraryUtils.occursOnSameServiceDay(trip.itinerary, targetZonedDateTime, trip.arriveBy)
+            ItineraryUtils.occursOnSameServiceDay(trip.itinerary, targetZonedDateTime, trip.otp2QueryParams.arriveBy)
         ) {
             targetZonedDateTime = targetZonedDateTime.plusDays(1);
         }
@@ -1010,7 +1010,7 @@ public class CheckMonitoredTrip implements Runnable {
         ZonedDateTime scheduledTime = makeOtpZonedDateTime(
             targetZonedDateTime,
             Instant.ofEpochMilli(
-                trip.arriveBy
+                trip.otp2QueryParams.arriveBy
                     ? matchingItinerary.getScheduledEndTimeEpochMillis()
                     : matchingItinerary.getScheduledStartTimeEpochMillis()
             )
@@ -1024,7 +1024,7 @@ public class CheckMonitoredTrip implements Runnable {
      */
     private void applyDelayOffset() {
         ZonedDateTime scheduledTime = DateTimeUtils.makeOtpZonedDateTime(new Date(
-            trip.arriveBy
+            trip.otp2QueryParams.arriveBy
                 ? matchingItinerary.getScheduledEndTimeEpochMillis()
                 : matchingItinerary.getScheduledStartTimeEpochMillis()
         ));
@@ -1037,7 +1037,7 @@ public class CheckMonitoredTrip implements Runnable {
      */
     private void applyDelayOffset(ZonedDateTime scheduledTime) {
         long offsetMillis = scheduledTime.toInstant().toEpochMilli() -
-            (trip.arriveBy
+            (trip.otp2QueryParams.arriveBy
                 ? matchingItinerary.endTime.getTime()
                 : matchingItinerary.getScheduledStartTimeEpochMillis()
             );

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -56,9 +56,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -90,9 +90,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -123,9 +123,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/Job"
           schema:
+            $ref: "#/definitions/Job"
+          responseSchema:
             $ref: "#/definitions/Job"
   /api/admin/user:
     get:
@@ -155,9 +155,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -178,9 +178,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -220,9 +220,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -269,9 +269,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -309,9 +309,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -356,9 +356,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -402,9 +402,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -447,9 +447,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/TokenHolder"
           schema:
+            $ref: "#/definitions/TokenHolder"
+          responseSchema:
             $ref: "#/definitions/TokenHolder"
   /api/secure/application/fromtoken:
     get:
@@ -464,9 +464,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -498,9 +498,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -531,9 +531,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/Job"
           schema:
+            $ref: "#/definitions/Job"
+          responseSchema:
             $ref: "#/definitions/Job"
   /api/secure/application:
     get:
@@ -563,9 +563,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -586,9 +586,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -628,9 +628,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -677,9 +677,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -717,9 +717,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -764,11 +764,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/CDPFile"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/CDPFile"
@@ -789,11 +789,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/URL"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/URL"
@@ -810,9 +810,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -844,9 +844,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -877,9 +877,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/Job"
           schema:
+            $ref: "#/definitions/Job"
+          responseSchema:
             $ref: "#/definitions/Job"
   /api/secure/cdp:
     get:
@@ -909,9 +909,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -932,9 +932,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -974,9 +974,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1023,9 +1023,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1063,9 +1063,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1110,11 +1110,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/BugsnagEvent"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/BugsnagEvent"
@@ -1151,11 +1151,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/ApiUsageResult"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/ApiUsageResult"
@@ -1187,9 +1187,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1210,9 +1210,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredComponent"
           schema:
+            $ref: "#/definitions/MonitoredComponent"
+          responseSchema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1252,9 +1252,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredComponent"
           schema:
+            $ref: "#/definitions/MonitoredComponent"
+          responseSchema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1301,9 +1301,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredComponent"
           schema:
+            $ref: "#/definitions/MonitoredComponent"
+          responseSchema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1342,9 +1342,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredComponent"
           schema:
+            $ref: "#/definitions/MonitoredComponent"
+          responseSchema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1385,9 +1385,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ItineraryExistence"
           schema:
+            $ref: "#/definitions/ItineraryExistence"
+          responseSchema:
             $ref: "#/definitions/ItineraryExistence"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1437,9 +1437,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1460,9 +1460,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredTrip"
           schema:
+            $ref: "#/definitions/MonitoredTrip"
+          responseSchema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1502,9 +1502,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredTrip"
           schema:
+            $ref: "#/definitions/MonitoredTrip"
+          responseSchema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1551,9 +1551,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredTrip"
           schema:
+            $ref: "#/definitions/MonitoredTrip"
+          responseSchema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1592,9 +1592,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredTrip"
           schema:
+            $ref: "#/definitions/MonitoredTrip"
+          responseSchema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1662,9 +1662,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1697,9 +1697,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MobilityProfileLite"
           schema:
+            $ref: "#/definitions/MobilityProfileLite"
+          responseSchema:
             $ref: "#/definitions/MobilityProfileLite"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1740,9 +1740,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/VerificationResult"
           schema:
+            $ref: "#/definitions/VerificationResult"
+          responseSchema:
             $ref: "#/definitions/VerificationResult"
   /api/secure/user/{id}/verify_sms/{code}:
     post:
@@ -1763,9 +1763,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/VerificationResult"
           schema:
+            $ref: "#/definitions/VerificationResult"
+          responseSchema:
             $ref: "#/definitions/VerificationResult"
   /api/secure/user/fromtoken:
     get:
@@ -1780,9 +1780,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1814,9 +1814,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1847,9 +1847,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/Job"
           schema:
+            $ref: "#/definitions/Job"
+          responseSchema:
             $ref: "#/definitions/Job"
   /api/secure/user:
     get:
@@ -1879,9 +1879,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1902,9 +1902,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1944,9 +1944,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1993,9 +1993,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -2033,9 +2033,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -2074,9 +2074,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/TrackingResponse"
           schema:
+            $ref: "#/definitions/TrackingResponse"
+          responseSchema:
             $ref: "#/definitions/TrackingResponse"
   /api/secure/monitoredtrip/updatetracking:
     post:
@@ -2095,9 +2095,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/TrackingResponse"
           schema:
+            $ref: "#/definitions/TrackingResponse"
+          responseSchema:
             $ref: "#/definitions/TrackingResponse"
   /api/secure/monitoredtrip/track:
     post:
@@ -2116,9 +2116,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/TrackingResponse"
           schema:
+            $ref: "#/definitions/TrackingResponse"
+          responseSchema:
             $ref: "#/definitions/TrackingResponse"
   /api/secure/monitoredtrip/endtracking:
     post:
@@ -2137,9 +2137,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/EndTrackingResponse"
           schema:
+            $ref: "#/definitions/EndTrackingResponse"
+          responseSchema:
             $ref: "#/definitions/EndTrackingResponse"
   /api/secure/monitoredtrip/forciblyendtracking:
     post:
@@ -2158,9 +2158,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/EndTrackingResponse"
           schema:
+            $ref: "#/definitions/EndTrackingResponse"
+          responseSchema:
             $ref: "#/definitions/EndTrackingResponse"
   /api/secure/monitoredtrip/reroute:
     post:
@@ -2180,9 +2180,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/RerouteResponse"
           schema:
+            $ref: "#/definitions/RerouteResponse"
+          responseSchema:
             $ref: "#/definitions/RerouteResponse"
   /api/secure/triprequests:
     get:
@@ -2228,9 +2228,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/TripRequest"
           schema:
+            $ref: "#/definitions/TripRequest"
+          responseSchema:
             $ref: "#/definitions/TripRequest"
   /api/trip-survey/open:
     get:

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -11,7 +11,7 @@ info:
   license:
     name: "MIT License"
     url: "https://opensource.org/licenses/MIT"
-host: "fe80:0:0:0:f74:9fe8:6f78:2b67%wlan0:4567"
+host: "localhost:4567"
 basePath: "/"
 tags:
 - name: "api/admin/user"

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -11,7 +11,7 @@ info:
   license:
     name: "MIT License"
     url: "https://opensource.org/licenses/MIT"
-host: "localhost:4567"
+host: "fe80:0:0:0:f74:9fe8:6f78:2b67%wlan0:4567"
 basePath: "/"
 tags:
 - name: "api/admin/user"
@@ -56,9 +56,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -90,9 +90,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -123,9 +123,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/Job"
           schema:
+            $ref: "#/definitions/Job"
+          responseSchema:
             $ref: "#/definitions/Job"
   /api/admin/user:
     get:
@@ -155,9 +155,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -178,9 +178,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -220,9 +220,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -269,9 +269,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -309,9 +309,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/AdminUser"
           schema:
+            $ref: "#/definitions/AdminUser"
+          responseSchema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -356,9 +356,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -402,9 +402,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -447,9 +447,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/TokenHolder"
           schema:
+            $ref: "#/definitions/TokenHolder"
+          responseSchema:
             $ref: "#/definitions/TokenHolder"
   /api/secure/application/fromtoken:
     get:
@@ -464,9 +464,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -498,9 +498,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -531,9 +531,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/Job"
           schema:
+            $ref: "#/definitions/Job"
+          responseSchema:
             $ref: "#/definitions/Job"
   /api/secure/application:
     get:
@@ -563,9 +563,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -586,9 +586,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -628,9 +628,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -677,9 +677,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -717,9 +717,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ApiUser"
           schema:
+            $ref: "#/definitions/ApiUser"
+          responseSchema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -764,11 +764,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/CDPFile"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/CDPFile"
@@ -789,11 +789,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/URL"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/URL"
@@ -810,9 +810,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -844,9 +844,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -877,9 +877,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/Job"
           schema:
+            $ref: "#/definitions/Job"
+          responseSchema:
             $ref: "#/definitions/Job"
   /api/secure/cdp:
     get:
@@ -909,9 +909,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -932,9 +932,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -974,9 +974,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1023,9 +1023,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1063,9 +1063,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/CDPUser"
           schema:
+            $ref: "#/definitions/CDPUser"
+          responseSchema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1110,11 +1110,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/BugsnagEvent"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/BugsnagEvent"
@@ -1151,11 +1151,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/ApiUsageResult"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/ApiUsageResult"
@@ -1187,9 +1187,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1210,9 +1210,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredComponent"
           schema:
+            $ref: "#/definitions/MonitoredComponent"
+          responseSchema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1252,9 +1252,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredComponent"
           schema:
+            $ref: "#/definitions/MonitoredComponent"
+          responseSchema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1301,9 +1301,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredComponent"
           schema:
+            $ref: "#/definitions/MonitoredComponent"
+          responseSchema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1342,9 +1342,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredComponent"
           schema:
+            $ref: "#/definitions/MonitoredComponent"
+          responseSchema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1385,9 +1385,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/ItineraryExistence"
           schema:
+            $ref: "#/definitions/ItineraryExistence"
+          responseSchema:
             $ref: "#/definitions/ItineraryExistence"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1437,9 +1437,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1460,9 +1460,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredTrip"
           schema:
+            $ref: "#/definitions/MonitoredTrip"
+          responseSchema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1502,9 +1502,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredTrip"
           schema:
+            $ref: "#/definitions/MonitoredTrip"
+          responseSchema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1551,9 +1551,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredTrip"
           schema:
+            $ref: "#/definitions/MonitoredTrip"
+          responseSchema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1592,9 +1592,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MonitoredTrip"
           schema:
+            $ref: "#/definitions/MonitoredTrip"
+          responseSchema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1662,9 +1662,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1697,9 +1697,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/MobilityProfileLite"
           schema:
+            $ref: "#/definitions/MobilityProfileLite"
+          responseSchema:
             $ref: "#/definitions/MobilityProfileLite"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1740,9 +1740,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/VerificationResult"
           schema:
+            $ref: "#/definitions/VerificationResult"
+          responseSchema:
             $ref: "#/definitions/VerificationResult"
   /api/secure/user/{id}/verify_sms/{code}:
     post:
@@ -1763,9 +1763,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/VerificationResult"
           schema:
+            $ref: "#/definitions/VerificationResult"
+          responseSchema:
             $ref: "#/definitions/VerificationResult"
   /api/secure/user/fromtoken:
     get:
@@ -1780,9 +1780,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1814,9 +1814,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1847,9 +1847,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/Job"
           schema:
+            $ref: "#/definitions/Job"
+          responseSchema:
             $ref: "#/definitions/Job"
   /api/secure/user:
     get:
@@ -1879,9 +1879,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/ResponseList"
           schema:
+            $ref: "#/definitions/ResponseList"
+          responseSchema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1902,9 +1902,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1944,9 +1944,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1993,9 +1993,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -2033,9 +2033,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          responseSchema:
-            $ref: "#/definitions/OtpUser"
           schema:
+            $ref: "#/definitions/OtpUser"
+          responseSchema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -2074,9 +2074,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/TrackingResponse"
           schema:
+            $ref: "#/definitions/TrackingResponse"
+          responseSchema:
             $ref: "#/definitions/TrackingResponse"
   /api/secure/monitoredtrip/updatetracking:
     post:
@@ -2095,9 +2095,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/TrackingResponse"
           schema:
+            $ref: "#/definitions/TrackingResponse"
+          responseSchema:
             $ref: "#/definitions/TrackingResponse"
   /api/secure/monitoredtrip/track:
     post:
@@ -2116,9 +2116,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/TrackingResponse"
           schema:
+            $ref: "#/definitions/TrackingResponse"
+          responseSchema:
             $ref: "#/definitions/TrackingResponse"
   /api/secure/monitoredtrip/endtracking:
     post:
@@ -2137,9 +2137,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/EndTrackingResponse"
           schema:
+            $ref: "#/definitions/EndTrackingResponse"
+          responseSchema:
             $ref: "#/definitions/EndTrackingResponse"
   /api/secure/monitoredtrip/forciblyendtracking:
     post:
@@ -2158,9 +2158,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/EndTrackingResponse"
           schema:
+            $ref: "#/definitions/EndTrackingResponse"
+          responseSchema:
             $ref: "#/definitions/EndTrackingResponse"
   /api/secure/monitoredtrip/reroute:
     post:
@@ -2180,9 +2180,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/RerouteResponse"
           schema:
+            $ref: "#/definitions/RerouteResponse"
+          responseSchema:
             $ref: "#/definitions/RerouteResponse"
   /api/secure/triprequests:
     get:
@@ -2228,9 +2228,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          responseSchema:
-            $ref: "#/definitions/TripRequest"
           schema:
+            $ref: "#/definitions/TripRequest"
+          responseSchema:
             $ref: "#/definitions/TripRequest"
   /api/trip-survey/open:
     get:
@@ -2712,14 +2712,10 @@ definitions:
         type: "string"
       tripName:
         type: "string"
-      tripTime:
-        type: "string"
       from:
         $ref: "#/definitions/Place"
       to:
         $ref: "#/definitions/Place"
-      arriveBy:
-        type: "boolean"
       leadTimeInMinutes:
         type: "integer"
         format: "int32"
@@ -2743,8 +2739,6 @@ definitions:
         type: "boolean"
       snoozed:
         type: "boolean"
-      queryParams:
-        type: "string"
       otp2QueryParams:
         $ref: "#/definitions/OtpGraphQLVariables"
       itinerary:

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -56,9 +56,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -90,9 +90,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -123,9 +123,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
           responseSchema:
+            $ref: "#/definitions/Job"
+          schema:
             $ref: "#/definitions/Job"
   /api/admin/user:
     get:
@@ -155,9 +155,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -178,9 +178,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -220,9 +220,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -269,9 +269,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -309,9 +309,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/AdminUser"
           responseSchema:
+            $ref: "#/definitions/AdminUser"
+          schema:
             $ref: "#/definitions/AdminUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -356,9 +356,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -402,9 +402,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -447,9 +447,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/TokenHolder"
           responseSchema:
+            $ref: "#/definitions/TokenHolder"
+          schema:
             $ref: "#/definitions/TokenHolder"
   /api/secure/application/fromtoken:
     get:
@@ -464,9 +464,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -498,9 +498,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -531,9 +531,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
           responseSchema:
+            $ref: "#/definitions/Job"
+          schema:
             $ref: "#/definitions/Job"
   /api/secure/application:
     get:
@@ -563,9 +563,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -586,9 +586,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -628,9 +628,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -677,9 +677,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -717,9 +717,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ApiUser"
           responseSchema:
+            $ref: "#/definitions/ApiUser"
+          schema:
             $ref: "#/definitions/ApiUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -764,11 +764,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/CDPFile"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/CDPFile"
@@ -789,11 +789,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/URL"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/URL"
@@ -810,9 +810,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -844,9 +844,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -877,9 +877,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
           responseSchema:
+            $ref: "#/definitions/Job"
+          schema:
             $ref: "#/definitions/Job"
   /api/secure/cdp:
     get:
@@ -909,9 +909,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -932,9 +932,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -974,9 +974,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1023,9 +1023,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1063,9 +1063,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/CDPUser"
           responseSchema:
+            $ref: "#/definitions/CDPUser"
+          schema:
             $ref: "#/definitions/CDPUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1110,11 +1110,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/BugsnagEvent"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/BugsnagEvent"
@@ -1151,11 +1151,11 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
+          responseSchema:
             type: "array"
             items:
               $ref: "#/definitions/ApiUsageResult"
-          responseSchema:
+          schema:
             type: "array"
             items:
               $ref: "#/definitions/ApiUsageResult"
@@ -1187,9 +1187,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1210,9 +1210,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredComponent"
           responseSchema:
+            $ref: "#/definitions/MonitoredComponent"
+          schema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1252,9 +1252,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredComponent"
           responseSchema:
+            $ref: "#/definitions/MonitoredComponent"
+          schema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1301,9 +1301,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredComponent"
           responseSchema:
+            $ref: "#/definitions/MonitoredComponent"
+          schema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1342,9 +1342,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredComponent"
           responseSchema:
+            $ref: "#/definitions/MonitoredComponent"
+          schema:
             $ref: "#/definitions/MonitoredComponent"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1385,9 +1385,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/ItineraryExistence"
           responseSchema:
+            $ref: "#/definitions/ItineraryExistence"
+          schema:
             $ref: "#/definitions/ItineraryExistence"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1437,9 +1437,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1460,9 +1460,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
           responseSchema:
+            $ref: "#/definitions/MonitoredTrip"
+          schema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1502,9 +1502,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
           responseSchema:
+            $ref: "#/definitions/MonitoredTrip"
+          schema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1551,9 +1551,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
           responseSchema:
+            $ref: "#/definitions/MonitoredTrip"
+          schema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1592,9 +1592,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MonitoredTrip"
           responseSchema:
+            $ref: "#/definitions/MonitoredTrip"
+          schema:
             $ref: "#/definitions/MonitoredTrip"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1662,9 +1662,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1697,9 +1697,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/MobilityProfileLite"
           responseSchema:
+            $ref: "#/definitions/MobilityProfileLite"
+          schema:
             $ref: "#/definitions/MobilityProfileLite"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1740,9 +1740,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/VerificationResult"
           responseSchema:
+            $ref: "#/definitions/VerificationResult"
+          schema:
             $ref: "#/definitions/VerificationResult"
   /api/secure/user/{id}/verify_sms/{code}:
     post:
@@ -1763,9 +1763,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/VerificationResult"
           responseSchema:
+            $ref: "#/definitions/VerificationResult"
+          schema:
             $ref: "#/definitions/VerificationResult"
   /api/secure/user/fromtoken:
     get:
@@ -1780,9 +1780,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1814,9 +1814,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1847,9 +1847,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/Job"
           responseSchema:
+            $ref: "#/definitions/Job"
+          schema:
             $ref: "#/definitions/Job"
   /api/secure/user:
     get:
@@ -1879,9 +1879,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/ResponseList"
           responseSchema:
+            $ref: "#/definitions/ResponseList"
+          schema:
             $ref: "#/definitions/ResponseList"
     post:
       tags:
@@ -1902,9 +1902,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1944,9 +1944,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -1993,9 +1993,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -2033,9 +2033,9 @@ paths:
         "200":
           description: "Successful operation"
           examples: {}
-          schema:
-            $ref: "#/definitions/OtpUser"
           responseSchema:
+            $ref: "#/definitions/OtpUser"
+          schema:
             $ref: "#/definitions/OtpUser"
         "400":
           description: "The request was not formed properly (e.g., some required parameters\
@@ -2074,9 +2074,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/TrackingResponse"
           responseSchema:
+            $ref: "#/definitions/TrackingResponse"
+          schema:
             $ref: "#/definitions/TrackingResponse"
   /api/secure/monitoredtrip/updatetracking:
     post:
@@ -2095,9 +2095,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/TrackingResponse"
           responseSchema:
+            $ref: "#/definitions/TrackingResponse"
+          schema:
             $ref: "#/definitions/TrackingResponse"
   /api/secure/monitoredtrip/track:
     post:
@@ -2116,9 +2116,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/TrackingResponse"
           responseSchema:
+            $ref: "#/definitions/TrackingResponse"
+          schema:
             $ref: "#/definitions/TrackingResponse"
   /api/secure/monitoredtrip/endtracking:
     post:
@@ -2137,9 +2137,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/EndTrackingResponse"
           responseSchema:
+            $ref: "#/definitions/EndTrackingResponse"
+          schema:
             $ref: "#/definitions/EndTrackingResponse"
   /api/secure/monitoredtrip/forciblyendtracking:
     post:
@@ -2158,9 +2158,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/EndTrackingResponse"
           responseSchema:
+            $ref: "#/definitions/EndTrackingResponse"
+          schema:
             $ref: "#/definitions/EndTrackingResponse"
   /api/secure/monitoredtrip/reroute:
     post:
@@ -2180,9 +2180,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/RerouteResponse"
           responseSchema:
+            $ref: "#/definitions/RerouteResponse"
+          schema:
             $ref: "#/definitions/RerouteResponse"
   /api/secure/triprequests:
     get:
@@ -2228,9 +2228,9 @@ paths:
       responses:
         "200":
           description: "successful operation"
-          schema:
-            $ref: "#/definitions/TripRequest"
           responseSchema:
+            $ref: "#/definitions/TripRequest"
+          schema:
             $ref: "#/definitions/TripRequest"
   /api/trip-survey/open:
     get:

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.auth.Auth0Connection.restoreDefaultAuthDisabled;
@@ -66,8 +65,6 @@ public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     private static OtpUser multiOtpUser;
     private static final String MONITORED_TRIP_PATH = "api/secure/monitoredtrip";
 
-    private static final String UI_QUERY_PARAMS
-        = "?fromPlace=fromplace%3A%3A28.556631%2C-81.411781&toPlace=toplace%3A%3A28.545925%2C-81.348609&date=2020-11-13&time=14%3A21&arriveBy=false&mode=WALK%2CBUS%2CRAIL&numItineraries=3";
     private static final String DUMMY_STRING = "ABCDxyz";
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -20,6 +20,7 @@ import org.opentripplanner.middleware.otp.response.Place;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.testutils.ApiTestUtils;
 import org.opentripplanner.middleware.testutils.OtpMiddlewareTestEnvironment;
+import org.opentripplanner.middleware.testutils.OtpTestUtils;
 import org.opentripplanner.middleware.testutils.PersistenceTestUtils;
 import org.opentripplanner.middleware.utils.HttpResponseValues;
 import org.opentripplanner.middleware.utils.JsonUtils;
@@ -138,10 +139,6 @@ public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         // Expect only 1 trip for solo Otp user.
         assertEquals(1, soloTrips.data.size());
 
-        // Certain fields such as tripTime should be null when obtained from parsing JSON responses
-        // because of the @JsonIgnore annotation.
-        assertNull(soloTrips.data.get(0).tripTime);
-
         // Get trips for multi Otp user/admin user.
         ResponseList<MonitoredTrip> multiTrips = getMonitoredTripsForUser(MONITORED_TRIP_PATH, multiOtpUser);
 
@@ -171,16 +168,13 @@ public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         assertNotNull(originalTrip.itinerary);
         assertNotNull(originalTrip.itineraryExistence);
         // Can't really assert journeyState because itinerary checks will not be run for these tests.
-        assertNotEquals(DUMMY_STRING, originalTrip.tripTime);
-        assertNotEquals(DUMMY_STRING, originalTrip.queryParams);
         assertNotEquals(DUMMY_STRING, originalTrip.userId);
         assertNotNull(originalTrip.from);
         assertNotNull(originalTrip.to);
 
         MonitoredTrip modifiedTrip = new MonitoredTrip();
         modifiedTrip.id = originalTrip.id;
-        modifiedTrip.tripTime = DUMMY_STRING;
-        modifiedTrip.queryParams = DUMMY_STRING;
+        modifiedTrip.otp2QueryParams = OtpTestUtils.getSampleQueryParams();
         modifiedTrip.userId = DUMMY_STRING;
 
         mockAuthenticatedRequest(MONITORED_TRIP_PATH,
@@ -191,8 +185,7 @@ public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
 
         MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(originalTrip.id);
         assertEquals(updatedTrip.itinerary.startTime, originalTrip.itinerary.startTime);
-        assertEquals(updatedTrip.tripTime, originalTrip.tripTime);
-        assertEquals(updatedTrip.queryParams, originalTrip.queryParams);
+        assertEquals(updatedTrip.otp2QueryParams.time, originalTrip.otp2QueryParams.time);
         assertEquals(updatedTrip.userId, originalTrip.userId);
         assertEquals(updatedTrip.from.name, originalTrip.from.name);
         assertEquals(updatedTrip.to.name, originalTrip.to.name);
@@ -213,8 +206,7 @@ public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         MonitoredTrip monitoredTrip = new MonitoredTrip();
         monitoredTrip.updateAllDaysOfWeek(true);
         monitoredTrip.userId = otpUser.id;
-        monitoredTrip.tripTime = "08:35";
-        monitoredTrip.queryParams = UI_QUERY_PARAMS;
+        monitoredTrip.otp2QueryParams = OtpTestUtils.getSampleQueryParams();
         monitoredTrip.itinerary = new Itinerary();
         monitoredTrip.itinerary.startTime = new Date();
         monitoredTrip.itineraryExistence = new ItineraryExistence();

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -146,7 +146,9 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         trip.userId = soloOtpUser.id;
         trip.itinerary = itin;
         // Original itinerary time should be populated.
-        trip.tripTime = DateTimeUtils.convertToLocalDateTime(itin.startTime).toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm"));
+        OtpGraphQLVariables params = new OtpGraphQLVariables();
+        params.time = DateTimeUtils.convertToLocalDateTime(itin.startTime).toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm"));
+        trip.otp2QueryParams = params;
         trip.journeyState = new JourneyState();
         trip.journeyState.matchingItinerary = itin;
         // Original target date should be populated but does not really matter.
@@ -633,7 +635,10 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         // Confirm traveler is no longer 'deviated'.
         assertNotEquals(TripStatus.DEVIATED.name(), updateTrackingResponse.tripStatus);
 
-        rerouteMonitoredTrip.tripTime = "12:31";
+        OtpGraphQLVariables params = new OtpGraphQLVariables();
+        params.time = "12:31";
+
+        rerouteMonitoredTrip.otp2QueryParams = params;
         Itinerary beforeCheck = rerouteMonitoredTrip.journeyState.matchingItinerary;
         CheckMonitoredTrip checkMonitoredTrip = new CheckMonitoredTrip(rerouteMonitoredTrip);
         checkMonitoredTrip.run();

--- a/src/test/java/org/opentripplanner/middleware/models/TripMonitorNotificationTest.java
+++ b/src/test/java/org/opentripplanner/middleware/models/TripMonitorNotificationTest.java
@@ -59,9 +59,6 @@ class TripMonitorNotificationTest {
         MonitoredTrip trip = new MonitoredTrip();
         trip.tripName = "Sample Trip";
 
-        // tripTime is for the OTP query, is included for reference only, and should not be used for notifications.
-        trip.tripTime = "13:31";
-
         // Set a start time for the itinerary, in the ambient/default OTP zone.
         ZonedDateTime startTime = ZonedDateTime.of(2023, 2, 12, 17, 44, 0, 0, DateTimeUtils.getOtpZoneId());
         Instant startInstant = startTime.toInstant();

--- a/src/test/java/org/opentripplanner/middleware/testutils/PersistenceTestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/testutils/PersistenceTestUtils.java
@@ -196,11 +196,10 @@ public class PersistenceTestUtils {
         MonitoredTrip monitoredTrip = new MonitoredTrip();
         monitoredTrip.userId = userId;
         monitoredTrip.tripName = "Commute to work";
-        monitoredTrip.tripTime = "07:30";
         monitoredTrip.leadTimeInMinutes = 30;
         monitoredTrip.updateWeekdays(true);
         monitoredTrip.excludeFederalHolidays = true;
-        monitoredTrip.queryParams = "fromPlace=28.54894%2C%20-81.38971%3A%3A28.548944048426772%2C-81.38970606029034&toPlace=28.53989%2C%20-81.37728%3A%3A28.539893820446867%2C-81.37727737426759&date=2020-05-05&time=12%3A04&arriveBy=false&mode=WALK%2CBUS%2CRAIL&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=true&companies=";
+        monitoredTrip.otp2QueryParams = OtpTestUtils.getSampleQueryParams();
 
         monitoredTrip.itinerary = createItinerary();
 
@@ -218,8 +217,6 @@ public class PersistenceTestUtils {
         monitoredTrip.userId = userId;
         monitoredTrip.tripName = "test trip";
         monitoredTrip.leadTimeInMinutes = 240;
-        // set trip time since otpDispatcherResponse doesn't have full query params in URI
-        monitoredTrip.tripTime = "08:35";
         monitoredTrip.updateWeekdays(true);
         monitoredTrip.itineraryExistence = new ItineraryExistence();
         if (journeyState != null) monitoredTrip.journeyState = journeyState;

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.middleware.models.ItineraryExistence;
 import org.opentripplanner.middleware.models.MonitoredTrip;
+import org.opentripplanner.middleware.otp.OtpGraphQLVariables;
 import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.tripmonitor.TripStatus;
 import org.opentripplanner.middleware.utils.DateTimeUtils;
@@ -119,9 +120,12 @@ public class CheckMonitoredTripBasicTest {
         itinerary.startTime = start;
         itinerary.endTime = Date.from(now.plusSeconds(endOffsetSecs));
 
+        OtpGraphQLVariables params = new OtpGraphQLVariables();
+        params.time = DateTimeUtils.makeOtpZonedDateTime(start).format(DateTimeFormatter.ISO_LOCAL_TIME);
+
         MonitoredTrip trip = new MonitoredTrip();
         trip.itinerary = itinerary;
-        trip.tripTime = DateTimeUtils.makeOtpZonedDateTime(start).format(DateTimeFormatter.ISO_LOCAL_TIME);
+        trip.otp2QueryParams = params;
         trip.leadTimeInMinutes = 30;
         return trip;
     }
@@ -133,10 +137,13 @@ public class CheckMonitoredTripBasicTest {
         // 10:25 am on some specified day in April 2025.
         ZonedDateTime fromDateTime = ZonedDateTime.of(2025, 4, fromDay, 10, 25, 0, 0, zoneId);
 
+        OtpGraphQLVariables params = new OtpGraphQLVariables();
+        params.time = "09:00";
+
         MonitoredTrip trip = makeMonitoredTripFromNow(300, 600);
         // Set the itinerary start time to 09:00 am, before the 'from' time above, on a different day (e.g. fromDay + 1).
         Instant itineraryStartInstant = fromDateTime.plusDays(1).withHour(9).withMinute(0).toInstant();
-        trip.tripTime = "09:00";
+        trip.otp2QueryParams = params;
         trip.itinerary.startTime = Date.from(itineraryStartInstant);
         trip.itinerary.endTime = Date.from(itineraryStartInstant.plusSeconds(300));
         trip.updateAllDaysOfWeek(false);
@@ -144,7 +151,7 @@ public class CheckMonitoredTripBasicTest {
 
         LocalDate expectedDate = fromDateTime.withDayOfMonth(expectedDay).toLocalDate();
         assertEquals(
-            ZonedDateTime.of(expectedDate, LocalTime.parse(trip.tripTime, DateTimeFormatter.ISO_LOCAL_TIME), zoneId),
+            ZonedDateTime.of(expectedDate, LocalTime.parse(trip.otp2QueryParams.time, DateTimeFormatter.ISO_LOCAL_TIME), zoneId),
             CheckMonitoredTrip.findEarliestTargetDate(trip, fromDateTime),
             message
         );

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -14,6 +14,7 @@ import org.opentripplanner.middleware.models.ItineraryExistence;
 import org.opentripplanner.middleware.models.MobilityProfileLite;
 import org.opentripplanner.middleware.models.RelatedUser;
 import org.opentripplanner.middleware.models.TrackedJourney;
+import org.opentripplanner.middleware.otp.OtpGraphQLVariables;
 import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.testutils.ApiTestUtils;
 import org.opentripplanner.middleware.testutils.OtpMiddlewareTestEnvironment;
@@ -159,13 +160,16 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // TODO refactor with above test.
         // Save an itinerary in the future, and run an itinerary check on it at at time before that itinerary start.
 
+        OtpGraphQLVariables params = new OtpGraphQLVariables();
+        params.time = "08:35";
+
         MonitoredTrip monitoredTrip = PersistenceTestUtils.createMonitoredTrip(
             user.id,
             OtpTestUtils.OTP2_DISPATCHER_PLAN_RESPONSE.clone(),
             false,
             null
         );
-        monitoredTrip.tripTime = "08:35";
+        monitoredTrip.otp2QueryParams = params;
         monitoredTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
         monitoredTrip.itineraryExistence.tuesday = new ItineraryExistence.ItineraryExistenceResult();
 
@@ -1243,9 +1247,13 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 .withMinute(30)
                 .withZoneSameInstant(DateTimeUtils.getOtpZoneId())
         );
+
+        OtpGraphQLVariables params = new OtpGraphQLVariables();
+        params.time = "17:30";
+
         monitoredTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
         monitoredTrip.itineraryExistence.tuesday = new ItineraryExistence.ItineraryExistenceResult();
-        monitoredTrip.tripTime = "17:30";
+        monitoredTrip.otp2QueryParams = params;
         monitoredTrip.leadTimeInMinutes = 30;
         Persistence.monitoredTrips.create(monitoredTrip);
         LOG.info("Created trip {}", monitoredTrip.id);

--- a/src/test/java/org/opentripplanner/middleware/utils/ItineraryUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/ItineraryUtilsTest.java
@@ -312,12 +312,10 @@ public class ItineraryUtilsTest extends OtpMiddlewareTestEnvironment {
 
         MonitoredTrip trip = new MonitoredTrip();
         trip.id = "Test trip";
-        trip.queryParams = BASE_QUERY;
         trip.otp2QueryParams = new OtpGraphQLVariables();
         trip.otp2QueryParams.date = QUERY_DATE;
         trip.otp2QueryParams.mobilityProfile = "mobility-profile";
         trip.otp2QueryParams.time = QUERY_TIME;
-        trip.tripTime = QUERY_TIME;
 
         trip.from = targetPlace;
         trip.to = dummyPlace;


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [x] The description lists all relevant PRs included in this release _(remove this if not merging to master)_

### Description

Remove OTP1 fields that have been superceded by OTP2 (OtpGraphQLVariables) fields.

Note that queryParams has been removed! It is being used by the web UI as a shortcut to re-plan a trip, but the UI should be refactored too.