### PR TITLE
Fix premature "destination in vicinity"

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/triptracker/ManageTripTracking.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/ManageTripTracking.java
@@ -126,8 +126,8 @@ public class ManageTripTracking {
                 tripStatus = TripStatus.getTimingStatus(travelerPosition);
             }
 
-            if (isEndOfRoutingInstruction(instruction)) {
-                // Deem trip completed if issuing a "destination in vicinity" instruction.
+            if (isEndOfRoutingInstruction(instruction) && travelerPosition.nextLeg == null) {
+                // Deem trip completed if on the last leg and issuing a "destination in vicinity" instruction.
                 tripStatus = TripStatus.COMPLETED;
             }
 

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -191,7 +191,7 @@ public class TravelerLocator {
             double distanceToLegDestination = getDistance(travelerPosition.currentPosition, legDestination);
 
             if (distanceToLastShapeCoords < distanceToLegDestination) {
-                // Issue an leg end-of-routing step
+                // Issue a leg end-of-routing step
                 Step endOfRoutingStep = createEndOfRoutingStep(
                     legPositions,
                     ItineraryUtils.isBusLeg(travelerPosition.nextLeg) ? "bus stop" : "destination"

--- a/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/TravelerLocator.java
@@ -20,6 +20,7 @@ import org.opentripplanner.middleware.triptracker.interactions.busnotifiers.BusO
 import org.opentripplanner.middleware.utils.Coordinates;
 import org.opentripplanner.middleware.utils.ConvertsToCoordinates;
 import org.opentripplanner.middleware.utils.DateTimeUtils;
+import org.opentripplanner.middleware.utils.ItineraryUtils;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
@@ -190,8 +191,11 @@ public class TravelerLocator {
             double distanceToLegDestination = getDistance(travelerPosition.currentPosition, legDestination);
 
             if (distanceToLastShapeCoords < distanceToLegDestination) {
-                // Issue an end-of-routing step
-                Step endOfRoutingStep = createEndOfRoutingStep(legPositions);
+                // Issue an leg end-of-routing step
+                Step endOfRoutingStep = createEndOfRoutingStep(
+                    legPositions,
+                    ItineraryUtils.isBusLeg(travelerPosition.nextLeg) ? "bus stop" : "destination"
+                );
                 return new OnTrackInstruction(
                     getDistance(travelerPosition.currentPosition, new Coordinates(endOfRoutingStep)),
                     endOfRoutingStep,
@@ -580,12 +584,13 @@ public class TravelerLocator {
     /**
      * Creates a special end-of-routing step to instruct that no further routing instructions are available.
      */
-    private static Step createEndOfRoutingStep(List<Coordinates> legPositions) {
+    private static Step createEndOfRoutingStep(List<Coordinates> legPositions, String locationName) {
         Coordinates lastShapeCoordinate = legPositions.get(legPositions.size() - 2);
         Step step = new Step();
         step.lat = lastShapeCoordinate.lat;
         step.lon = lastShapeCoordinate.lon;
         step.relativeDirection = Step.END_OF_ROUTING;
+        step.streetName = locationName;
         return step;
     }
 

--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/OnTrackInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/OnTrackInstruction.java
@@ -67,7 +67,7 @@ public class OnTrackInstruction extends SelfLegInstruction {
         if (hasInstruction()) {
             if (legStep != null) {
                 if (legStep.isEndOfRouting()) {
-                    // Hacky - The kind of place is stored in streetName.
+                    // Hacky - The kind of place will either be 'bus stop' or 'destination' and is stored in streetName.
                     return String.format(TRIP_INSTRUCTION_END_OF_ROUTING, legStep.streetName);
                 } else {
                     String instruction = legStep.relativeDirection.equals(Step.DEPART)

--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/OnTrackInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/OnTrackInstruction.java
@@ -16,7 +16,7 @@ public class OnTrackInstruction extends SelfLegInstruction {
     public static final String TRIP_INSTRUCTION_ARRIVED_PREFIX = "ARRIVED: ";
 
     /** Generic text when arriving at the end of routing. */
-    public static final String TRIP_INSTRUCTION_END_OF_ROUTING = "Your destination is in the vicinity.";
+    public static final String TRIP_INSTRUCTION_END_OF_ROUTING = "Your %s is in the vicinity.";
 
     public OnTrackInstruction(boolean isDestination, double distance, Locale locale) {
         this.distance = distance;
@@ -53,11 +53,12 @@ public class OnTrackInstruction extends SelfLegInstruction {
     }
 
     /**
-     * Build on track instruction based on step instructions and location. e.g.
+     * Build on track instruction based on step instructions and location. e.g.:
      * <p>
      * "UPCOMING: CONTINUE on Langley Drive"
      * "IMMEDIATE: RIGHT on service road"
      * "ARRIVED: Gwinnett Justice Center (Central)"
+     * "Your destination/bus stop is in the vicinity."
      * <p>
      * TODO: Internationalization and refinements to these generated instructions with input from the mobile app team.
      */
@@ -66,7 +67,8 @@ public class OnTrackInstruction extends SelfLegInstruction {
         if (hasInstruction()) {
             if (legStep != null) {
                 if (legStep.isEndOfRouting()) {
-                    return TRIP_INSTRUCTION_END_OF_ROUTING;
+                    // Hacky - The kind of place is stored in streetName.
+                    return String.format(TRIP_INSTRUCTION_END_OF_ROUTING, legStep.streetName);
                 } else {
                     String instruction = legStep.relativeDirection.equals(Step.DEPART)
                         ? "Head " + legStep.absoluteDirection

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -81,7 +81,7 @@ import static org.opentripplanner.middleware.triptracker.ManageTripTracking.setO
 import static org.opentripplanner.middleware.triptracker.instruction.OnTrackInstruction.TRIP_INSTRUCTION_END_OF_ROUTING;
 import static org.opentripplanner.middleware.utils.GeometryUtils.createPoint;
 
-public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
+class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
 
     private static OtpUser soloOtpUser;
     private static TrackedJourney trackedJourney;
@@ -89,6 +89,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
     private static Itinerary multiLegItinerary;
     private static Itinerary walkToVoterRegCenterItinerary;
     private static Itinerary walkToBus20;
+    private static Itinerary walkToBus12;
     private static Itinerary arrivingOnBus40;
 
     private static final String ROUTE_PATH = "api/secure/monitoredtrip/";
@@ -121,6 +122,10 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         );
         walkToBus20 = JsonUtils.getPOJOFromJSON(
             CommonTestUtils.getTestResourceAsString("controllers/api/walk-to-bus-20.json"),
+            Itinerary.class
+        );
+        walkToBus12 = JsonUtils.getPOJOFromJSON(
+            CommonTestUtils.getTestResourceAsString("controllers/api/walk-to-bus-12.json"),
             Itinerary.class
         );
         arrivingOnBus40 = JsonUtils.getPOJOFromJSON(
@@ -478,7 +483,7 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
                 new TraceData()
                     .withPosition(pointNearEndOfSidewalk)
                     .withTripStatus(TripStatus.COMPLETED)
-                    .withExpectedInstruction(TRIP_INSTRUCTION_END_OF_ROUTING)
+                    .withExpectedInstruction("Your destination is in the vicinity.")
             ),
             Arguments.of(
                 "Arrival instruction when destination is away from sidewalk",
@@ -486,7 +491,15 @@ public class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
                 new TraceData()
                     .withPosition(pointPastEndOfSidewalk)
                     .withTripStatus(TripStatus.COMPLETED)
-                    .withExpectedInstruction(TRIP_INSTRUCTION_END_OF_ROUTING)
+                    .withExpectedInstruction("Your destination is in the vicinity.")
+            ),
+            Arguments.of(
+                "Arrival at bus stop instruction when bus stop farther from end-of-leg",
+                walkToBus12,
+                new TraceData()
+                    .withPosition(new Coordinates(33.78118173054279, -84.3867252767086))
+                    .withTripStatus(TripStatus.AHEAD_OF_SCHEDULE)
+                    .withExpectedInstruction("Your bus stop is in the vicinity.")
             ),
             Arguments.of(
                 "Deviated significantly from nearest step should still produce walk instruction",

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -554,7 +554,7 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                     .withExpectedInstruction("Wait 40 minutes for your bus, route 40, scheduled at 6:41 AM (On time)")
             ),
             Arguments.of(
-                "Arrive at bus stop where the walk geometry is so the stop is farther than the last walk shape. Should produce a wait-for-bus instruction, not 'destination in vicinity'.",
+                "Arrive at bus stop where the walk geometry is so the stop is farther than the last walk shape. Should produce a bus-stop-in-vicinity instruction, not 'destination in vicinity'.",
                 walkToBus12,
                 0,
                 new TraceData()

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -45,7 +45,6 @@ import static org.opentripplanner.middleware.triptracker.ManageLegTraversal.getS
 import static org.opentripplanner.middleware.triptracker.ManageLegTraversal.interpolatePoints;
 import static org.opentripplanner.middleware.triptracker.TravelerLocator.getNextOrClosestWayPoint;
 import static org.opentripplanner.middleware.triptracker.TravelerLocator.isWithinExclusionZone;
-import static org.opentripplanner.middleware.triptracker.instruction.OnTrackInstruction.TRIP_INSTRUCTION_END_OF_ROUTING;
 import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.NO_INSTRUCTION;
 import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.TRIP_INSTRUCTION_UPCOMING_RADIUS;
 import static org.opentripplanner.middleware.utils.ConfigUtils.DEFAULT_ENV;
@@ -70,11 +69,12 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
     private static Itinerary walkToBusTransition;
     private static Itinerary walkToBus20;
     private static Itinerary walkToBus10B;
+    private static Itinerary walkToBus12;
 
     private static final Locale locale = Locale.US;
 
     @BeforeAll
-    public static void setUp() throws IOException {
+    static void setUp() throws IOException {
         // Load default env.yml configuration.
         ConfigUtils.loadConfig(DEFAULT_ENV);
 
@@ -126,6 +126,10 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
         );
         walkToBus10B = JsonUtils.getPOJOFromJSON(
             CommonTestUtils.getTestResourceAsString("controllers/api/walk-to-bus-10B.json"),
+            Itinerary.class
+        );
+        walkToBus12 = JsonUtils.getPOJOFromJSON(
+            CommonTestUtils.getTestResourceAsString("controllers/api/walk-to-bus-12.json"),
             Itinerary.class
         );
 
@@ -423,7 +427,7 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                 legToDestinationAwayFromSidewalk,
                 new TraceData()
                     .withPosition(pointNearEndOfSidewalk)
-                    .withExpectedInstruction(TRIP_INSTRUCTION_END_OF_ROUTING)
+                    .withExpectedInstruction("Your destination is in the vicinity.")
             ),
             Arguments.of(
                 "Immediately after departure instruction. Should provide a 'Continue' instruction and not 'No instruction'.",
@@ -548,6 +552,16 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                     .withTripStatus(TripStatus.AHEAD_OF_SCHEDULE)
                     .withInstant(walkToBusTransition.legs.get(1).startTime.toInstant().minus(40, ChronoUnit.MINUTES))
                     .withExpectedInstruction("Wait 40 minutes for your bus, route 40, scheduled at 6:41 AM (On time)")
+            ),
+            Arguments.of(
+                "Arrive at bus stop where the walk geometry is so the stop is farther than the last walk shape. Should produce a wait-for-bus instruction, not 'destination in vicinity'.",
+                walkToBus12,
+                0,
+                new TraceData()
+                    .withPosition(new Coordinates(33.78118173054279, -84.3867252767086))
+                    .withTripStatus(TripStatus.AHEAD_OF_SCHEDULE)
+                    .withInstant(walkToBus12.startTime.toInstant())
+                    .withExpectedInstruction("Your bus stop is in the vicinity.")
             ),
             Arguments.of(
                 "After boarding bus and bus starts moving, but incorrectly produced 'COMPLETED' status.",

--- a/src/test/resources/org/opentripplanner/middleware/controllers/api/walk-to-bus-12.json
+++ b/src/test/resources/org/opentripplanner/middleware/controllers/api/walk-to-bus-12.json
@@ -1,0 +1,265 @@
+{
+  "duration": 535,
+  "startTime": 1756249113000,
+  "endTime": 1756249648000,
+  "walkTime": 188,
+  "transitTime": 0,
+  "waitingTime": 0,
+  "walkDistance": 0,
+  "walkLimitExceeded": false,
+  "elevationLost": 0,
+  "elevationGained": 0,
+  "transfers": 0,
+  "fare": null,
+  "legs": [
+    {
+      "startTime": 1756249113000,
+      "endTime": 1756249200000,
+      "departureDelay": 0,
+      "arrivalDelay": 0,
+      "realTime": false,
+      "distance": 168.27,
+      "mode": "WALK",
+      "interlineWithPreviousLeg": false,
+      "from": {
+        "name": "33.78144, -84.38519",
+        "lon": -84.385193,
+        "lat": 33.7814398,
+        "vertexType": "NORMAL"
+      },
+      "to": {
+        "name": "Midtown Station",
+        "lon": -84.386697,
+        "lat": 33.78111,
+        "vertexType": "TRANSIT",
+        "stop": {
+          "alerts": [],
+          "code": "904800",
+          "gtfsId": "MARTA:81910",
+          "id": "U3RvcDpNQVJUQTo4MTkxMA",
+          "lon": -84.386697,
+          "lat": 33.78111
+        }
+      },
+      "legGeometry": {
+        "points": "w|dmEln`bO@T?b@@bB?Z?l@?L?d@?LN?`@?B??B",
+        "length": 13
+      },
+      "rentedBike": false,
+      "transitLeg": false,
+      "duration": 87,
+      "steps": [
+        {
+          "distance": 137.91,
+          "relativeDirection": "DEPART",
+          "streetName": "10th Street Northeast",
+          "absoluteDirection": "WEST",
+          "stayOn": false,
+          "area": false,
+          "lon": -84.3851875,
+          "lat": 33.7814088
+        },
+        {
+          "distance": 30.36,
+          "relativeDirection": "LEFT",
+          "streetName": "service road",
+          "absoluteDirection": "SOUTH",
+          "stayOn": false,
+          "area": false,
+          "lon": -84.3866782,
+          "lat": 33.781383
+        }
+      ]
+    },
+    {
+      "startTime": 1756249200000,
+      "endTime": 1756249547000,
+      "departureDelay": 0,
+      "arrivalDelay": 66,
+      "realTime": true,
+      "distance": 1510.59,
+      "mode": "BUS",
+      "interlineWithPreviousLeg": false,
+      "from": {
+        "name": "Midtown Station",
+        "lon": -84.386697,
+        "lat": 33.78111,
+        "vertexType": "TRANSIT",
+        "stop": {
+          "alerts": [],
+          "code": "904800",
+          "gtfsId": "MARTA:81910",
+          "id": "U3RvcDpNQVJUQTo4MTkxMA",
+          "lon": -84.386697,
+          "lat": 33.78111
+        }
+      },
+      "to": {
+        "name": "10th St NW at Hirsch St NW",
+        "lon": -84.401956,
+        "lat": 33.781538,
+        "vertexType": "TRANSIT",
+        "stop": {
+          "alerts": [],
+          "code": "905012",
+          "gtfsId": "MARTA:80171",
+          "id": "U3RvcDpNQVJUQTo4MDE3MQ",
+          "lon": -84.401956,
+          "lat": 33.781538
+        }
+      },
+      "legGeometry": {
+        "points": "}zdmEzw`bOdA?BzCq@VYJUHs@J?jB?n@?j@?jA?j@Ar@AT???t@?f@?dAC`A?`ACpAAdADnA?l@??@XBbD@rD?nA@b@ClE?R@z@???B?r@?hA?tB?zC?bCAz@?j@?N???\\?P?l@?hA?l@?b@?BCt@?z@@t@?FAD?D",
+        "length": 57
+      },
+      "transitLeg": true,
+      "duration": 347,
+      "intermediateStops": [
+        {
+          "name": "10th St NE at Williams St",
+          "lon": -84.389733,
+          "lat": 33.781591,
+          "stopId": "U3RvcDpNQVJUQTo4MTAwNQ",
+          "stopCode": "600018"
+        },
+        {
+          "name": "10th St NW at Techwood Dr NW",
+          "lon": -84.392606,
+          "lat": 33.781557,
+          "stopId": "U3RvcDpNQVJUQTo4MTA4Mg",
+          "stopCode": "904350"
+        },
+        {
+          "name": "10th St at Holly St",
+          "lon": -84.396467,
+          "lat": 33.781528,
+          "stopId": "U3RvcDpNQVJUQTo4MTA4Mw",
+          "stopCode": "904285"
+        },
+        {
+          "name": "10th St NW at State St NW",
+          "lon": -84.39975,
+          "lat": 33.781554,
+          "stopId": "U3RvcDpNQVJUQTo4MDI0Mw",
+          "stopCode": "905018"
+        }
+      ],
+      "steps": [],
+      "headsign": "Cumberland Transfer Center",
+      "agency": {
+        "alerts": [],
+        "gtfsId": "MARTA:MARTA",
+        "id": "MARTA:MARTA",
+        "name": "Metropolitan Atlanta Rapid Transit Authority"
+      },
+      "route": {
+        "alerts": [],
+        "color": "FF00FF",
+        "gtfsId": "MARTA:26781",
+        "id": "MARTA:26781",
+        "longName": "Howell Mill Road / Cumberland",
+        "shortName": "12",
+        "textColor": "000000",
+        "type": 3
+      },
+      "trip": {
+        "gtfsId": "MARTA:10737755",
+        "id": "VHJpcDpNQVJUQToxMDczNzc1NQ",
+        "departureStoptime": {
+          "stop": {
+            "id": "U3RvcDpNQVJUQTo4MTkxMA",
+            "gtfsId": "MARTA:81910"
+          },
+          "stopPosition": 1
+        },
+        "arrivalStoptime": {
+          "stop": {
+            "id": "U3RvcDpNQVJUQTo5OTk3MDA4OA",
+            "gtfsId": "MARTA:99970088"
+          },
+          "stopPosition": 44
+        }
+      }
+    },
+    {
+      "startTime": 1756249547000,
+      "endTime": 1756249648000,
+      "departureDelay": 0,
+      "arrivalDelay": 0,
+      "realTime": false,
+      "distance": 183.27,
+      "mode": "WALK",
+      "interlineWithPreviousLeg": false,
+      "from": {
+        "name": "10th St NW at Hirsch St NW",
+        "lon": -84.401956,
+        "lat": 33.781538,
+        "vertexType": "TRANSIT",
+        "stop": {
+          "alerts": [],
+          "code": "905012",
+          "gtfsId": "MARTA:80171",
+          "id": "U3RvcDpNQVJUQTo4MDE3MQ",
+          "lon": -84.401956,
+          "lat": 33.781538
+        }
+      },
+      "to": {
+        "name": "492 Lynch Avenue NW, Atlanta, GA, USA",
+        "lon": -84.4031749,
+        "lat": 33.7821839,
+        "vertexType": "NORMAL"
+      },
+      "legGeometry": {
+        "points": "q}dmEfwcbO@??n@?^O??bA?F?HuBD?p@?T",
+        "length": 11
+      },
+      "rentedBike": false,
+      "transitLeg": false,
+      "duration": 101,
+      "steps": [
+        {
+          "distance": 76.49,
+          "relativeDirection": "DEPART",
+          "streetName": "10th Street Northwest",
+          "absoluteDirection": "WEST",
+          "stayOn": false,
+          "area": false,
+          "lon": -84.4019561,
+          "lat": 33.7815206
+        },
+        {
+          "distance": 8.32,
+          "relativeDirection": "CONTINUE",
+          "streetName": "path",
+          "absoluteDirection": "WEST",
+          "stayOn": false,
+          "area": false,
+          "lon": -84.4026912,
+          "lat": 33.7816031
+        },
+        {
+          "distance": 65.65,
+          "relativeDirection": "RIGHT",
+          "streetName": "Northwest Center Street",
+          "absoluteDirection": "NORTH",
+          "stayOn": false,
+          "area": false,
+          "lon": -84.4027813,
+          "lat": 33.7816029
+        },
+        {
+          "distance": 32.8,
+          "relativeDirection": "LEFT",
+          "streetName": "Lynch Avenue Northwest",
+          "absoluteDirection": "WEST",
+          "stayOn": false,
+          "area": false,
+          "lon": -84.4028197,
+          "lat": 33.7821924
+        }
+      ]
+    }
+  ],
+  "alerts": []
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

When a traveler approaches a leg's destination so that the ending point for the leg's geometry is closer to the leg's destination, a "destination in vicinity" instruction was incorrectly shown and the trip status was incorrectly shown as completed ended. This PR fixes that.
