### PR TITLE
Fix rerouting test

### DIFF
--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opentripplanner.middleware.auth.Auth0Users;
 import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.models.OtpUser;
@@ -160,6 +161,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
     @AfterAll
     public static void tearDown() throws Exception {
         assumeTrue(IS_END_TO_END);
+        DateTimeUtils.useSystemDefaultClockAndTimezone();
         restoreDefaultAuthDisabled();
         soloOtpUser = Persistence.otpUsers.getById(soloOtpUser.id);
         if (soloOtpUser != null) soloOtpUser.delete(true);
@@ -592,8 +594,9 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         assertEquals("Provided journey does not exist or has already been completed!", updateTrackingResponse.message);
     }
 
-    @Test
-    void canRerouteTrip() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = {-300, 30, 3000})
+    void canRerouteTrip(int offsetSeconds) throws Exception {
         assumeTrue(IS_END_TO_END);
 
         MonitoredTrip rerouteMonitoredTrip = monitoredTrip = createMonitoredTrip(walkToVoterRegCenterItinerary);
@@ -601,6 +604,10 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         var startTrackingPayload = createStartTrackingPayload(rerouteMonitoredTrip.id);
         var mockOtpResponse = mockOtpReroutedPlanResponse();
         var expectedReroutedItinerary = getShortestDuration(mockOtpResponse.get().plan.itineraries);
+
+        // Use current time relative to itinerary start (this will affect the computed target date after end tracking).
+        DateTimeUtils.useFixedClockAt(ZonedDateTime.ofInstant(expectedReroutedItinerary.startTime.toInstant().plusSeconds(offsetSeconds), DateTimeUtils.getOtpZoneId()));
+
         ManageTripTracking.otpResponseProviderOverride = mockOtpResponse;
         var deviatedPosition = new TrackingLocation(Instant.now(), 33.94412, -83.98899);
         var reroutingPoint = new Coordinates(expectedReroutedItinerary.legs.get(0).steps.get(2));
@@ -675,9 +682,10 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
             resetTrip.journeyState.matchingItinerary.legs.get(0).from.toCoordinates()
         );
 
-        // Check that matching itinerary time corresponds to "today".
+        // Check that matching itinerary time corresponds to "today" if current time is before trip end,
+        // or "tomorrow" if trip has ended (assuming a recurring trip).
         assertEquals(
-            DateTimeUtils.nowAsZonedDateTime().toLocalDate(),
+            DateTimeUtils.nowAsZonedDateTime().plusDays(expectedReroutedItinerary.hasEnded() ? 1 : 0).toLocalDate(),
             ZonedDateTime.ofInstant(resetTrip.journeyState.matchingItinerary.startTime.toInstant(), DateTimeUtils.getOtpZoneId()).toLocalDate()
         );
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes a test to compute the target date of an itinerary when resetting trip monitoring after rerouting.
