### PR TITLE
Deviated instruction in one-step leg

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -467,6 +467,15 @@ public class TravelerLocator {
         return Math.min(distanceToLastShapeCoords, distanceToLegDestination);
     }
 
+    private static <T extends ConvertsToCoordinates> T findWaypointAt(Map<T, Coordinates> waypoints, Coordinates position) {
+        for (var entry : waypoints.entrySet()) {
+            if (position.equals(entry.getValue())) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
     /**
      * From the starting index, find the next waypoint along a leg.
      */
@@ -476,14 +485,12 @@ public class TravelerLocator {
             .collect(Collectors.toMap(s -> s, ConvertsToCoordinates::toCoordinates));
 
         for (int i = startIndex; i < positions.size(); i++) {
-            Coordinates pos = positions.get(i);
-            for (var entry : waypoints.entrySet()) {
-                if (pos.equals(entry.getValue())) {
-                    return entry.getKey();
-                }
-            }
+            T waypoint = findWaypointAt(waypoints, positions.get(i));
+            if (waypoint != null) return waypoint;
         }
-        return null;
+
+        // If no waypoint has been found, try the previous position (result can still be null).
+        return findWaypointAt(waypoints, positions.get(Math.max(startIndex - 1, 0)));
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -467,6 +467,9 @@ public class TravelerLocator {
         return Math.min(distanceToLastShapeCoords, distanceToLegDestination);
     }
 
+    /**
+     * Returns, from a list of waypoints, one that is at the specified position.
+     */
     private static <T extends ConvertsToCoordinates> T findWaypointAt(Map<T, Coordinates> waypoints, Coordinates position) {
         for (var entry : waypoints.entrySet()) {
             if (position.equals(entry.getValue())) {

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -264,7 +264,7 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
         Coordinates pointBeforeTurn = new Coordinates(33.78151,-84.36481);
         Coordinates pointAfterTurn = new Coordinates(33.78165, -84.36484);
         Coordinates pointOnKanugaStreet = new Coordinates(33.781544, -84.367849);
-        Coordinates deviatedFrom10B = new Coordinates(33.924073513840774,-84.25019791869008);
+        Coordinates deviatedFrom10B = new Coordinates(33.924073513840774, -84.25019791869008);
 
         Leg toEastCroganFirstLeg = baptistChurchToEastCroganStreetIntinerary.legs.get(0);
         Step southClaytonSt = toEastCroganFirstLeg.steps.get(1);

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -69,6 +69,7 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
     private static Itinerary walkGjacTo1js;
     private static Itinerary walkToBusTransition;
     private static Itinerary walkToBus20;
+    private static Itinerary walkToBus10B;
 
     private static final Locale locale = Locale.US;
 
@@ -121,6 +122,10 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
         );
         walkToBus20 = JsonUtils.getPOJOFromJSON(
             CommonTestUtils.getTestResourceAsString("controllers/api/walk-to-bus-20.json"),
+            Itinerary.class
+        );
+        walkToBus10B = JsonUtils.getPOJOFromJSON(
+            CommonTestUtils.getTestResourceAsString("controllers/api/walk-to-bus-10B.json"),
             Itinerary.class
         );
 
@@ -259,6 +264,7 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
         Coordinates pointBeforeTurn = new Coordinates(33.78151,-84.36481);
         Coordinates pointAfterTurn = new Coordinates(33.78165, -84.36484);
         Coordinates pointOnKanugaStreet = new Coordinates(33.781544, -84.367849);
+        Coordinates deviatedFrom10B = new Coordinates(33.924073513840774,-84.25019791869008);
 
         Leg toEastCroganFirstLeg = baptistChurchToEastCroganStreetIntinerary.legs.get(0);
         Step southClaytonSt = toEastCroganFirstLeg.steps.get(1);
@@ -424,6 +430,14 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                 new TraceData()
                     .withPosition(midtownWalkCoords)
                     .withExpectedInstruction(new ContinueInstruction(midtownWalkFirstStep, locale))
+            ),
+            Arguments.of(
+                "Deviated position near walk leg should result in a 'walk back' instruction and not 'No instruction'.",
+                walkToBus10B.legs.get(0),
+                new TraceData()
+                    .withPosition(deviatedFrom10B)
+                    .withTripStatus(TripStatus.DEVIATED)
+                    .withExpectedInstruction("Head to Buford Highway")
             )
         );
     }
@@ -670,7 +684,7 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
             Arguments.of(leg.steps.get(1), 5, "Approaching second step, expecting the second step."),
             Arguments.of(leg.steps.get(2), 7, "Approaching third step, expecting the third step."),
             Arguments.of(leg.steps.get(3), 9, "After third step, expecting the fourth step."),
-            Arguments.of(null, 10, "After fourth and final step, expecting no step.")
+            Arguments.of(leg.steps.get(3), 10, "After fourth and final step, keep referring to the final step, so that an instruction is generated.")
         );
     }
 

