### PR TITLE
Fix next monitored day for late night trips

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -568,12 +568,16 @@ public class MonitoredTrip extends Model {
      * (Itinerary existence is not being checked, assuming that clients prevent monitoring days when a trip doesn't exist.)
      */
     public ZonedDateTime findEarliestTargetDate(ZonedDateTime fromDateTime) {
+        ZonedDateTime itineraryStartTimeToday = makeOtpZonedDateTime(
+            fromDateTime,
+            itinerary.startTime.toInstant()
+        );
         ZonedDateTime itineraryEndTimeToday = makeOtpZonedDateTime(
             fromDateTime,
             itinerary.endTime.toInstant()
         );
 
-        int daysToAdd = fromDateTime.toInstant().isAfter(itineraryEndTimeToday.toInstant()) ? 1 : 0;
+        int daysToAdd = fromDateTime.isAfter(itineraryStartTimeToday) && fromDateTime.isAfter(itineraryEndTimeToday) ? 1 : 0;
 
         ZonedDateTime nextStartDay = makeOtpZonedDateTime(
             fromDateTime.plusDays(daysToAdd),

--- a/src/main/java/org/opentripplanner/middleware/otp/response/Leg.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/response/Leg.java
@@ -167,11 +167,15 @@ public class Leg implements Cloneable {
         Leg cloned = (Leg) super.clone();
         cloned.from = this.from.clone();
         cloned.to = this.to.clone();
-        cloned.steps = new ArrayList<>();
-        for (Step step : this.steps) {
-            cloned.steps.add(step.clone());
+        if (this.steps != null) {
+            cloned.steps = new ArrayList<>();
+            for (Step step : this.steps) {
+                cloned.steps.add(step.clone());
+            }
         }
-        cloned.legGeometry = this.legGeometry.clone();
+        if (this.legGeometry != null) {
+            cloned.legGeometry = this.legGeometry.clone();
+        }
         return cloned;
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/otp/response/Leg.java
+++ b/src/main/java/org/opentripplanner/middleware/otp/response/Leg.java
@@ -165,16 +165,16 @@ public class Leg implements Cloneable {
     @Override
     protected Leg clone() throws CloneNotSupportedException {
         Leg cloned = (Leg) super.clone();
-        cloned.from = this.from.clone();
-        cloned.to = this.to.clone();
-        if (this.steps != null) {
+        cloned.from = from.clone();
+        cloned.to = to.clone();
+        if (steps != null) {
             cloned.steps = new ArrayList<>();
-            for (Step step : this.steps) {
+            for (Step step : steps) {
                 cloned.steps.add(step.clone());
             }
         }
-        if (this.legGeometry != null) {
-            cloned.legGeometry = this.legGeometry.clone();
+        if (legGeometry != null) {
+            cloned.legGeometry = legGeometry.clone();
         }
         return cloned;
     }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -16,7 +16,10 @@ import org.opentripplanner.middleware.models.MobilityProfileLite;
 import org.opentripplanner.middleware.models.RelatedUser;
 import org.opentripplanner.middleware.models.TrackedJourney;
 import org.opentripplanner.middleware.otp.OtpGraphQLVariables;
+import org.opentripplanner.middleware.otp.response.EncodedPolyline;
 import org.opentripplanner.middleware.otp.response.Leg;
+import org.opentripplanner.middleware.otp.response.Place;
+import org.opentripplanner.middleware.otp.response.TripPlan;
 import org.opentripplanner.middleware.testutils.ApiTestUtils;
 import org.opentripplanner.middleware.testutils.OtpMiddlewareTestEnvironment;
 import org.opentripplanner.middleware.testutils.OtpTestUtils;
@@ -167,6 +170,63 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         assertTrue(checkMonitoredTrip.notifications.isEmpty());
         assertEquals(TRIP_UPCOMING, checkMonitoredTrip.journeyState.tripStatus);
         PersistenceTestUtils.deleteMonitoredTrip(monitoredTrip);
+    }
+
+    @ParameterizedTest
+    @MethodSource("tripEndingPastMidnightCases")
+    void canMonitorTripEndingPastMidNight(
+        String startDate,
+        String startTime,
+        String endDate,
+        String endTime,
+        String targetDate
+    ) throws Exception {
+        MonitoredTrip trip = new MonitoredTrip();
+
+        Itinerary itinerary = new Itinerary();
+        ZonedDateTime start = DateTimeUtils.makeOtpZonedDateTime(startDate, startTime);
+        ZonedDateTime end = DateTimeUtils.makeOtpZonedDateTime(endDate, endTime);
+        itinerary.startTime = Date.from(start.toInstant());
+        itinerary.endTime = Date.from(end.toInstant());
+        Leg walkLeg = new Leg();
+        walkLeg.mode = "WALK";
+        walkLeg.from = new Place();
+        walkLeg.to = new Place();
+        walkLeg.legGeometry = new EncodedPolyline();
+        walkLeg.steps = new ArrayList<>();
+        walkLeg.transitLeg = false;
+        walkLeg.realTime = false;
+        itinerary.legs = List.of(walkLeg);
+        trip.itinerary = itinerary;
+        trip.updateAllDaysOfWeek(true);
+        trip.itineraryExistence = new ItineraryExistence();
+        trip.itineraryExistence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
+        trip.itineraryExistence.thursday = new ItineraryExistence.ItineraryExistenceResult();
+
+        DateTimeUtils.useFixedClockAt(start.minusMinutes(10));
+
+        Persistence.monitoredTrips.create(trip);
+        OtpResponse response = new OtpResponse();
+        response.plan = new TripPlan();
+        response.plan.itineraries = List.of(itinerary);
+        CheckMonitoredTrip checkMonitoredTrip = new CheckMonitoredTrip(trip, () -> response);
+        checkMonitoredTrip.run();
+
+        MonitoredTrip updated = Persistence.monitoredTrips.getById(trip.id);
+        assertEquals(TRIP_UPCOMING, checkMonitoredTrip.journeyState.tripStatus);
+        assertEquals(targetDate, updated.journeyState.targetDate);
+        PersistenceTestUtils.deleteMonitoredTrip(trip);
+    }
+
+    private static Stream<Arguments> tripEndingPastMidnightCases() {
+        return Stream.of(
+            // Wednesday
+            Arguments.of("2025-10-01", "23:50", "2025-10-02", "00:00", "2025-10-01"),
+            // Thursday
+            Arguments.of("2025-10-02", "00:00", "2025-10-02", "00:15", "2025-10-02"),
+            // Overlap
+            Arguments.of("2025-10-01", "23:50", "2025-10-02", "00:15", "2025-10-01")
+        );
     }
 
     @Test

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -16,7 +16,6 @@ import org.opentripplanner.middleware.models.MobilityProfileLite;
 import org.opentripplanner.middleware.models.RelatedUser;
 import org.opentripplanner.middleware.models.TrackedJourney;
 import org.opentripplanner.middleware.otp.OtpGraphQLVariables;
-import org.opentripplanner.middleware.otp.response.EncodedPolyline;
 import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.Place;
 import org.opentripplanner.middleware.otp.response.TripPlan;
@@ -192,10 +191,6 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         walkLeg.mode = "WALK";
         walkLeg.from = new Place();
         walkLeg.to = new Place();
-        walkLeg.legGeometry = new EncodedPolyline();
-        walkLeg.steps = new ArrayList<>();
-        walkLeg.transitLeg = false;
-        walkLeg.realTime = false;
         itinerary.legs = List.of(walkLeg);
         trip.itinerary = itinerary;
         trip.updateAllDaysOfWeek(true);


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes an incorrect calculation of the target date for late night monitored trips that start just before midnight and end after midnight.
