### PR TITLE
Fix wait for transit messages

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstruction.java
@@ -25,18 +25,13 @@ public class WaitForTransitInstruction extends TransitLegInstruction {
     public String build() {
         // TODO: i18n
         String routeShortName = getRouteShortNameFromLeg(transitLeg);
-        long delayInMinutes = transitLeg.departureDelay / 60;
-        long absoluteMinutes = Math.abs(delayInMinutes);
-        long waitInMinutes = Duration
-            .between(
-                currentTime.atZone(DateTimeUtils.getOtpZoneId()),
-                ZonedDateTime.ofInstant(transitLeg.startTime.toInstant(), DateTimeUtils.getOtpZoneId())
-            )
-            .toMinutes();
+        long waitInMinutes = getWaitInMinutes();
         String waitInfo;
         if (waitInMinutes < -2) {
             waitInfo = " (That time has passed)";
         } else if (Boolean.TRUE.equals(transitLeg.realTime)) {
+            long delayInMinutes = transitLeg.departureDelay / 60;
+            long absoluteMinutes = Math.abs(delayInMinutes);
             String delayInfo = (delayInMinutes > 0) ? "late" : "early";
             waitInfo = (absoluteMinutes <= 1)
                 ? ", on time"
@@ -51,5 +46,12 @@ public class WaitForTransitInstruction extends TransitLegInstruction {
             DateTimeUtils.formatShortDate(Date.from(transitLeg.getScheduledStartTime().toInstant()), locale),
             waitInfo
         );
+    }
+
+    public long getWaitInMinutes() {
+        return Duration.between(
+            currentTime.atZone(DateTimeUtils.getOtpZoneId()),
+            ZonedDateTime.ofInstant(transitLeg.startTime.toInstant(), DateTimeUtils.getOtpZoneId())
+        ).toMinutes();
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstruction.java
@@ -5,6 +5,7 @@ import org.opentripplanner.middleware.utils.DateTimeUtils;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Locale;
 
@@ -27,7 +28,10 @@ public class WaitForTransitInstruction extends TransitLegInstruction {
         long delayInMinutes = transitLeg.departureDelay / 60;
         long absoluteMinutes = Math.abs(delayInMinutes);
         long waitInMinutes = Duration
-            .between(currentTime.atZone(DateTimeUtils.getOtpZoneId()), transitLeg.getScheduledStartTime())
+            .between(
+                currentTime.atZone(DateTimeUtils.getOtpZoneId()),
+                ZonedDateTime.ofInstant(transitLeg.startTime.toInstant(), DateTimeUtils.getOtpZoneId())
+            )
             .toMinutes();
         String waitInfo;
         if (waitInMinutes < -2) {

--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstruction.java
@@ -36,11 +36,13 @@ public class WaitForTransitInstruction extends TransitLegInstruction {
         String waitInfo;
         if (waitInMinutes < -2) {
             waitInfo = " (That time has passed)";
-        } else {
+        } else if (Boolean.TRUE.equals(transitLeg.realTime)) {
             String delayInfo = (delayInMinutes > 0) ? "late" : "early";
             waitInfo = (absoluteMinutes <= 1)
                 ? ", on time"
                 : String.format(" now%s %s", getReadableMinutes(delayInMinutes), delayInfo);
+        } else {
+            waitInfo = " (No real-time info)";
         }
         return String.format(
             "Wait%s for your bus, route %s, scheduled at %s%s",

--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstruction.java
@@ -29,7 +29,7 @@ public class WaitForTransitInstruction extends TransitLegInstruction {
         String status = getStatus(waitInMinutes);
 
         return String.format(
-            "Wait%s for your bus, route %s, scheduled at %s%s",
+            "Wait%s for your bus, route %s, scheduled at %s (%s)",
             getReadableMinutes(waitInMinutes),
             routeShortName,
             DateTimeUtils.formatShortDate(Date.from(transitLeg.getScheduledStartTime().toInstant()), locale),
@@ -39,16 +39,16 @@ public class WaitForTransitInstruction extends TransitLegInstruction {
 
     public String getStatus(long waitInMinutes) {
         if (waitInMinutes < -2) {
-            return " (That time has passed)";
+            return "That time has passed";
         } else if (Boolean.TRUE.equals(transitLeg.realTime)) {
             long delayInMinutes = transitLeg.departureDelay / 60;
             long absoluteMinutes = Math.abs(delayInMinutes);
             String delayInfo = (delayInMinutes > 0) ? "late" : "early";
             return (absoluteMinutes <= 1)
-                ? ", on time"
-                : String.format(", now%s %s", getReadableMinutes(absoluteMinutes), delayInfo);
+                ? "On time"
+                : String.format("Now%s %s", getReadableMinutes(absoluteMinutes), delayInfo);
         } else {
-            return " (No real-time info)";
+            return "No real-time info";
         }
     }
 

--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstruction.java
@@ -26,26 +26,30 @@ public class WaitForTransitInstruction extends TransitLegInstruction {
         // TODO: i18n
         String routeShortName = getRouteShortNameFromLeg(transitLeg);
         long waitInMinutes = getWaitInMinutes();
-        String waitInfo;
-        if (waitInMinutes < -2) {
-            waitInfo = " (That time has passed)";
-        } else if (Boolean.TRUE.equals(transitLeg.realTime)) {
-            long delayInMinutes = transitLeg.departureDelay / 60;
-            long absoluteMinutes = Math.abs(delayInMinutes);
-            String delayInfo = (delayInMinutes > 0) ? "late" : "early";
-            waitInfo = (absoluteMinutes <= 1)
-                ? ", on time"
-                : String.format(" now%s %s", getReadableMinutes(delayInMinutes), delayInfo);
-        } else {
-            waitInfo = " (No real-time info)";
-        }
+        String status = getStatus(waitInMinutes);
+
         return String.format(
             "Wait%s for your bus, route %s, scheduled at %s%s",
             getReadableMinutes(waitInMinutes),
             routeShortName,
             DateTimeUtils.formatShortDate(Date.from(transitLeg.getScheduledStartTime().toInstant()), locale),
-            waitInfo
+            status
         );
+    }
+
+    public String getStatus(long waitInMinutes) {
+        if (waitInMinutes < -2) {
+            return " (That time has passed)";
+        } else if (Boolean.TRUE.equals(transitLeg.realTime)) {
+            long delayInMinutes = transitLeg.departureDelay / 60;
+            long absoluteMinutes = Math.abs(delayInMinutes);
+            String delayInfo = (delayInMinutes > 0) ? "late" : "early";
+            return (absoluteMinutes <= 1)
+                ? ", on time"
+                : String.format(", now%s %s", getReadableMinutes(absoluteMinutes), delayInfo);
+        } else {
+            return " (No real-time info)";
+        }
     }
 
     public long getWaitInMinutes() {

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -524,7 +524,7 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                     .withPosition(walkToBusTransition.legs.get(0).to.toCoordinates())
                     .withTripStatus(TripStatus.AHEAD_OF_SCHEDULE)
                     .withInstant(walkToBusTransition.legs.get(1).startTime.toInstant().minus(40, ChronoUnit.MINUTES))
-                    .withExpectedInstruction("Wait 40 minutes for your bus, route 40, scheduled at 6:41 AM, on time")
+                    .withExpectedInstruction("Wait 40 minutes for your bus, route 40, scheduled at 6:41 AM (On time)")
             ),
             Arguments.of(
                 "After boarding bus and bus starts moving, but incorrectly produced 'COMPLETED' status.",

--- a/src/test/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstructionTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstructionTest.java
@@ -1,0 +1,39 @@
+package org.opentripplanner.middleware.triptracker.instruction;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentripplanner.middleware.otp.response.Leg;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WaitForTransitInstructionTest {
+    @ParameterizedTest
+    @MethodSource("getWaitTimeMinutesCases")
+    void testGetWaitTimeInMinutes(int legOffsetSeconds, int expectedWaitMinutes, String message) {
+        Instant now = Instant.now();
+        Instant legStart = now.plusSeconds(legOffsetSeconds);
+        Leg transitLeg = new Leg();
+        transitLeg.startTime = Date.from(legStart);
+
+        assertEquals(
+            expectedWaitMinutes,
+            new WaitForTransitInstruction(transitLeg, now, Locale.US).getWaitInMinutes(),
+            message
+        );
+    }
+
+    static Stream<Arguments> getWaitTimeMinutesCases() {
+        // Note that 310 seconds are used to avoid millisecond shifts that could happen right at the 300s mark.
+        return Stream.of(
+            Arguments.of(0, 0, "zero wait"),
+            Arguments.of(-310, -5, "5 min past"),
+            Arguments.of(310, 5, "5 min wait")
+        );
+    }
+}

--- a/src/test/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstructionTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstructionTest.java
@@ -57,14 +57,14 @@ class WaitForTransitInstructionTest {
 
     static Stream<Arguments> getStatusCases() {
         return Stream.of(
-            Arguments.of(0, false, 0, " (No real-time info)", "zero wait"),
-            Arguments.of(300, false, 0, " (No real-time info)", "5 min wait"),
-            Arguments.of(-300, false, 0, " (That time has passed)", "5 min past"),
-            Arguments.of(0, true, 0, ", on time", "zero delay"),
-            Arguments.of(300, true, 0, ", on time", "5 min wait"),
-            Arguments.of(300, true, 160, ", now 2 minutes late", "5 min wait incl 2 min delay"),
-            Arguments.of(300, true, -160, ", now 2 minutes early", "5 min wait incl 2 min advance"),
-            Arguments.of(-300, false, 100, " (That time has passed)", "5 min past incl 1 min delay")
+            Arguments.of(0, false, 0, "No real-time info", "zero wait"),
+            Arguments.of(300, false, 0, "No real-time info", "5 min wait"),
+            Arguments.of(-300, false, 0, "That time has passed", "5 min past"),
+            Arguments.of(0, true, 0, "On time", "zero delay"),
+            Arguments.of(300, true, 0, "On time", "5 min wait"),
+            Arguments.of(300, true, 160, "Now 2 minutes late", "5 min wait incl 2 min delay"),
+            Arguments.of(300, true, -160, "Now 2 minutes early", "5 min wait incl 2 min advance"),
+            Arguments.of(-300, false, 100, "That time has passed", "5 min past incl 1 min delay")
         );
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstructionTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstructionTest.java
@@ -36,4 +36,35 @@ class WaitForTransitInstructionTest {
             Arguments.of(310, 5, "5 min wait")
         );
     }
+
+    @ParameterizedTest
+    @MethodSource("getStatusCases")
+    void testGetStatus(int waitMinutes, boolean realTime, int delaySeconds, String expectedStatus, String message) {
+        Instant now = Instant.now();
+        Leg transitLeg = new Leg();
+        transitLeg.startTime = Date.from(now);
+        transitLeg.realTime = realTime;
+        if (realTime) {
+            transitLeg.departureDelay = delaySeconds;
+        }
+
+        assertEquals(
+            expectedStatus,
+            new WaitForTransitInstruction(transitLeg, now, Locale.US).getStatus(waitMinutes),
+            message
+        );
+    }
+
+    static Stream<Arguments> getStatusCases() {
+        return Stream.of(
+            Arguments.of(0, false, 0, " (No real-time info)", "zero wait"),
+            Arguments.of(300, false, 0, " (No real-time info)", "5 min wait"),
+            Arguments.of(-300, false, 0, " (That time has passed)", "5 min past"),
+            Arguments.of(0, true, 0, ", on time", "zero delay"),
+            Arguments.of(300, true, 0, ", on time", "5 min wait"),
+            Arguments.of(300, true, 160, ", now 2 minutes late", "5 min wait incl 2 min delay"),
+            Arguments.of(300, true, -160, ", now 2 minutes early", "5 min wait incl 2 min advance"),
+            Arguments.of(-300, false, 100, " (That time has passed)", "5 min past incl 1 min delay")
+        );
+    }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR tweaks messages related to waiting for a transit vehicle when using `TrackedJourneys`.
