### PR TITLE
Update User Preferred Language in Auth0 Metadata

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -11,6 +11,7 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.opentripplanner.middleware.bugsnag.BugsnagReporter;
 import org.opentripplanner.middleware.models.AbstractUser;
+import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.persistence.TypedPersistence;
 import org.opentripplanner.middleware.utils.HttpResponseValues;
 import org.opentripplanner.middleware.utils.HttpUtils;
@@ -23,6 +24,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.HashMap;
+import java.util.Objects;
 
 import static com.mongodb.client.model.Filters.eq;
 import static org.opentripplanner.middleware.utils.ConfigUtils.getConfigPropertyAsText;
@@ -135,6 +138,25 @@ public class Auth0Users {
         }
         return null;
     }
+
+    public static User updateAuth0Language(OtpUser user, OtpUser preExistingUser) {
+        if (!Objects.equals(user.preferredLocale, preExistingUser.preferredLocale)) {
+            try {
+                Map<String, Object> userMetadata = new HashMap<>();
+                userMetadata.put("lang", user.preferredLocale);
+                User auth0user = new User();
+                auth0user.setUserMetadata(userMetadata);
+                return getManagementAPI()
+                        .users()
+                        .update(user.auth0UserId, auth0user)
+                        .execute();
+            } catch (Auth0Exception e) {
+                BugsnagReporter.reportErrorToBugsnag("Could not update metadata", e);
+                return null;
+            }
+        }
+        return null;
+    };
 
     /**
      * Method to trigger an Auth0 job to resend a verification email. Returns an Auth0 {@link Job} which can be used to

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -150,6 +150,8 @@ public class Auth0Users {
             try {
                 Map<String, Object> userMetadata = new HashMap<>();
                 userMetadata.put("lang", user.preferredLocale);
+                // Passing the entire user here will return a 403, because Auth0 sees it as you overwriting
+                // read-only fields, so create a blank user and give it only the data we want to update.
                 User auth0user = new User();
                 auth0user.setUserMetadata(userMetadata);
                 getManagementAPI()

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -139,7 +139,13 @@ public class Auth0Users {
         return null;
     }
 
+    /**
+     * Method to update a user's Auth0 metadata to include their preferred language as set in OTP-RR. This will
+     * ensure that account emails (such as email verification and reset password emails) are sent in the correct
+     * language.
+     */
     public static User updateAuth0Language(OtpUser user, OtpUser preExistingUser) {
+        // Only call API if the user language has changed
         if (!Objects.equals(user.preferredLocale, preExistingUser.preferredLocale)) {
             try {
                 Map<String, Object> userMetadata = new HashMap<>();

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -148,12 +148,10 @@ public class Auth0Users {
         // Only call API if the user language has changed
         if (!Objects.equals(user.preferredLocale, preExistingUser.preferredLocale)) {
             try {
-                Map<String, Object> userMetadata = new HashMap<>();
-                userMetadata.put("lang", user.preferredLocale);
                 // Passing the entire user here will return a 403, because Auth0 sees it as you overwriting
                 // read-only fields, so create a blank user and give it only the data we want to update.
                 User auth0user = new User();
-                auth0user.setUserMetadata(userMetadata);
+                auth0user.setUserMetadata(Map.of("lang", user.preferredLocale));
                 getManagementAPI()
                         .users()
                         .update(user.auth0UserId, auth0user)

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -144,7 +144,7 @@ public class Auth0Users {
      * ensure that account emails (such as email verification and reset password emails) are sent in the correct
      * language.
      */
-    public static User updateAuth0Language(OtpUser user, OtpUser preExistingUser) {
+    public static void updateAuth0Language(OtpUser user, OtpUser preExistingUser) {
         // Only call API if the user language has changed
         if (!Objects.equals(user.preferredLocale, preExistingUser.preferredLocale)) {
             try {
@@ -152,16 +152,14 @@ public class Auth0Users {
                 userMetadata.put("lang", user.preferredLocale);
                 User auth0user = new User();
                 auth0user.setUserMetadata(userMetadata);
-                return getManagementAPI()
+                getManagementAPI()
                         .users()
                         .update(user.auth0UserId, auth0user)
                         .execute();
             } catch (Auth0Exception e) {
                 BugsnagReporter.reportErrorToBugsnag("Could not update metadata", e);
-                return null;
             }
         }
-        return null;
     };
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
+++ b/src/main/java/org/opentripplanner/middleware/auth/Auth0Users.java
@@ -140,6 +140,26 @@ public class Auth0Users {
     }
 
     /**
+     * Auth0 supported locale codes occasionally differ from the ones used in OTP-RR.
+     * See https://auth0.com/docs/customize/internationalization-and-localization/universal-login-internationalization
+     */
+    public static String getAuth0Locale(String locale) {
+        if (locale == null) {
+            return "en";
+        }
+        switch (locale) {
+            case "fr":
+                return "fr-FR";
+            case "zh-Hant":
+                return "zh-TW";
+            case "zh-Hans":
+                return "zh-CN";
+            default:
+                return locale;
+        }
+    }
+
+    /**
      * Method to update a user's Auth0 metadata to include their preferred language as set in OTP-RR. This will
      * ensure that account emails (such as email verification and reset password emails) are sent in the correct
      * language.
@@ -151,7 +171,7 @@ public class Auth0Users {
                 // Passing the entire user here will return a 403, because Auth0 sees it as you overwriting
                 // read-only fields, so create a blank user and give it only the data we want to update.
                 User auth0user = new User();
-                auth0user.setUserMetadata(Map.of("lang", user.preferredLocale));
+                auth0user.setUserMetadata(Map.of("lang", getAuth0Locale(user.preferredLocale)));
                 getManagementAPI()
                         .users()
                         .update(user.auth0UserId, auth0user)

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.middleware.controllers.api;
 
+
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.mgmt.jobs.Job;
 import com.auth0.json.mgmt.users.User;
@@ -22,6 +23,7 @@ import spark.Response;
 
 import static io.github.manusant.ss.descriptor.MethodDescriptor.path;
 import static org.opentripplanner.middleware.auth.Auth0Users.deleteAuth0User;
+import static org.opentripplanner.middleware.auth.Auth0Users.updateAuth0Language;
 import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
 
 /**
@@ -35,7 +37,7 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
     public static final String VERIFICATION_EMAIL_PATH = "/verification-email";
 
     /**
-     * Constructor that child classes can access to setup persistence and API route.
+     * Constructor that child classes can access to set up persistence and API route.
      */
     public AbstractUserController(String apiPrefix, TypedPersistence<U> persistence, String resource) {
         super(apiPrefix, persistence, resource);
@@ -177,6 +179,7 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
     @Override
     U preUpdateHook(U user, U preExistingUser, Request req) {
         Auth0Users.validateExistingUser(user, preExistingUser, req, this.persistence);
+        updateAuth0Language((OtpUser) user, (OtpUser) preExistingUser);
         if (user instanceof OtpUser) {
             OtpUser otpUser = (OtpUser) user;
             OtpUser existingOtpUser = (OtpUser) preExistingUser;

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.middleware.controllers.api;
 
-
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.mgmt.jobs.Job;
 import com.auth0.json.mgmt.users.User;

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/AbstractUserController.java
@@ -178,10 +178,10 @@ public abstract class AbstractUserController<U extends AbstractUser> extends Api
     @Override
     U preUpdateHook(U user, U preExistingUser, Request req) {
         Auth0Users.validateExistingUser(user, preExistingUser, req, this.persistence);
-        updateAuth0Language((OtpUser) user, (OtpUser) preExistingUser);
         if (user instanceof OtpUser) {
             OtpUser otpUser = (OtpUser) user;
             OtpUser existingOtpUser = (OtpUser) preExistingUser;
+            updateAuth0Language(otpUser, existingOtpUser);
             if (!otpUser.storeTripHistory && existingOtpUser.storeTripHistory) {
                 // If an OTP user no longer wants their trip history stored, remove all history from MongoDB.
                 ConnectedDataManager.removeUsersTripHistory(otpUser.id);

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
@@ -23,11 +23,7 @@ import org.opentripplanner.middleware.tripmonitor.TrustedCompanion;
 import org.opentripplanner.middleware.utils.HttpResponseValues;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -59,6 +55,7 @@ public class OtpUserControllerTest extends OtpMiddlewareTestEnvironment {
     private static OtpUser relatedUserFour;
     private static OtpUser dependentUserFour;
     private static final String NICKNAME = "my-trusted-companion";
+    private static User auth0User = new User();
 
     @BeforeAll
     public static void setUp() throws Exception {
@@ -83,8 +80,9 @@ public class OtpUserControllerTest extends OtpMiddlewareTestEnvironment {
         dependentUserThree = PersistenceTestUtils.createUser(ApiTestUtils.generateEmailAddress("dependent-three"));
 
         relatedUserFour = PersistenceTestUtils.createUser(ApiTestUtils.generateEmailAddress("related-user-four"));
+        relatedUserFour.preferredLocale = "fr";
 
-        User auth0User = createAuth0UserForEmail(relatedUserFour.email, TEMP_AUTH0_USER_PASSWORD);
+        auth0User = createAuth0UserForEmail(relatedUserFour.email, TEMP_AUTH0_USER_PASSWORD);
         relatedUserFour.auth0UserId = auth0User.getId();
         Persistence.otpUsers.replace(relatedUserFour.id, relatedUserFour);
 
@@ -292,6 +290,20 @@ public class OtpUserControllerTest extends OtpMiddlewareTestEnvironment {
         assertEquals(RelatedUser.RelatedUserStatus.INVALID, updatedTripWithCompanionAndObserver.companion.status);
         assertFalse(updatedTripWithCompanionAndObserver.observers.isEmpty());
         assertEquals(RelatedUser.RelatedUserStatus.INVALID, updatedTripWithCompanionAndObserver.observers.get(0).status);
+    }
+
+    @Test
+    void canPassUserMetadataToAuth0() throws Exception {
+        Map<String, Object> relatedUserFourMetadata = new HashMap<>();
+        relatedUserFourMetadata.put("lang", relatedUserFour.preferredLocale);
+        auth0User.setUserMetadata(relatedUserFourMetadata);
+        makeRequest(
+                String.format("api/secure/user/%s", relatedUserFour.id),
+                JsonUtils.toJson(relatedUserFour),
+                getMockHeaders(relatedUserFour),
+                HttpMethod.PUT
+        );
+        assertTrue(auth0User.getUserMetadata().containsValue(relatedUserFour.preferredLocale));
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.auth.Auth0Connection.restoreDefaultAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Connection.setAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Users.createAuth0UserForEmail;
+import static org.opentripplanner.middleware.auth.Auth0Users.getUserByEmail;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.TEMP_AUTH0_USER_PASSWORD;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.getMockHeaders;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.makeGetRequest;
@@ -55,7 +56,6 @@ public class OtpUserControllerTest extends OtpMiddlewareTestEnvironment {
     private static OtpUser relatedUserFour;
     private static OtpUser dependentUserFour;
     private static final String NICKNAME = "my-trusted-companion";
-    private static User auth0User = new User();
 
     @BeforeAll
     public static void setUp() throws Exception {
@@ -80,9 +80,8 @@ public class OtpUserControllerTest extends OtpMiddlewareTestEnvironment {
         dependentUserThree = PersistenceTestUtils.createUser(ApiTestUtils.generateEmailAddress("dependent-three"));
 
         relatedUserFour = PersistenceTestUtils.createUser(ApiTestUtils.generateEmailAddress("related-user-four"));
-        relatedUserFour.preferredLocale = "fr";
 
-        auth0User = createAuth0UserForEmail(relatedUserFour.email, TEMP_AUTH0_USER_PASSWORD);
+        User auth0User = createAuth0UserForEmail(relatedUserFour.email, TEMP_AUTH0_USER_PASSWORD);
         relatedUserFour.auth0UserId = auth0User.getId();
         Persistence.otpUsers.replace(relatedUserFour.id, relatedUserFour);
 
@@ -294,16 +293,24 @@ public class OtpUserControllerTest extends OtpMiddlewareTestEnvironment {
 
     @Test
     void canPassUserMetadataToAuth0() throws Exception {
-        Map<String, Object> relatedUserFourMetadata = new HashMap<>();
-        relatedUserFourMetadata.put("lang", relatedUserFour.preferredLocale);
-        auth0User.setUserMetadata(relatedUserFourMetadata);
+        relatedUserFour.preferredLocale = "fr";
+
+        // Confirm the user as currently exists in Auth0 does not contain metadata
+        User auth0UserProfile = getUserByEmail(relatedUserFour.email, false);
+        assertNotNull(auth0UserProfile);
+        assertNull(auth0UserProfile.getUserMetadata());
+
         makeRequest(
                 String.format("api/secure/user/%s", relatedUserFour.id),
                 JsonUtils.toJson(relatedUserFour),
                 getMockHeaders(relatedUserFour),
                 HttpMethod.PUT
         );
-        assertTrue(auth0User.getUserMetadata().containsValue(relatedUserFour.preferredLocale));
+
+        // Confirm that the same user now has language metadata set correctly
+        User updatedAuth0UserProfile = getUserByEmail(relatedUserFour.email, false);
+        assertNotNull(updatedAuth0UserProfile);
+        assertEquals("fr", updatedAuth0UserProfile.getUserMetadata().get("lang"));
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
@@ -23,7 +23,11 @@ import org.opentripplanner.middleware.tripmonitor.TrustedCompanion;
 import org.opentripplanner.middleware.utils.HttpResponseValues;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
-import java.util.*;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -301,16 +305,16 @@ public class OtpUserControllerTest extends OtpMiddlewareTestEnvironment {
         assertNull(auth0UserProfile.getUserMetadata());
 
         makeRequest(
-                String.format("api/secure/user/%s", relatedUserFour.id),
-                JsonUtils.toJson(relatedUserFour),
-                getMockHeaders(relatedUserFour),
-                HttpMethod.PUT
+            String.format("api/secure/user/%s", relatedUserFour.id),
+            JsonUtils.toJson(relatedUserFour),
+            getMockHeaders(relatedUserFour),
+            HttpMethod.PUT
         );
 
         // Confirm that the same user now has language metadata set correctly
         User updatedAuth0UserProfile = getUserByEmail(relatedUserFour.email, false);
         assertNotNull(updatedAuth0UserProfile);
-        assertEquals("fr", updatedAuth0UserProfile.getUserMetadata().get("lang"));
+        assertEquals(relatedUserFour.preferredLocale, updatedAuth0UserProfile.getUserMetadata().get("lang"));
     }
 
     /**

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/OtpUserControllerTest.java
@@ -40,6 +40,7 @@ import static org.opentripplanner.middleware.auth.Auth0Connection.restoreDefault
 import static org.opentripplanner.middleware.auth.Auth0Connection.setAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Users.createAuth0UserForEmail;
 import static org.opentripplanner.middleware.auth.Auth0Users.getUserByEmail;
+import static org.opentripplanner.middleware.auth.Auth0Users.getAuth0Locale;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.TEMP_AUTH0_USER_PASSWORD;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.getMockHeaders;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.makeGetRequest;
@@ -314,7 +315,7 @@ public class OtpUserControllerTest extends OtpMiddlewareTestEnvironment {
         // Confirm that the same user now has language metadata set correctly
         User updatedAuth0UserProfile = getUserByEmail(relatedUserFour.email, false);
         assertNotNull(updatedAuth0UserProfile);
-        assertEquals(relatedUserFour.preferredLocale, updatedAuth0UserProfile.getUserMetadata().get("lang"));
+        assertEquals(getAuth0Locale(relatedUserFour.preferredLocale), updatedAuth0UserProfile.getUserMetadata().get("lang"));
     }
 
     /**


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [x] The description lists all relevant PRs included in this release _(remove this if not merging to master)_

### Description
Creates a new method `updateAuth0Language` that takes the user's new `preferredLanguage` as set in the application, and updates it in the Auth0 user metadata. This is in order to send account emails (such as password reset emails) to users in their preferred language (currently all emails are sent in English)
