### PR TITLE
Fix trip reminder conditions

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -200,15 +200,21 @@ public class CheckMonitoredTrip implements Runnable {
      * occurs within the monitoring lead time.
      */
     private void addInitialReminderIfNeeded() {
-        boolean isFirstTimeCheckWithinLeadMonitoringTime = isFirstTimeCheckWithinLeadMonitoringTime();
-        boolean userWantsInitialReminder = !trip.snoozed && trip.notifyAtLeadingInterval;
-
-        if (trip.isActive && isFirstTimeCheckWithinLeadMonitoringTime && userWantsInitialReminder) {
+        if (shouldSendInitialReminder()) {
             initialReminderNotification = TripMonitorNotification.createInitialReminderNotification(
                 trip,
                 getOtpUserLocale()
             );
         }
+    }
+
+    /**
+     * Whether an initial trip reminder should be sent.
+     */
+    public boolean shouldSendInitialReminder() {
+        boolean isFirstTimeCheckWithinLeadMonitoringTime = isFirstTimeCheckWithinLeadMonitoringTime();
+        boolean userWantsInitialReminder = !trip.snoozed && trip.notifyAtLeadingInterval;
+        return trip.isActive && isFirstTimeCheckWithinLeadMonitoringTime && userWantsInitialReminder;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -410,6 +410,8 @@ public class CheckMonitoredTrip implements Runnable {
                 trip.snoozed = true;
                 trip.attemptsToGetMatchingItinerary = 0;
                 LOG.info("Trip for today was not found after the allowed attempts. Snoozing for today.");
+                // Delete previous such notifications to ensure this one gets sent.
+                previousJourneyState.lastNotifications.removeIf(n -> n.type == NotificationType.ITINERARY_NOT_FOUND);
             }
 
             updateMonitoredTrip();
@@ -626,7 +628,7 @@ public class CheckMonitoredTrip implements Runnable {
         }
         // If the same notifications were just sent, there is no need to send the same notification.
         // TODO: Should there be some time threshold check here based on lastNotificationTime?
-        if (previousJourneyState.lastNotifications.containsAll(notifications) && !hasInitialReminder) {
+        if (thereAreNoNewNotifications() && !hasInitialReminder) {
             LOG.info("Last notifications match current ones. Skipping notify.");
             return;
         }
@@ -669,6 +671,13 @@ public class CheckMonitoredTrip implements Runnable {
         if (successEmail || successPush || successSms || IS_TEST) {
             notificationTimestampMillis = DateTimeUtils.currentTimeMillis();
         }
+    }
+
+    /**
+     * Determines whether pending notifications are the same as notifications previously sent.
+     */
+    public boolean thereAreNoNewNotifications() {
+        return previousJourneyState.lastNotifications.containsAll(notifications);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -212,9 +212,13 @@ public class CheckMonitoredTrip implements Runnable {
      * Whether an initial trip reminder should be sent.
      */
     public boolean shouldSendInitialReminder() {
-        boolean isFirstTimeCheckWithinLeadMonitoringTime = isFirstTimeCheckWithinLeadMonitoringTime();
-        boolean userWantsInitialReminder = !trip.snoozed && trip.notifyAtLeadingInterval;
-        return trip.isActive && isFirstTimeCheckWithinLeadMonitoringTime && userWantsInitialReminder;
+        TripStatus tripStatus = trip.journeyState.tripStatus;
+        return trip.isActive &&
+            !trip.snoozed &&
+            trip.notifyAtLeadingInterval &&
+            (tripStatus == TripStatus.TRIP_UPCOMING || tripStatus == TripStatus.TRIP_ACTIVE) &&
+            DateTimeUtils.convertToLocalDateTime(matchingItinerary.startTime).toLocalDate().equals(DateTimeUtils.nowAsLocalDate()) &&
+            isFirstTimeCheckWithinLeadMonitoringTime();
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -17,6 +17,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.stream.Stream;
@@ -179,6 +180,109 @@ public class CheckMonitoredTripBasicTest {
             Arguments.of(ONE_HOURS_IN_SECS, false, "Should not advance monitored day if trip in near future"),
             Arguments.of(TWO_MINUTES_IN_SECS, false, "Should not advance monitored day if trip is ongoing"),
             Arguments.of(-ONE_HOURS_IN_SECS, true, "Should advance monitored day if trip is past.")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shouldSendInitialReminderCases")
+    void testShouldSendInitialReminder(
+        int offsetSeconds,
+        boolean active,
+        boolean snoozed,
+        TripStatus tripStatus,
+        boolean expected,
+        String message
+    ) throws CloneNotSupportedException {
+        MonitoredTrip trip = makeMonitoredTripFromNow(offsetSeconds, offsetSeconds + 300);
+        if (tripStatus != TripStatus.PAST_TRIP) {
+            setRecurringTodayAndTomorrow(trip);
+        } else {
+            trip.updateAllDaysOfWeek(false);
+        }
+        trip.isActive = active;
+        trip.snoozed = snoozed;
+        trip.notifyAtLeadingInterval = true;
+        trip.leadTimeInMinutes = 30;
+        trip.journeyState.lastCheckedEpochMillis = Instant.now().minus(60, ChronoUnit.MINUTES).toEpochMilli();
+        trip.journeyState.tripStatus = tripStatus;
+
+        CheckMonitoredTrip check = new CheckMonitoredTrip(trip);
+        check.matchingItinerary = trip.itinerary;
+        check.previousMatchingItinerary = trip.itinerary;
+
+        assertEquals(
+            expected,
+            check.shouldSendInitialReminder(),
+            message
+        );
+    }
+
+    static Stream<Arguments> shouldSendInitialReminderCases() {
+        return Stream.of(
+            Arguments.of(
+                300,
+                true,
+                false,
+                TripStatus.TRIP_UPCOMING,
+                true,
+                "Send reminder today for upcoming monitored trip today."
+            ),
+            Arguments.of(
+                -60,
+                true,
+                false,
+                TripStatus.TRIP_ACTIVE,
+                true,
+                "Send reminder for ongoing monitored trip (for trips is saved after starting time)."
+            ),
+            Arguments.of(
+                -60 + 24 * 3600, // Next trip starts tomorrow.
+                true,
+                false,
+                TripStatus.TRIP_UPCOMING,
+                false,
+                "Don't send reminder today after today's trip is complete. (Send it tomorrow.)"
+            ),
+            Arguments.of(
+                300,
+                false,
+                true,
+                TripStatus.TRIP_UPCOMING,
+                false,
+                "Don't send reminder for upcoming non-monitored trip."
+            ),
+            Arguments.of(
+                300,
+                true,
+                true,
+                TripStatus.TRIP_UPCOMING,
+                false,
+                "Don't send reminder for upcoming snoozed trip."
+            ),
+            Arguments.of(
+                300,
+                true,
+                false,
+                TripStatus.NEXT_TRIP_NOT_POSSIBLE,
+                false,
+                "Don't send reminder for unmonitorable trip."
+            ),
+            Arguments.of(
+                -3000,
+                true,
+                false,
+                TripStatus.PAST_TRIP,
+                false,
+                "Don't send reminder for one-time past trip."
+            ),
+            Arguments.of(
+                -3000,
+                true,
+                false,
+                TripStatus.NO_LONGER_POSSIBLE,
+                false,
+                "Don't send reminder for trip no longer possible."
+            )
         );
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripBasicTest.java
@@ -233,7 +233,7 @@ public class CheckMonitoredTripBasicTest {
                 false,
                 TripStatus.TRIP_ACTIVE,
                 true,
-                "Send reminder for ongoing monitored trip (for trips is saved after starting time)."
+                "Send reminder for ongoing monitored trip (for trips saved after starting time)."
             ),
             Arguments.of(
                 -60 + 24 * 3600, // Next trip starts tomorrow.
@@ -241,7 +241,7 @@ public class CheckMonitoredTripBasicTest {
                 false,
                 TripStatus.TRIP_UPCOMING,
                 false,
-                "Don't send reminder today after today's trip is complete. (Send it tomorrow.)"
+                "Don't send reminder today after today's trip is complete (send it tomorrow)."
             ),
             Arguments.of(
                 300,

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -212,9 +212,10 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
         Persistence.monitoredTrips.create(monitoredTrip);
 
-        DateTimeUtils.useFixedClockAt(MONDAY_20200615_0845);
+        // Mock time to be 7:30am on Tuesday, June 9 before the trip start at 8:40am.
+        DateTimeUtils.useFixedClockAt(TUESDAY_20200609.withHour(7).withMinute(30));
 
-        CheckMonitoredTrip checkMonitoredTrip = new CheckMonitoredTrip(monitoredTrip, this::getMockOtpResponseJune15);
+        CheckMonitoredTrip checkMonitoredTrip = new CheckMonitoredTrip(monitoredTrip, this::mockOtpPlanResponse);
         checkMonitoredTrip.run();
         // Assert that the initial reminder has been generated.
         Assertions.assertNotNull(checkMonitoredTrip.initialReminderNotification);

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -42,6 +42,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -56,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.middleware.models.TripMonitorNotification.STOPWATCH_ICON;
+import static org.opentripplanner.middleware.models.TripMonitorNotification.createItineraryNotFoundNotification;
 import static org.opentripplanner.middleware.testutils.OtpTestUtils.firstItinerary;
 import static org.opentripplanner.middleware.tripmonitor.TripStatus.NEXT_TRIP_NOT_POSSIBLE;
 import static org.opentripplanner.middleware.tripmonitor.TripStatus.NO_LONGER_POSSIBLE;
@@ -540,6 +542,12 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // update the target date to be an upcoming Monday within the CheckMonitoredTrip
         mockCheckMonitoredTrip.targetZonedDateTime = MONDAY_20200615_0835;
 
+        // Assume that an unmonitorable trip notification has been previously sent
+        // to ensure a new notification is sent anyways.
+        mockCheckMonitoredTrip.previousJourneyState.lastNotifications.add(
+            createItineraryNotFoundNotification(true, Locale.US)
+        );
+
         Itinerary mockMondayJune15Itinerary = firstItinerary(mockWeekdayResponse);
         // parse original itinerary date/time and then update mock itinerary to occur on Monday June 15, but at a time
         // that does not match the previous itinerary
@@ -590,6 +598,10 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             "Unable to monitor trip. Monitoring snoozed for today after multiple failed attempts to locate your itinerary. Go to Trip Details for options.",
             mockCheckMonitoredTrip.notifications.iterator().next().body,
             "The notification should have the appropriate message when the next trip could not be monitored"
+        );
+        assertFalse(
+            mockCheckMonitoredTrip.thereAreNoNewNotifications(),
+            "Unmonitorable trip notification should be sent even if one was previously sent."
         );
     }
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes the conditions under which a trip reminder is sent. Namely, don't send reminders for trips not monitorable or if the trip has concluded for the day. Tests updated to reflect the cases.