--- a/src/test/resources/org/opentripplanner/middleware/controllers/api/walk-to-bus-10B.json
+++ b/src/test/resources/org/opentripplanner/middleware/controllers/api/walk-to-bus-10B.json
@@ -1,0 +1,312 @@
+{
+  "duration": 1095,
+  "startTime": 1753384473000,
+  "endTime": 1753385568000,
+  "walkTime": 175,
+  "transitTime": 0,
+  "waitingTime": 300,
+  "walkDistance": 0,
+  "walkLimitExceeded": false,
+  "elevationLost": 0,
+  "elevationGained": 0,
+  "transfers": 0,
+  "fare": null,
+  "legs": [
+    {
+      "startTime": 1753384473000,
+      "endTime": 1753384531000,
+      "departureDelay": 0,
+      "arrivalDelay": 0,
+      "realTime": false,
+      "distance": 99.19,
+      "mode": "WALK",
+      "interlineWithPreviousLeg": false,
+      "from": {
+        "name": "33.924, -84.25051",
+        "lon": -84.2505092,
+        "lat": 33.924001,
+        "vertexType": "NORMAL"
+      },
+      "to": {
+        "name": "Buford Hwy at Pleasantdale Rd IB",
+        "lon": -84.249667,
+        "lat": 33.924555,
+        "vertexType": "TRANSIT",
+        "stop": {
+          "alerts": [],
+          "code": "1073",
+          "gtfsId": "GwinnettCountyTransit:1073",
+          "id": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA3Mw",
+          "lon": -84.249667,
+          "lat": 33.924555
+        }
+      },
+      "legGeometry": {
+        "points": "_x`nEvdfaOw@sAQ_@SYQY@A",
+        "length": 6
+      },
+      "rentedBike": false,
+      "transitLeg": false,
+      "duration": 58,
+      "steps": [
+        {
+          "distance": 99.19,
+          "relativeDirection": "DEPART",
+          "streetName": "Buford Highway",
+          "absoluteDirection": "NORTHEAST",
+          "stayOn": false,
+          "area": false,
+          "lon": -84.2505103,
+          "lat": 33.9240022
+        }
+      ]
+    },
+    {
+      "startTime": 1753384831000,
+      "endTime": 1753385451000,
+      "departureDelay": 431,
+      "arrivalDelay": 431,
+      "realTime": true,
+      "distance": 4573.87,
+      "mode": "BUS",
+      "interlineWithPreviousLeg": false,
+      "from": {
+        "name": "Buford Hwy at Pleasantdale Rd IB",
+        "lon": -84.249667,
+        "lat": 33.924555,
+        "vertexType": "TRANSIT",
+        "stop": {
+          "alerts": [],
+          "code": "1073",
+          "gtfsId": "GwinnettCountyTransit:1073",
+          "id": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA3Mw",
+          "lon": -84.249667,
+          "lat": 33.924555
+        }
+      },
+      "to": {
+        "name": "Buford Hwy & Summerour St IB",
+        "lon": -84.20651,
+        "lat": 33.9426,
+        "vertexType": "TRANSIT",
+        "stop": {
+          "alerts": [],
+          "code": "1089",
+          "gtfsId": "GwinnettCountyTransit:1089",
+          "id": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA4OQ",
+          "lon": -84.20651,
+          "lat": 33.9426
+        }
+      },
+      "legGeometry": {
+        "points": "{{`nEz_faOACgGaM??CEeEaOkBcM??AA{DoX??AAcByK??AC{AmK??ACEYk@{De@iD??AAGc@[sBqA}I??AAsCsS??ACsBkO??AAc@kEiDeS?A??cBgGaBaEyEkI??AAgAaBsD}D???@oO{Q????AAgGiI??ACgGqI???AaF{G",
+        "length": 58
+      },
+      "transitLeg": true,
+      "duration": 620,
+      "intermediateStops": [
+        {
+          "name": "Buford Hwy & Button Gwinnett Dr IB",
+          "lon": -84.247394,
+          "lat": 33.925875,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA3NA",
+          "stopCode": "1074"
+        },
+        {
+          "name": "Buford Hwy & Susan Ln",
+          "lon": -84.242584,
+          "lat": 33.927436,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA3NQ",
+          "stopCode": "1075"
+        },
+        {
+          "name": "Buford Hwy at Oak Rd IB",
+          "lon": -84.238496,
+          "lat": 33.928394,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA3Ng",
+          "stopCode": "1076"
+        },
+        {
+          "name": "Buford Hwy at Hillside Dr IB",
+          "lon": -84.236424,
+          "lat": 33.928888,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA3Nw",
+          "stopCode": "1077"
+        },
+        {
+          "name": "Buford Hwy & Pine St IB",
+          "lon": -84.234414,
+          "lat": 33.929351,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA3OA",
+          "stopCode": "1078"
+        },
+        {
+          "name": "Buford Hwy at Car Z Atlanta IB",
+          "lon": -84.232476,
+          "lat": 33.929792,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA3OQ",
+          "stopCode": "1079"
+        },
+        {
+          "name": "Buford Hwy & Gwinn Dr IB",
+          "lon": -84.229966,
+          "lat": 33.930425,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA4MA",
+          "stopCode": "1080"
+        },
+        {
+          "name": "Buford Hwy & S Peachtree St IB",
+          "lon": -84.226642,
+          "lat": 33.931147,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA4MQ",
+          "stopCode": "1081"
+        },
+        {
+          "name": "Buford Hwy at Huntington Rd Apts IB",
+          "lon": -84.224021,
+          "lat": 33.931777,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA4Mg",
+          "stopCode": "1082"
+        },
+        {
+          "name": "Buford Hwy at Jimmy Carter IB",
+          "lon": -84.219746,
+          "lat": 33.932774,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA4Mw",
+          "stopCode": "1083"
+        },
+        {
+          "name": "Buford Hwy & N Norcross Tucker Rd",
+          "lon": -84.215772,
+          "lat": 33.934894,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA4NA",
+          "stopCode": "1084"
+        },
+        {
+          "name": "Buford Hwy at Lively Ave IB",
+          "lon": -84.214272,
+          "lat": 33.936159,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA4NQ",
+          "stopCode": "1085"
+        },
+        {
+          "name": "Buford Hwy & S Cemetery St IB",
+          "lon": -84.211318,
+          "lat": 33.938828,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA4Ng",
+          "stopCode": "1086"
+        },
+        {
+          "name": "Buford Hwy & Centro Norcross Plaza IB",
+          "lon": -84.209622,
+          "lat": 33.940124,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA4Nw",
+          "stopCode": "1087"
+        },
+        {
+          "name": "Buford Hwy & Mitchell Rd (NAPA) IB",
+          "lon": -84.207948,
+          "lat": 33.941476,
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA4OA",
+          "stopCode": "1088"
+        }
+      ],
+      "steps": [],
+      "headsign": "Sugarloaf Mills",
+      "agency": {
+        "alerts": [],
+        "gtfsId": "GwinnettCountyTransit:GCT",
+        "id": "GwinnettCountyTransit:GCT",
+        "name": "Gwinnett County Transit"
+      },
+      "route": {
+        "alerts": [],
+        "color": "008B44",
+        "gtfsId": "GwinnettCountyTransit:50",
+        "id": "GwinnettCountyTransit:50",
+        "longName": "Sugarloaf - GTC - Dora via Remington",
+        "shortName": "10B",
+        "textColor": "FFFFFF",
+        "type": 3
+      },
+      "trip": {
+        "gtfsId": "GwinnettCountyTransit:t5E1-b72-sl5-v3B",
+        "id": "VHJpcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6dDVFMS1iNzItc2w1LXYzQg",
+        "departureStoptime": {
+          "stop": {
+            "id": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA2MQ",
+            "gtfsId": "GwinnettCountyTransit:1061"
+          },
+          "stopPosition": 0
+        },
+        "arrivalStoptime": {
+          "stop": {
+            "id": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTAwMA",
+            "gtfsId": "GwinnettCountyTransit:1000"
+          },
+          "stopPosition": 3300
+        }
+      }
+    },
+    {
+      "startTime": 1753385451000,
+      "endTime": 1753385568000,
+      "departureDelay": 0,
+      "arrivalDelay": 0,
+      "realTime": false,
+      "distance": 145.76,
+      "mode": "WALK",
+      "interlineWithPreviousLeg": false,
+      "from": {
+        "name": "Buford Hwy & Summerour St IB",
+        "lon": -84.20651,
+        "lat": 33.9426,
+        "vertexType": "TRANSIT",
+        "stop": {
+          "alerts": [],
+          "code": "1089",
+          "gtfsId": "GwinnettCountyTransit:1089",
+          "id": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTA4OQ",
+          "lon": -84.20651,
+          "lat": 33.9426
+        }
+      },
+      "to": {
+        "name": "5576 Buford Highway, Norcross, GA, USA",
+        "lon": -84.2055628,
+        "lat": 33.9428565,
+        "vertexType": "NORMAL"
+      },
+      "legGeometry": {
+        "points": "gldnEtq}`OABMSe@o@QUa@m@EEf@_@KQBSPI",
+        "length": 11
+      },
+      "rentedBike": false,
+      "transitLeg": false,
+      "duration": 117,
+      "steps": [
+        {
+          "distance": 89.41,
+          "relativeDirection": "DEPART",
+          "streetName": "Buford Highway",
+          "absoluteDirection": "NORTHEAST",
+          "stayOn": false,
+          "area": false,
+          "lon": -84.2065228,
+          "lat": 33.9426116
+        },
+        {
+          "distance": 56.36,
+          "relativeDirection": "RIGHT",
+          "streetName": "service road",
+          "absoluteDirection": "SOUTHEAST",
+          "stayOn": true,
+          "area": false,
+          "lon": -84.2058182,
+          "lat": 33.9431638
+        }
+      ]
+    }
+  ],
+  "alerts": []
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes a NO_INSTRUCTION situation when deviating from a one-step walk leg.