### PR TITLE
Restored name to Stop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM openjdk:11
+FROM amazoncorretto:11
 WORKDIR /middleware
 
 # Grab latest dev build

--- a/src/main/java/org/opentripplanner/middleware/otp/response/Stop.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/response/Stop.java
@@ -10,6 +10,11 @@ import org.opentripplanner.middleware.utils.Coordinates;
 public class Stop implements ConvertsToCoordinates, Cloneable {
 
     /**
+     * Name of the stop.
+     */
+    public String name;
+
+    /**
      * Stop code which is visible at the stop.
      */
     public String code;

--- a/src/main/resources/latest-spark-swagger-output.yaml
+++ b/src/main/resources/latest-spark-swagger-output.yaml
@@ -2474,6 +2474,8 @@ definitions:
   Stop:
     type: "object"
     properties:
+      name:
+        type: "string"
       code:
         type: "string"
       gtfsId:


### PR DESCRIPTION
Name is now available for intermediate stops

### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Restored the name parameter to Stop so it can be used in intermediate stops.
ALSO... replaced retired base image `openjdk:11` with `amazoncorretto:11`
