### PR TITLE
fix(CheckMonitoredTrip): Offset clone of saved itin after unsnoozing.

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -28,8 +28,10 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -787,7 +789,15 @@ public class CheckMonitoredTrip implements Runnable {
         if (trip.snoozed) {
             if (shouldUnsnoozeTrip()) {
                 // Clear previous matching itinerary as we want to start afresh.
-                previousMatchingItinerary = null;
+                previousMatchingItinerary = matchingItinerary = trip.itinerary.clone();
+
+                // TODO refactor same formula as in CheckMonitoredTrip
+                computeTargetZonedDateTime();
+                //ZonedDateTime targetZonedDateTime = trip.tripZonedDateTime(LocalDate.parse(targetZonedDateTime, DateTimeFormatter.ISO_LOCAL_DATE));
+                long offsetMillis = targetZonedDateTime.toInstant().toEpochMilli() - matchingItinerary.getScheduledStartTimeEpochMillis();
+                // update overall itinerary and leg start/end times by adding offset
+                matchingItinerary.offsetTimes(offsetMillis);
+
                 // unsnooze trip now, for cases where the next itinerary isn't calculated
                 trip.snoozed = false;
             } else {

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -102,7 +102,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         .withYear(2025)
         .withMonth(10)
         .withDayOfMonth(16)
-        .withHour(12)
+        .withHour(0)
         .withMinute(0)
         .withSecond(17)
         .withNano(0);
@@ -144,6 +144,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
     @Test
     void canMonitorTripAtMidNight() throws Exception {
+        //DateTimeUtils.useFixedClockAt(THURS_20251016_0000.minusHours(2));
         DateTimeUtils.useFixedClockAt(THURS_20251016_0000);
 
         // Mock empty OTP response to simulate trip not possible.
@@ -167,8 +168,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip.wednesday = true;
         monitoredTrip.thursday = true;
         monitoredTrip.friday = true;
-        monitoredTrip.saturday = false;
-        monitoredTrip.sunday = false;
+        monitoredTrip.saturday = true;
+        monitoredTrip.sunday = true;
         monitoredTrip.excludeFederalHolidays = true;
         monitoredTrip.isActive = true;
         monitoredTrip.itineraryExistence.monday = new ItineraryExistence.ItineraryExistenceResult();
@@ -186,6 +187,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip.itineraryExistence.saturday.invalidDates.add("2025-05-31");
         monitoredTrip.itineraryExistence.sunday = new ItineraryExistence.ItineraryExistenceResult();
         monitoredTrip.itineraryExistence.sunday.invalidDates.add("2025-06-01");
+        monitoredTrip.snoozed = true;
+        monitoredTrip.journeyState.lastCheckedEpochMillis = THURS_20251016_0000.minusDays(1).toInstant().toEpochMilli();
 
         Persistence.monitoredTrips.create(monitoredTrip);
         CheckMonitoredTrip checkMonitoredTrip = new CheckMonitoredTrip(monitoredTrip, () -> mockResponse);


### PR DESCRIPTION
Fix to offset the cloned saved itinerary time after unsnoozing.
