### PR TITLE
Fix more "no instruction" cases

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.middleware.triptracker;
 
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import io.leonard.PolylineUtils;
 import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.Place;
@@ -489,14 +491,13 @@ public class TravelerLocator {
             .stream()
             .collect(Collectors.toMap(s -> s, ConvertsToCoordinates::toCoordinates));
 
-        for (int i = startIndex; i < positions.size(); i++) {
-            T waypoint = findWaypointAt(waypoints, positions.get(i));
-            if (waypoint != null) return waypoint;
-        }
+        // Look in the next waypoints first, starting from startIndex.
+        List<Coordinates> initialPositions = positions.subList(startIndex, positions.size());
+        // Fallback from the position before startIndex, going back to the first waypoint.
+        List<Coordinates> fallbackPositions = Lists.reverse(positions.subList(0, startIndex));
 
-        // If no waypoint has been found, try the previous positions (result much less likely to be null).
-        for (int i = startIndex - 1; i >= 0; i--) {
-            T waypoint = findWaypointAt(waypoints, positions.get(i));
+        for (Coordinates position : Iterables.concat(initialPositions, fallbackPositions)) {
+            T waypoint = findWaypointAt(waypoints, position);
             if (waypoint != null) return waypoint;
         }
 

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -471,18 +471,6 @@ public class TravelerLocator {
     }
 
     /**
-     * Returns, from a list of waypoints, one that is at the specified position.
-     */
-    private static <T extends ConvertsToCoordinates> T findWaypointAt(Map<T, Coordinates> waypoints, Coordinates position) {
-        for (var entry : waypoints.entrySet()) {
-            if (position.equals(entry.getValue())) {
-                return entry.getKey();
-            }
-        }
-        return null;
-    }
-
-    /**
      * From the starting index, find the next waypoint along a leg.
      * If no waypoint has been found, try the previous positions (result much less likely to be null).
      */
@@ -497,8 +485,12 @@ public class TravelerLocator {
         List<Coordinates> fallbackPositions = Lists.reverse(positions.subList(0, startIndex));
 
         for (Coordinates position : Iterables.concat(initialPositions, fallbackPositions)) {
-            T waypoint = findWaypointAt(waypoints, position);
-            if (waypoint != null) return waypoint;
+            for (var entry : waypoints.entrySet()) {
+                if (position.equals(entry.getValue())) {
+                    T waypoint = entry.getKey();
+                    if (waypoint != null) return waypoint;
+                }
+            }
         }
 
         return null;

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -36,7 +36,6 @@ import static org.opentripplanner.middleware.triptracker.instruction.TripInstruc
 import static org.opentripplanner.middleware.utils.GeometryUtils.getDistance;
 import static org.opentripplanner.middleware.utils.GeometryUtils.isPointBetween;
 import static org.opentripplanner.middleware.utils.ItineraryUtils.isBusLeg;
-import static org.opentripplanner.middleware.utils.ItineraryUtils.legsMatch;
 
 /**
  * Locate the traveler in relation to the nearest step or destination and provide the appropriate instructions.
@@ -128,7 +127,7 @@ public class TravelerLocator {
             return (nearestStep != null && !nearestStep.isEndOfRouting())
                 ? new DeviatedInstruction(nearestStep.streetName, travelerPosition.locale)
                 : null;
-        } else if (atStartOfTransitTrip(travelerPosition)) {
+        } else if (atStartOfTransitLeg(travelerPosition)) {
             // Only provide instruction if at the start of a trip.
             String busStopName = getBusStopName(travelerPosition.expectedLeg);
             return (busStopName != null)
@@ -289,14 +288,16 @@ public class TravelerLocator {
     }
 
     /**
-     * A trip which starts with a transit leg and the traveler is on that leg.
+     * Determines whether the traveler is at the beginning of a transit leg,
+     * i.e. is near the departing stop.
      */
-    private static boolean atStartOfTransitTrip(TravelerPosition travelerPosition) {
-        return
-            travelerPosition.expectedLeg != null &&
-            travelerPosition.firstLegOfTrip != null &&
-            travelerPosition.firstLegOfTrip.transitLeg &&
-            legsMatch(travelerPosition.expectedLeg, travelerPosition.firstLegOfTrip);
+    private static boolean atStartOfTransitLeg(TravelerPosition travelerPosition) {
+        Leg expectedLeg = travelerPosition.expectedLeg;
+        if (expectedLeg == null || !expectedLeg.transitLeg) return false;
+
+        Place nextStop = snapToWaypoint(travelerPosition, getIntermediateAndLastStop(expectedLeg), true);
+        int stopsRemaining = stopsUntilEndOfLeg(nextStop, expectedLeg);
+        return stopsRemaining == expectedLeg.intermediateStops.size();
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -492,8 +492,13 @@ public class TravelerLocator {
             if (waypoint != null) return waypoint;
         }
 
-        // If no waypoint has been found, try the previous position (result can still be null).
-        return findWaypointAt(waypoints, positions.get(Math.max(startIndex - 1, 0)));
+        // If no waypoint has been found, try the previous positions (result much less likely to be null).
+        for (int i = startIndex - 1; i >= 0; i--) {
+            T waypoint = findWaypointAt(waypoints, positions.get(i));
+            if (waypoint != null) return waypoint;
+        }
+
+        return null;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -482,8 +482,9 @@ public class TravelerLocator {
 
     /**
      * From the starting index, find the next waypoint along a leg.
+     * If no waypoint has been found, try the previous positions (result much less likely to be null).
      */
-    public static <T extends ConvertsToCoordinates> T getNextWayPoint(List<Coordinates> positions, List<T> steps, int startIndex) {
+    public static <T extends ConvertsToCoordinates> T getNextOrClosestWayPoint(List<Coordinates> positions, List<T> steps, int startIndex) {
         Map<T, Coordinates> waypoints = steps
             .stream()
             .collect(Collectors.toMap(s -> s, ConvertsToCoordinates::toCoordinates));
@@ -580,7 +581,7 @@ public class TravelerLocator {
         List<Coordinates> legPositions = injectWaypointsIntoLegPositions(pos.expectedLeg, waypoints, TRIP_INSTRUCTION_UPCOMING_RADIUS);
         int pointIndex = getNearestPointIndex(legPositions, pos.currentPosition);
         int startingIndex = excludeCurrent ? Math.min(pointIndex + 1, legPositions.size() - 1) : pointIndex;
-        return pointIndex != -1 ? getNextWayPoint(legPositions, waypoints, startingIndex) : null;
+        return pointIndex != -1 ? getNextOrClosestWayPoint(legPositions, waypoints, startingIndex) : null;
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -78,7 +78,6 @@ import static org.opentripplanner.middleware.tripmonitor.TripStatus.TRIP_ACTIVE;
 import static org.opentripplanner.middleware.triptracker.ManageLegTraversalTest.WALK_AND_TRANSIT_LEG_OVERLAP_POINT;
 import static org.opentripplanner.middleware.triptracker.ManageTripTracking.setOtpGraphQLVariables;
 import static org.opentripplanner.middleware.triptracker.instruction.OnTrackInstruction.TRIP_INSTRUCTION_END_OF_ROUTING;
-import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.NO_INSTRUCTION;
 import static org.opentripplanner.middleware.utils.GeometryUtils.createPoint;
 
 public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
@@ -486,12 +485,12 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
                     .withExpectedInstruction(TRIP_INSTRUCTION_END_OF_ROUTING)
             ),
             Arguments.of(
-                "Deviated significantly from nearest step should produce no instruction",
+                "Deviated significantly from nearest step should still produce walk instruction",
                 itinerary,
                 new TraceData()
                     .withPosition(createPoint(thirdStepCoords, 1000, NORTH_WEST_BEARING))
                     .withTripStatus(TripStatus.DEVIATED)
-                    .withExpectedInstruction(NO_INSTRUCTION)
+                    .withExpectedInstruction("Head to Kanuga Street Northeast")
             ),
             Arguments.of(
                 "Standing at location where walk leg and start of transit leg overlap, should produce walk instruction",

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -265,6 +265,7 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
         Coordinates pointAfterTurn = new Coordinates(33.78165, -84.36484);
         Coordinates pointOnKanugaStreet = new Coordinates(33.781544, -84.367849);
         Coordinates deviatedFrom10B = new Coordinates(33.924073513840774, -84.25019791869008);
+        Coordinates deviatedFrom10B2 = new Coordinates(33.924106088790076, -84.2493224143982);
 
         Leg toEastCroganFirstLeg = baptistChurchToEastCroganStreetIntinerary.legs.get(0);
         Step southClaytonSt = toEastCroganFirstLeg.steps.get(1);
@@ -436,6 +437,14 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                 walkToBus10B.legs.get(0),
                 new TraceData()
                     .withPosition(deviatedFrom10B)
+                    .withTripStatus(TripStatus.DEVIATED)
+                    .withExpectedInstruction("Head to Buford Highway")
+            ),
+            Arguments.of(
+                "Deviated position near walk leg should result in a 'walk back' instruction and not 'No instruction'.",
+                walkToBus10B.legs.get(0),
+                new TraceData()
+                    .withPosition(deviatedFrom10B2)
                     .withTripStatus(TripStatus.DEVIATED)
                     .withExpectedInstruction("Head to Buford Highway")
             )

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opentripplanner.middleware.triptracker.ManageLegTraversal.getSecondsToMilliseconds;
 import static org.opentripplanner.middleware.triptracker.ManageLegTraversal.interpolatePoints;
-import static org.opentripplanner.middleware.triptracker.TravelerLocator.getNextWayPoint;
+import static org.opentripplanner.middleware.triptracker.TravelerLocator.getNextOrClosestWayPoint;
 import static org.opentripplanner.middleware.triptracker.TravelerLocator.isWithinExclusionZone;
 import static org.opentripplanner.middleware.triptracker.instruction.OnTrackInstruction.TRIP_INSTRUCTION_END_OF_ROUTING;
 import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.NO_INSTRUCTION;
@@ -686,7 +686,7 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
     void canGetNearestWaypoint(Step expectedStep, int startIndex, String message) {
         Leg leg = edmundParkDriveToRockSpringsItinerary.legs.get(0);
         List<Coordinates> allPositions = TravelerLocator.injectWaypointsIntoLegPositions(leg, leg.steps, TRIP_INSTRUCTION_UPCOMING_RADIUS);
-        assertEquals(expectedStep, getNextWayPoint(allPositions, leg.steps, startIndex), message);
+        assertEquals(expectedStep, getNextOrClosestWayPoint(allPositions, leg.steps, startIndex), message);
     }
 
     private static Stream<Arguments> createGetNearestWaypointTrace() {

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -597,7 +597,7 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
 
         return Stream.of(
             Arguments.of(
-                "If present at the transit stop after the trip departure, there should not be an instruction.",
+                "If present at the transit stop after the trip departure, instruct to wait (indicate past departure).",
                 new TraceData()
                     .withPosition(originCoords)
                     .withExpectedInstruction("Wait for your bus, route 27, scheduled at 9:18 AM (That time has passed)")

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -670,6 +670,13 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                     .withPosition(33.79371, -84.37711)
                     .withTripStatus(TripStatus.DEVIATED)
                     .withExpectedInstruction(NO_INSTRUCTION)
+            ),
+            Arguments.of(
+                "If 'near' departing stop, instruct to head to stop.",
+                new TraceData()
+                    .withPosition(33.786558, -84.381534)
+                    .withTripStatus(TripStatus.DEVIATED)
+                    .withExpectedInstruction("Head to 14th St at Juniper St")
             )
         );
     }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes more cases where "No instruction" was given when a traveler is near a bus stop but deviating. With this PR, an instruction to go to the stop or to the adjoining street is given instead.
