### PR TITLE
OTP-1785 "Millions of Minutes"

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -321,6 +321,8 @@ public class CheckMonitoredTrip implements Runnable {
                 // Set the matching itinerary.
                 matchingItinerary = candidateItinerary;
 
+                // reset journey state departure/arrival times
+                resetJourneyState();
                 // update the journey state with whether the matching itinerary has realtime data
                 journeyState.hasRealtimeData = matchingItinerary.legs.stream().anyMatch(leg -> leg.realTime);
 

--- a/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
+++ b/src/test/java/org/opentripplanner/middleware/testutils/OtpTestUtils.java
@@ -242,10 +242,6 @@ public class OtpTestUtils {
 
     private static JourneyState createDefaultJourneyState(Itinerary defaultItinerary) {
         JourneyState journeyState = new JourneyState();
-        journeyState.scheduledArrivalTimeEpochMillis = defaultItinerary.endTime.getTime();
-        journeyState.scheduledDepartureTimeEpochMillis = defaultItinerary.startTime.getTime();
-        journeyState.baselineArrivalTimeEpochMillis = defaultItinerary.endTime.getTime();
-        journeyState.baselineDepartureTimeEpochMillis = defaultItinerary.startTime.getTime();
         journeyState.tripStatus = defaultItinerary.isActive()
             ? TripStatus.TRIP_ACTIVE
             : TripStatus.TRIP_UPCOMING;

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -235,6 +235,11 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     ) throws Exception {
         long previousDelayMillis = TimeUnit.MILLISECONDS.convert(previousMinutesLate, TimeUnit.MINUTES);
         JourneyState journeyState = OtpTestUtils.createDefaultJourneyState();
+        // initialize JourneyState time values 
+        journeyState.scheduledArrivalTimeEpochMillis = journeyState.matchingItinerary.endTime.getTime();
+        journeyState.scheduledDepartureTimeEpochMillis = journeyState.matchingItinerary.startTime.getTime();
+        journeyState.baselineArrivalTimeEpochMillis = journeyState.matchingItinerary.endTime.getTime();
+        journeyState.baselineDepartureTimeEpochMillis = journeyState.matchingItinerary.startTime.getTime();
 
         if (notificationType == NotificationType.DEPARTURE_AND_ARRIVAL_DELAY || notificationType == NotificationType.DEPARTURE_DELAY) {
             journeyState.baselineDepartureTimeEpochMillis += previousDelayMillis;
@@ -260,6 +265,34 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
             assertEquals(notificationType, notification.type);
             assertThat(message, notification.body, matchesPattern(expectedNotificationPattern));
         }
+    }
+
+    /**
+     * Ensure that journey state time values are properly initialized for OTP request and don't show delays
+     */
+    @Test
+    void testJourneyStateAfterOTPRequest() throws Exception {
+        // create a mock monitored trip and CheckMonitorTrip instance.
+        // Note that the response below gets modified from the original mockOtpPlanResponse.
+        CheckMonitoredTrip check = createCheckMonitoredTrip(this::getMockOtpResponseJune15);
+        MonitoredTrip mockTrip = check.trip;
+        Persistence.monitoredTrips.create(mockTrip);
+
+        // set trip status to be upcoming
+        mockTrip.journeyState.tripStatus = TripStatus.TRIP_UPCOMING;
+
+        // update the target date to be an upcoming Monday within the CheckMonitoredTrip
+        check.targetZonedDateTime = MONDAY_20200615_0835;
+
+        // mock the current time to be 8:45am on Monday, June 15, 2020.
+        DateTimeUtils.useFixedClockAt(MONDAY_20200615_0845);
+
+        // Execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome.
+        assertTrue(check.checkOtpAndUpdateTripStatus());
+        assertEquals(TripStatus.TRIP_ACTIVE, mockTrip.journeyState.tripStatus);
+
+        // There should be no notifications.
+        assertNull(check.checkTripForDelays());
     }
 
     private static Stream<Arguments> createDelayNotificationTestCases() {

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -268,12 +268,11 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
     }
 
     /**
-     * Ensure that journey state time values are properly initialized for OTP request and don't show delays
+     * Ensure that journey state time values are properly initialized after making OTP request
+     * and setting the matchingItinerary, so that delays are correctly computed.
      */
     @Test
     void testJourneyStateAfterOTPRequest() throws Exception {
-        // create a mock monitored trip and CheckMonitorTrip instance.
-        // Note that the response below gets modified from the original mockOtpPlanResponse.
         CheckMonitoredTrip check = createCheckMonitoredTrip(this::getMockOtpResponseJune15);
         MonitoredTrip mockTrip = check.trip;
         Persistence.monitoredTrips.create(mockTrip);
@@ -287,7 +286,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         // mock the current time to be 8:45am on Monday, June 15, 2020.
         DateTimeUtils.useFixedClockAt(MONDAY_20200615_0845);
 
-        // Execute makeOTPRequestAndUpdateMatchingItinerary method and verify the expected outcome.
+        // Execute checkOtpAndUpdateTripStatus method and verify the expected outcome.
         assertTrue(check.checkOtpAndUpdateTripStatus());
         assertEquals(TripStatus.TRIP_ACTIVE, mockTrip.journeyState.tripStatus);
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Some notifications displayed predictions and delays as being millions of minutes late. These displayed values turned out to be the current epoch time, which suggested that the delays and other differences were being calculated from uninitialized zero values. Investigation showed a case where JourneyState times went unset.

This commit sets those values. Test code was adapted accordingly, and a new unit test verifies it.

There are no configuration settings changed.