### PR TITLE
Keep Rerouted Itinerary

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -464,7 +464,7 @@ public class CheckMonitoredTrip implements Runnable {
      * Generate the appropriate OTP query params for the trip for the current check by replacing the date query
      * parameter with the appropriate date.
      */
-    private OtpGraphQLVariables getQueryParamsForTargetZonedDateTime() {
+    public OtpGraphQLVariables getQueryParamsForTargetZonedDateTime() {
         OtpGraphQLVariables params = trip.otp2QueryParams.clone();
         params.date = targetZonedDateTime.format(DEFAULT_DATE_FORMATTER);
         checkForRerouting(params);

--- a/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTrip.java
@@ -477,13 +477,11 @@ public class CheckMonitoredTrip implements Runnable {
      * attributed to the trip.
      */
     public void checkForRerouting(OtpGraphQLVariables params) {
-        if (trip.journeyState.tripStatus == TripStatus.TRIP_ACTIVE) {
-            TrackedJourney trackedJourney = TripTrackingData.getOngoingTrackedJourney(trip.id);
-            if (trackedJourney != null) {
-                String reroutingLocation = trackedJourney.getLastReroutingLocation();
-                if (reroutingLocation != null) {
-                    params.fromPlace = reroutingLocation;
-                }
+        TrackedJourney trackedJourney = TripTrackingData.getOngoingTrackedJourney(trip.id);
+        if (trackedJourney != null) {
+            String reroutingLocation = trackedJourney.getLastReroutingLocation();
+            if (reroutingLocation != null) {
+                params.fromPlace = reroutingLocation;
             }
         }
     }

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -695,6 +695,7 @@ class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
 
         MonitoredTrip rerouteMonitoredTrip = monitoredTrip = createMonitoredTrip(walkToVoterRegCenterItinerary);
         rerouteMonitoredTrip.observers = soloOtpUser.relatedUsers;
+        rerouteMonitoredTrip.leadTimeInMinutes = 10;
         Persistence.monitoredTrips.replace(rerouteMonitoredTrip.id, rerouteMonitoredTrip);
 
         var startTrackingPayload = new StartTrackingPayload();
@@ -706,7 +707,12 @@ class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         var expectedReroutedItinerary = getShortestDuration(mockOtpResponse.get().plan.itineraries);
 
         // Use current time relative to itinerary start (this will affect the computed target date after end tracking).
-        DateTimeUtils.useFixedClockAt(ZonedDateTime.ofInstant(expectedReroutedItinerary.startTime.toInstant().plusSeconds(offsetSeconds), DateTimeUtils.getOtpZoneId()));
+        DateTimeUtils.useFixedClockAt(
+            ZonedDateTime.ofInstant(
+                expectedReroutedItinerary.startTime.toInstant().plusSeconds(offsetSeconds),
+                DateTimeUtils.getOtpZoneId()
+            )
+        );
 
         ManageTripTracking.otpResponseProviderOverride = mockOtpResponse;
         var deviatedPosition = new TrackingLocation(Instant.now(), 33.94412, -83.98899);

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -23,6 +23,7 @@ import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.OtpResponse;
 import org.opentripplanner.middleware.otp.response.Step;
+import org.opentripplanner.middleware.otp.response.TripPlan;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.testutils.ApiTestUtils;
 import org.opentripplanner.middleware.testutils.CommonTestUtils;
@@ -161,6 +162,7 @@ class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         trip.itinerary = itin;
         // Original itinerary time should be populated.
         OtpGraphQLVariables params = new OtpGraphQLVariables();
+        params.fromPlace = itin.legs.get(0).from.toCoordinates().getCoordinates();
         params.time = DateTimeUtils.convertToLocalDateTime(itin.startTime).toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm"));
         trip.otp2QueryParams = params;
         trip.journeyState = new JourneyState();
@@ -725,9 +727,11 @@ class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         long initialDepartedNotificationCount = pollDepartedNotificationCount(rerouteMonitoredTrip);
         assertEquals(1, initialDepartedNotificationCount);
 
-        // Reroute trip from 'deviated' position.
+        // Reroute trip from 'deviated' position (fetch the latest tracked journey data first).
+        trackedJourney = Persistence.trackedJourneys.getById(startTrackingResponse.journeyId);
         var reroutedItinerary = ManageTripTracking.rerouteTrip(
-            new TripTrackingData(rerouteMonitoredTrip, trackedJourney, List.of(deviatedPosition))
+            // Last parameter to TripTrackingData::ctor is not used for rerouting.
+            new TripTrackingData(rerouteMonitoredTrip, trackedJourney, List.of())
         );
         assertEquals(expectedReroutedItinerary.duration, reroutedItinerary.duration);
         TrackedJourney updated = Persistence.trackedJourneys.getById(trackedJourney.id);
@@ -747,13 +751,20 @@ class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         // The current number of departed notifications should not have changed.
         assertEquals(initialDepartedNotificationCount, pollDepartedNotificationCount(rerouteMonitoredTrip));
 
-        OtpGraphQLVariables params = new OtpGraphQLVariables();
-        params.time = "12:31";
-
         MonitoredTrip tripAfterRerouting = Persistence.monitoredTrips.getById(rerouteMonitoredTrip.id);
-        tripAfterRerouting.otp2QueryParams = params;
         Itinerary beforeCheck = tripAfterRerouting.journeyState.matchingItinerary;
-        CheckMonitoredTrip checkMonitoredTrip = new CheckMonitoredTrip(tripAfterRerouting);
+
+        // Set up an itinerary provider that returns the original itinerary of the rerouted itinerary
+        // based on the query param position.
+        RerouteOtpResponseSupplier rerouteOtpResponseSupplier = new RerouteOtpResponseSupplier(
+            deviatedPosition
+        );
+
+        CheckMonitoredTrip checkMonitoredTrip = new CheckMonitoredTrip(
+            tripAfterRerouting,
+            rerouteOtpResponseSupplier::getOtpResponse
+        );
+        rerouteOtpResponseSupplier.setVariableSupplier(checkMonitoredTrip::getQueryParamsForTargetZonedDateTime);
         checkMonitoredTrip.run();
         Itinerary afterCheck = Persistence.monitoredTrips.getById(tripAfterRerouting.id).journeyState.matchingItinerary;
         assertEquals(beforeCheck.duration, afterCheck.duration);
@@ -961,5 +972,33 @@ class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
         var response = makeRequest(UPDATE_TRACKING_TRIP_PATH, JsonUtils.toJson(payload), headers, HttpMethod.POST);
         assertEquals(expectedStatus, response.status);
         return JsonUtils.getPOJOFromJSON(response.responseBody, TrackingResponse.class);
+    }
+
+    /**
+     * Provides an OTP response based on a trip's query params.
+     */
+    private class RerouteOtpResponseSupplier {
+        private final TrackingLocation triggerLocation;
+        private Supplier<OtpGraphQLVariables> variableSupplier;
+
+        public RerouteOtpResponseSupplier(
+            TrackingLocation triggerLocation
+        ) {
+            this.triggerLocation = triggerLocation;
+        }
+
+        public void setVariableSupplier(Supplier<OtpGraphQLVariables> supplier) {
+            this.variableSupplier = supplier;
+        }
+
+        public OtpResponse getOtpResponse() {
+            if (variableSupplier.get().fromPlace.endsWith(new Coordinates(triggerLocation).getCoordinates())) {
+                return mockOtpReroutedPlanResponse().get();
+            }
+            OtpResponse response = new OtpResponse();
+            response.plan = new TripPlan();
+            response.plan.itineraries = List.of(walkToVoterRegCenterItinerary);
+            return response;
+        }
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/TrackedTripControllerTest.java
@@ -106,7 +106,7 @@ class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
     private MonitoredTrip monitoredTrip;
 
     @BeforeAll
-    public static void setUp() throws Exception {
+    static void setUp() throws Exception {
         assumeTrue(IS_END_TO_END);
         setAuthDisabled(false);
         OtpTestUtils.mockOtpServer();
@@ -172,7 +172,7 @@ class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
     }
 
     @AfterAll
-    public static void tearDown() throws Exception {
+    static void tearDown() throws Exception {
         assumeTrue(IS_END_TO_END);
         DateTimeUtils.useSystemDefaultClockAndTimezone();
         restoreDefaultAuthDisabled();
@@ -183,13 +183,13 @@ class TrackedTripControllerTest extends OtpMiddlewareTestEnvironment {
     }
 
     @BeforeEach
-    public void beforeEachTest() {
+    void beforeEachTest() {
         assumeTrue(IS_END_TO_END);
         monitoredTrip = createMonitoredTrip(itinerary);
     }
 
     @AfterEach
-    public void tearDownAfterTest() {
+    void tearDownAfterTest() {
         assumeTrue(IS_END_TO_END);
         if (trackedJourney != null) {
             trackedJourney.delete();


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Prevents trip monitoring from reverting to the original itinerary after rerouting (unless live tracking is ended).
