### PR TITLE
Improve Itinerary Checks

### DIFF
--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -112,14 +112,7 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
         // Ensure user has not reached their limit for number of trips.
         verifyBelowMaxNumTrips(monitoredTrip.userId, req);
         preCreateOrUpdateChecks(monitoredTrip, req);
-
-        // FIXME: Pending https://github.com/ibi-group/otp-middleware/pull/219,
-        //   check itinerary existence for recurring trips only for now.
-        //   (Existence should ultimately be checked on all trips.)
-        if (!monitoredTrip.isOneTime()) {
-            checkItineraryExistenceOrReusePriorCheck(monitoredTrip, req);
-        }
-
+        checkItineraryExistenceOrReusePriorCheck(monitoredTrip, req);
         notifyTripCompanionsAndObservers(monitoredTrip, null);
 
         return monitoredTrip;

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -117,41 +117,45 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
         //   check itinerary existence for recurring trips only for now.
         //   (Existence should ultimately be checked on all trips.)
         if (!monitoredTrip.isOneTime()) {
-            String checkId = monitoredTrip.itineraryExistence != null ? monitoredTrip.itineraryExistence.id : null;
-            ItineraryExistence previousExistence = checksPerformed.get(checkId);
-            if (previousExistence != null) {
-                if (previousExistence.allMonitoredDaysAreValid(monitoredTrip)) {
-                    LOG.info("Skipping itinerary check in preCreateHook because we have already checked it exists.");
-                    monitoredTrip.itineraryExistence = previousExistence;
-                    monitoredTrip.updateTripWithVerifiedItinerary();
-
-                    // Consume (remove) the check
-                    checksPerformed.remove(checkId);
-                } else {
-                    logMessageAndHalt(
-                        req,
-                        HttpStatus.BAD_REQUEST_400,
-                        previousExistence.message
-                    );
-                }
-            } else {
-                // Check itinerary existence for all days and replace the provided trip's itinerary with a verified,
-                // non-realtime version of it.
-                LOG.info("Running itinerary check in preCreateHook because it has not been run before.");
-                boolean success = monitoredTrip.checkItineraryExistence(true);
-                if (!success) {
-                    logMessageAndHalt(
-                        req,
-                        HttpStatus.BAD_REQUEST_400,
-                        monitoredTrip.itineraryExistence.message
-                    );
-                }
-            }
+            checkItineraryExistenceOrReusePriorCheck(monitoredTrip, req);
         }
 
         notifyTripCompanionsAndObservers(monitoredTrip, null);
 
         return monitoredTrip;
+    }
+
+    private static void checkItineraryExistenceOrReusePriorCheck(MonitoredTrip monitoredTrip, Request req) {
+        String checkId = monitoredTrip.itineraryExistence != null ? monitoredTrip.itineraryExistence.id : null;
+        ItineraryExistence previousExistence = checksPerformed.get(checkId);
+        if (previousExistence != null) {
+            if (previousExistence.allMonitoredDaysAreValid(monitoredTrip)) {
+                LOG.info("Skipping itinerary check in preCreateHook because we have already checked it exists.");
+                monitoredTrip.itineraryExistence = previousExistence;
+                monitoredTrip.updateTripWithVerifiedItinerary();
+
+                // Consume (remove) the check
+                checksPerformed.remove(checkId);
+            } else {
+                logMessageAndHalt(
+                    req,
+                    HttpStatus.BAD_REQUEST_400,
+                    previousExistence.message
+                );
+            }
+        } else {
+            // Check itinerary existence for all days and replace the provided trip's itinerary with a verified,
+            // non-realtime version of it.
+            LOG.info("Running itinerary check in preCreateHook because it has not been run before.");
+            boolean success = monitoredTrip.checkItineraryExistence(true);
+            if (!success) {
+                logMessageAndHalt(
+                    req,
+                    HttpStatus.BAD_REQUEST_400,
+                    monitoredTrip.itineraryExistence.message
+                );
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -16,9 +16,13 @@ import org.opentripplanner.middleware.utils.InvalidItineraryReason;
 import org.opentripplanner.middleware.utils.JsonUtils;
 import org.opentripplanner.middleware.utils.NotificationUtils;
 import org.opentripplanner.middleware.utils.SwaggerUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -40,8 +44,30 @@ import static org.opentripplanner.middleware.utils.JsonUtils.logMessageAndHalt;
  * controller connects with Auth0 services using the hooks provided by {@link ApiController}.
  */
 public class MonitoredTripController extends ApiController<MonitoredTrip> {
+    private static final Logger LOG = LoggerFactory.getLogger(MonitoredTripController.class);
+
     private static final int MAXIMUM_PERMITTED_MONITORED_TRIPS
         = getConfigPropertyAsInt("MAXIMUM_PERMITTED_MONITORED_TRIPS", 5);
+
+    /**
+     * Size of the cached itinerary checks that we should not repeat.
+     */
+    private static final int MAXIMUM_EXISTENCE_CHECKS = 100;
+
+    /**
+     * Caches a number of recent ItineraryExistence with their ids. Implements a
+     * <a href="https://stackoverflow.com/questions/1963806/is-there-a-fixed-sized-queue-which-removes-excessive-elements">
+     *     fixed-sized queue trick
+     * </a>
+     * This approach loses its effect if many calls are made to /checkitinerary beyond MAXIMUM_CHECKS without
+     * a subsequent POST to actually persist the itinerary.
+     */
+    private static final LinkedHashMap<String, ItineraryExistence> checksPerformed = new LinkedHashMap<>() {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, ItineraryExistence> eldest) {
+            return this.size() > MAXIMUM_EXISTENCE_CHECKS;
+        }
+    };
 
     public MonitoredTripController(String apiPrefix) {
         super(apiPrefix, Persistence.monitoredTrips, "secure/monitoredtrip");
@@ -74,6 +100,8 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
     /**
      * Before creating a {@link MonitoredTrip}, check that the itinerary associated with the trip exists on the selected
      * days of the week. Update the itinerary if everything looks OK, otherwise halt the request.
+     * If a check has already been performed (the caller populates the itineraryExistence field including the id of
+     * such check), and the check shows the itinerary exists, skip the check.
      */
     @Override
     MonitoredTrip preCreateHook(MonitoredTrip monitoredTrip, Request req) {
@@ -85,15 +113,32 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
         //   check itinerary existence for recurring trips only for now.
         //   (Existence should ultimately be checked on all trips.)
         if (!monitoredTrip.isOneTime()) {
-            // Check itinerary existence for all days and replace the provided trip's itinerary with a verified,
-            // non-realtime version of it.
-            boolean success = monitoredTrip.checkItineraryExistence(true);
-            if (!success) {
-                logMessageAndHalt(
-                    req,
-                    HttpStatus.BAD_REQUEST_400,
-                    monitoredTrip.itineraryExistence.message
-                );
+            String checkId = monitoredTrip.itineraryExistence != null ? monitoredTrip.itineraryExistence.id : null;
+            ItineraryExistence previousExistence = checksPerformed.get(checkId);
+            if (previousExistence != null) {
+                if (previousExistence.allMonitoredDaysAreValid(monitoredTrip)) {
+                    LOG.info("Skipping itinerary check in preCreateHook because we have already checked it exists.");
+                    monitoredTrip.itineraryExistence = previousExistence;
+                    // Consume (remove) the check
+                    checksPerformed.remove(checkId);
+                } else {
+                    logMessageAndHalt(
+                        req,
+                        HttpStatus.BAD_REQUEST_400,
+                        previousExistence.message
+                    );
+                }
+            } else {
+                // Check itinerary existence for all days and replace the provided trip's itinerary with a verified,
+                // non-realtime version of it.
+                boolean success = monitoredTrip.checkItineraryExistence(true);
+                if (!success) {
+                    logMessageAndHalt(
+                        req,
+                        HttpStatus.BAD_REQUEST_400,
+                        monitoredTrip.itineraryExistence.message
+                    );
+                }
             }
         }
 
@@ -196,9 +241,6 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
             monitoredTrip.from = preExisting.from;
             monitoredTrip.to = preExisting.to;
 
-            // TODO: Update itinerary existence record when updating a trip?
-            //   (Currently, we let web requests change the monitored days regardless of existence.)
-
             // perform the database update here before releasing the lock to be sure that the record is updated in the
             // database before a CheckMonitoredTripJob analyzes the data
             Persistence.monitoredTrips.replace(monitoredTrip.id, monitoredTrip);
@@ -235,6 +277,7 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
         }
         trip.initializeFromItineraryAndQueryParams(trip.otp2QueryParams);
         trip.checkItineraryExistence(false);
+        checksPerformed.put(trip.itineraryExistence.id, trip.itineraryExistence);
         return trip.itineraryExistence;
     }
 
@@ -270,5 +313,19 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
                 String.format("The trip cannot be monitored: %s", reasonsString)
             );
         }
+    }
+
+    /**
+     * For use in tests only.
+     */
+    static void simulateExistenceCheck(ItineraryExistence existence) {
+        checksPerformed.put(existence.id, existence);
+    }
+
+    /**
+     * For use in tests only.
+     */
+    static int getChecksSize() {
+        return checksPerformed.size();
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -137,6 +137,7 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
             } else {
                 // Check itinerary existence for all days and replace the provided trip's itinerary with a verified,
                 // non-realtime version of it.
+                LOG.info("Running itinerary check in preCreateHook because it has not been run before.");
                 boolean success = monitoredTrip.checkItineraryExistence(true);
                 if (!success) {
                     logMessageAndHalt(

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -49,6 +49,10 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
     private static final int MAXIMUM_PERMITTED_MONITORED_TRIPS
         = getConfigPropertyAsInt("MAXIMUM_PERMITTED_MONITORED_TRIPS", 5);
 
+    public static final String MONITORED_TRIP_PATH = "secure/monitoredtrip";
+
+    public static final String CHECK_ITINERARY_SUBPATH = "/checkitinerary";
+
     /**
      * Size of the cached itinerary checks that we should not repeat.
      */
@@ -70,14 +74,14 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
     };
 
     public MonitoredTripController(String apiPrefix) {
-        super(apiPrefix, Persistence.monitoredTrips, "secure/monitoredtrip");
+        super(apiPrefix, Persistence.monitoredTrips, MONITORED_TRIP_PATH);
     }
 
     @Override
     protected void buildEndpoint(ApiEndpoint baseEndpoint) {
         // Add the api key route BEFORE the regular CRUD methods
         ApiEndpoint modifiedEndpoint = baseEndpoint
-            .post(path("/checkitinerary")
+            .post(path(CHECK_ITINERARY_SUBPATH)
                     .withDescription("Returns the itinerary existence check results for a monitored trip.")
                     .withRequestType(MonitoredTrip.class)
                     .withProduces(JSON_ONLY)
@@ -279,7 +283,12 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
         }
         trip.initializeFromItineraryAndQueryParams(trip.otp2QueryParams);
         trip.checkItineraryExistence(false);
-        checksPerformed.put(trip.itineraryExistence.id, trip.itineraryExistence);
+        boolean isNewTrip = Persistence.monitoredTrips.getCountFiltered(eq(trip.id)) == 0;
+        if (isNewTrip) {
+            checksPerformed.put(trip.itineraryExistence.id, trip.itineraryExistence);
+        } else {
+            Persistence.monitoredTrips.replace(trip.id, trip);
+        }
         return trip.itineraryExistence;
     }
 

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -119,6 +119,8 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
                 if (previousExistence.allMonitoredDaysAreValid(monitoredTrip)) {
                     LOG.info("Skipping itinerary check in preCreateHook because we have already checked it exists.");
                     monitoredTrip.itineraryExistence = previousExistence;
+                    monitoredTrip.updateTripWithVerifiedItinerary();
+
                     // Consume (remove) the check
                     checksPerformed.remove(checkId);
                 } else {

--- a/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
+++ b/src/main/java/org/opentripplanner/middleware/controllers/api/MonitoredTripController.java
@@ -282,13 +282,15 @@ public class MonitoredTripController extends ApiController<MonitoredTrip> {
             logMessageAndHalt(request, HttpStatus.BAD_REQUEST_400, "Error parsing JSON for MonitoredTrip", e);
             return null;
         }
-        trip.initializeFromItineraryAndQueryParams(trip.otp2QueryParams);
-        trip.checkItineraryExistence(false);
-        boolean isNewTrip = Persistence.monitoredTrips.getCountFiltered(eq(trip.id)) == 0;
+        MonitoredTrip existingTrip = Persistence.monitoredTrips.getById(trip.id);
+        boolean isNewTrip = existingTrip == null;
         if (isNewTrip) {
+            trip.initializeFromItineraryAndQueryParams(trip.otp2QueryParams);
+            trip.checkItineraryExistence(false);
             checksPerformed.put(trip.itineraryExistence.id, trip.itineraryExistence);
         } else {
-            Persistence.monitoredTrips.replace(trip.id, trip);
+            existingTrip.checkItineraryExistence(false);
+            Persistence.monitoredTrips.replace(trip.id, existingTrip);
         }
         return trip.itineraryExistence;
     }

--- a/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
+++ b/src/main/java/org/opentripplanner/middleware/models/MonitoredTrip.java
@@ -227,7 +227,7 @@ public class MonitoredTrip extends Model {
      * Replace the itinerary provided with the monitored trip
      * with a non-real-time, verified itinerary from the responses provided.
      */
-    private boolean updateTripWithVerifiedItinerary() {
+    public boolean updateTripWithVerifiedItinerary() {
         String queryDate = otp2QueryParams.date;
         DayOfWeek dayOfWeek = DateTimeUtils.getDateFromQueryDateString(queryDate).getDayOfWeek();
 

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -1,7 +1,7 @@
 package org.opentripplanner.middleware.controllers.api;
 
 import com.auth0.json.mgmt.users.User;
-import com.mongodb.BasicDBObject;
+import org.bson.conversions.Bson;
 import org.eclipse.jetty.http.HttpMethod;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.auth.Auth0Connection.restoreDefaultAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Connection.setAuthDisabled;
+import static org.opentripplanner.middleware.persistence.TypedPersistence.filterByUserId;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.TEMP_AUTH0_USER_PASSWORD;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.createAndAssignAuth0User;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.mockAuthenticatedGet;
@@ -59,7 +60,7 @@ import static org.opentripplanner.middleware.testutils.PersistenceTestUtils.dele
  *
  * Auth0 must be correctly configured as described here: https://auth0.com/docs/flows/call-your-api-using-resource-owner-password-flow
  */
-public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
+class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     private static AdminUser multiAdminUser;
     private static OtpUser soloOtpUser;
     private static OtpUser multiOtpUser;
@@ -72,7 +73,7 @@ public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
      * an Auth0 account is created for the admin user it will fail because the email address already exists.
      */
     @BeforeAll
-    public static void setUp() {
+    static void setUp() {
         assumeTrue(IS_END_TO_END);
         setAuthDisabled(false);
 
@@ -97,7 +98,7 @@ public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
      * Delete the users if they were not already deleted during the test script.
      */
     @AfterAll
-    public static void tearDown() {
+    static void tearDown() {
         assumeTrue(IS_END_TO_END);
         restoreDefaultAuthDisabled();
         multiAdminUser = Persistence.adminUsers.getById(multiAdminUser.id);
@@ -110,15 +111,9 @@ public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     }
 
     @AfterEach
-    public void tearDownAfterTest() {
-        Persistence.monitoredTrips.removeFiltered(getUserFilter(soloOtpUser.id));
-        Persistence.monitoredTrips.removeFiltered(getUserFilter(multiOtpUser.id));
-    }
-
-    private static BasicDBObject getUserFilter(String id) {
-        BasicDBObject userFilter = new BasicDBObject();
-        userFilter.put("userId", id);
-        return userFilter;
+    void tearDownAfterTest() {
+        Persistence.monitoredTrips.removeFiltered(filterByUserId(soloOtpUser.id));
+        Persistence.monitoredTrips.removeFiltered(filterByUserId(multiOtpUser.id));
     }
 
     /**
@@ -156,7 +151,7 @@ public class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         // Create a trip for the solo OTP user.
         createMonitoredTripForUser(soloOtpUser);
 
-        BasicDBObject filter = getUserFilter(soloOtpUser.id);
+        Bson filter = filterByUserId(soloOtpUser.id);
 
         // Expect only 1 trip for solo Otp user.
         assertEquals(1, Persistence.monitoredTrips.getCountFiltered(filter));

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -33,7 +33,6 @@ import org.opentripplanner.middleware.utils.HttpResponseValues;
 import org.opentripplanner.middleware.utils.ItineraryUtils;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -84,8 +83,8 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     private static OtpUser multiOtpUser;
     private static Bson soloUserFilter;
     private static final String MONITORED_TRIP_PATH = String.join("/", "api", MonitoredTripController.MONITORED_TRIP_PATH);
-
     private static final String DUMMY_STRING = "ABCDxyz";
+    private static final String WED_2026_04_22 = "2026-04-22";
 
     /**
      * Create Otp and Admin user accounts. Create Auth0 account for just the Otp users. If
@@ -237,18 +236,39 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         assertEquals(1, updatedTrip.itineraryExistence.wednesday.validDates.size());
         // No checks should have been added/cached.
         assertEquals(checksSize, MonitoredTripController.getChecksSize());
+    }
 
+    @Test
+    void canCreateCheckForNewMonitoredTrip() throws Exception {
+        ItineraryExistence.otpResponseProviderOverride = this::fakeOtpResponse;
+
+        // Create a trip for the solo OTP user without persisting.
+        MonitoredTrip trip = createMonitoredTripForUser(soloOtpUser);
+
+        int checksSize = MonitoredTripController.getChecksSize();
+
+        // Make call to check itinerary existence.
+        var result = mockAuthenticatedRequest(
+            MONITORED_TRIP_PATH + CHECK_ITINERARY_SUBPATH,
+            JsonUtils.toJson(trip),
+            soloOtpUser,
+            HttpMethod.POST
+        );
+
+        assertNull(Persistence.monitoredTrips.getOneFiltered(soloUserFilter));
+        // A check should have been added/cached.
+        assertEquals(checksSize + 1, MonitoredTripController.getChecksSize());
+
+        // Check that we got data populated in the result.
+        ItineraryExistence existence = JsonUtils.getPOJOFromJSON(result.responseBody, ItineraryExistence.class);
+        assertEquals(1, existence.wednesday.validDates.size());
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void canCreateMonitoredTripUsingPriorExistenceCheck(boolean monitorAllDays) throws Exception {
-        final String WED_2026_04_22 = "2026-04-22";
         // Create a trip for the solo OTP user without persisting.
         MonitoredTrip trip = createMonitoredTripForUser(soloOtpUser);
-        trip.tripName = UUID.randomUUID().toString();
-        trip.otp2QueryParams.date = WED_2026_04_22;
-        trip.itinerary.startTime = Date.from(Instant.ofEpochMilli(0));
         if (!monitorAllDays) {
             trip.updateAllDaysOfWeek(false);
             trip.wednesday = true;
@@ -300,12 +320,8 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     void canCreateMonitoredTripWithoutPriorExistenceCheck() throws Exception {
         ItineraryExistence.otpResponseProviderOverride = this::fakeOtpResponse;
 
-        final String WED_2026_04_22 = "2026-04-22";
         // Create a trip for the solo OTP user without persisting.
         MonitoredTrip trip = createMonitoredTripForUser(soloOtpUser);
-        trip.tripName = UUID.randomUUID().toString();
-        trip.otp2QueryParams.date = WED_2026_04_22;
-        trip.itinerary.startTime = Date.from(Instant.ofEpochMilli(0));
 
         // Make call to persist the trip.
         mockAuthenticatedRequest(MONITORED_TRIP_PATH,
@@ -364,6 +380,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip.updateAllDaysOfWeek(true);
         monitoredTrip.userId = otpUser.id;
         monitoredTrip.otp2QueryParams = OtpTestUtils.getSampleQueryParams();
+        monitoredTrip.otp2QueryParams.date = WED_2026_04_22;
         monitoredTrip.itinerary = makeItinerary(new Date());
         monitoredTrip.itineraryExistence = new ItineraryExistence();
         monitoredTrip.itineraryExistence.id = "itinerary-existence-id";
@@ -372,6 +389,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip.from.name = "From Place";
         monitoredTrip.to = new Place();
         monitoredTrip.to.name = "To Place";
+        monitoredTrip.tripName = UUID.randomUUID().toString();
         return monitoredTrip;
     }
 

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -25,9 +25,15 @@ import org.opentripplanner.middleware.testutils.ApiTestUtils;
 import org.opentripplanner.middleware.testutils.OtpMiddlewareTestEnvironment;
 import org.opentripplanner.middleware.testutils.OtpTestUtils;
 import org.opentripplanner.middleware.testutils.PersistenceTestUtils;
+import org.opentripplanner.middleware.utils.DateTimeUtils;
 import org.opentripplanner.middleware.utils.HttpResponseValues;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -198,9 +204,12 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void canCreateMonitoredTripUsingPriorExistenceCheck(boolean monitorAllDays) throws Exception {
+        final String WED_2026_04_22 = "2026-04-22";
         // Create a trip for the solo OTP user without persisting.
         MonitoredTrip trip = createMonitoredTripForUser(soloOtpUser);
         trip.tripName = UUID.randomUUID().toString();
+        trip.otp2QueryParams.date = WED_2026_04_22;
+        trip.itinerary.startTime = Date.from(Instant.ofEpochMilli(0));
         if (!monitorAllDays) {
             trip.updateAllDaysOfWeek(false);
             trip.wednesday = true;
@@ -210,7 +219,13 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         ItineraryExistence existence = new ItineraryExistence();
         existence.id = UUID.randomUUID().toString();
         existence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
-        existence.wednesday.validDates.add("2026-04-22");
+        existence.wednesday.validDates.add(WED_2026_04_22);
+        Itinerary verifiedItinerary = new Itinerary();
+        verifiedItinerary.startTime = DateTimeUtils.convertToDate(
+            LocalDateTime.of(LocalDate.parse(WED_2026_04_22, DateTimeFormatter.ISO_LOCAL_DATE), LocalTime.MIDNIGHT)
+        );
+        verifiedItinerary.legs = List.of(new Leg());
+        existence.wednesday.itineraries = List.of(verifiedItinerary);
 
         int checksSize = MonitoredTripController.getChecksSize();
         MonitoredTripController.simulateExistenceCheck(existence);
@@ -237,7 +252,8 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
             // The persisted trip should have its existence overwritten with the one simulated above.
             assertEquals(existence.id, persistedTrip.itineraryExistence.id);
             assertEquals(1, persistedTrip.itineraryExistence.wednesday.validDates.size());
-            assertTrue(persistedTrip.itineraryExistence.wednesday.validDates.contains("2026-04-22"));
+            assertTrue(persistedTrip.itineraryExistence.wednesday.validDates.contains(WED_2026_04_22));
+            assertEquals(verifiedItinerary.startTime, persistedTrip.itinerary.startTime);
             // The previous itinerary check should have been removed.
             assertEquals(checksSize, MonitoredTripController.getChecksSize());
         }

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.auth.Auth0Connection.restoreDefaultAuthDisabled;
@@ -168,6 +169,9 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         modifiedTrip.id = originalTrip.id;
         modifiedTrip.otp2QueryParams = OtpTestUtils.getSampleQueryParams();
         modifiedTrip.userId = DUMMY_STRING;
+        modifiedTrip.itineraryExistence = new ItineraryExistence();
+        modifiedTrip.itineraryExistence.id = DUMMY_STRING;
+        modifiedTrip.itineraryExistence.thursday = new ItineraryExistence.ItineraryExistenceResult();
 
         mockAuthenticatedRequest(MONITORED_TRIP_PATH,
             JsonUtils.toJson(modifiedTrip),
@@ -176,11 +180,14 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         );
 
         MonitoredTrip updatedTrip = Persistence.monitoredTrips.getById(originalTrip.id);
-        assertEquals(updatedTrip.itinerary.startTime, originalTrip.itinerary.startTime);
-        assertEquals(updatedTrip.otp2QueryParams.time, originalTrip.otp2QueryParams.time);
-        assertEquals(updatedTrip.userId, originalTrip.userId);
-        assertEquals(updatedTrip.from.name, originalTrip.from.name);
-        assertEquals(updatedTrip.to.name, originalTrip.to.name);
+        assertEquals(originalTrip.itinerary.startTime, updatedTrip.itinerary.startTime);
+        assertEquals(originalTrip.otp2QueryParams.time, updatedTrip.otp2QueryParams.time);
+        assertEquals(originalTrip.userId, updatedTrip.userId);
+        assertEquals(originalTrip.from.name, updatedTrip.from.name);
+        assertEquals(originalTrip.to.name, updatedTrip.to.name);
+        assertEquals(originalTrip.itineraryExistence.id, updatedTrip.itineraryExistence.id);
+        assertNull(updatedTrip.itineraryExistence.thursday);
+        assertNotNull(updatedTrip.itineraryExistence.wednesday);
     }
 
     /**
@@ -202,6 +209,8 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip.itinerary = new Itinerary();
         monitoredTrip.itinerary.startTime = new Date();
         monitoredTrip.itineraryExistence = new ItineraryExistence();
+        monitoredTrip.itineraryExistence.id = "itinerary-existence-id";
+        monitoredTrip.itineraryExistence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
         monitoredTrip.from = new Place();
         monitoredTrip.from.name = "From Place";
         monitoredTrip.to = new Place();

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -33,11 +33,13 @@ import org.opentripplanner.middleware.utils.HttpResponseValues;
 import org.opentripplanner.middleware.utils.ItineraryUtils;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -261,7 +263,9 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
 
         // Check that we got data populated in the result.
         ItineraryExistence existence = JsonUtils.getPOJOFromJSON(result.responseBody, ItineraryExistence.class);
-        assertEquals(1, existence.wednesday.validDates.size());
+        Arrays.stream(DayOfWeek.values()).forEach(day -> {
+            assertEquals(1, existence.getResultForDayOfWeek(day).validDates.size());
+        });
     }
 
     @ParameterizedTest

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.middleware.auth.Auth0Users;
 import org.opentripplanner.middleware.controllers.response.ResponseList;
 import org.opentripplanner.middleware.models.AdminUser;
@@ -44,7 +45,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.mongodb.client.model.Filters.eq;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -277,25 +280,31 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         });
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void canCreateMonitoredTripUsingPriorExistenceCheck(boolean monitorAllDays) throws Exception {
+    @ParameterizedTest(name = "{3} Itinerary exists: {1}, Should save trip: {2}")
+    @MethodSource("createMonitoredTripUsingPriorExistenceCheckCases")
+    void canCreateMonitoredTripUsingPriorExistenceCheck(
+        TripModifier tripArgs,
+        boolean tripExists,
+        boolean shouldSave,
+        String message // used in test name above
+    ) throws Exception {
         // Create a trip for the solo OTP user without persisting.
         MonitoredTrip trip = createMonitoredTripForUser(soloOtpUser);
-        if (!monitorAllDays) {
-            trip.updateAllDaysOfWeek(false);
-            trip.wednesday = true;
+        if (tripArgs.tripModifier != null) {
+            tripArgs.tripModifier.accept(trip);
         }
 
         // Simulate a prior itinerary existence check for that trip.
-        ItineraryExistence existence = new ItineraryExistence();
-        existence.id = UUID.randomUUID().toString();
-        existence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
-        existence.wednesday.validDates.add(WED_2026_04_22);
         Itinerary verifiedItinerary = makeItinerary(DateTimeUtils.convertToDate(
             LocalDateTime.of(LocalDate.parse(WED_2026_04_22, DateTimeFormatter.ISO_LOCAL_DATE), LocalTime.MIDNIGHT)
         ));
-        existence.wednesday.itineraries = List.of(verifiedItinerary);
+        ItineraryExistence existence = new ItineraryExistence();
+        existence.id = UUID.randomUUID().toString();
+        if (tripExists) {
+            existence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
+            existence.wednesday.validDates.add(WED_2026_04_22);
+            existence.wednesday.itineraries = List.of(verifiedItinerary);
+        }
 
         int checksSize = MonitoredTripController.getChecksSize();
         MonitoredTripController.simulateExistenceCheck(existence);
@@ -313,20 +322,60 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         );
 
         MonitoredTrip persistedTrip = Persistence.monitoredTrips.getOneFiltered(eq("tripName", trip.tripName));
-        if (monitorAllDays) {
+        if (shouldSave) {
+            assertNotNull(persistedTrip);
+            // If applicable, the persisted trip should have its existence overwritten with the one simulated above.
+            if (tripExists) {
+                assertEquals(existence.id, persistedTrip.itineraryExistence.id);
+                assertEquals(1, persistedTrip.itineraryExistence.wednesday.validDates.size());
+                assertTrue(persistedTrip.itineraryExistence.wednesday.validDates.contains(WED_2026_04_22));
+                assertEquals(verifiedItinerary.startTime, persistedTrip.itinerary.startTime);
+            }
+            // The previous itinerary check should have been removed.
+            assertEquals(checksSize, MonitoredTripController.getChecksSize());
+        } else {
             assertNull(persistedTrip);
             // The previous itinerary check should have been kept.
             assertEquals(checksSize + 1, MonitoredTripController.getChecksSize());
-        } else {
-            assertNotNull(persistedTrip);
-            // The persisted trip should have its existence overwritten with the one simulated above.
-            assertEquals(existence.id, persistedTrip.itineraryExistence.id);
-            assertEquals(1, persistedTrip.itineraryExistence.wednesday.validDates.size());
-            assertTrue(persistedTrip.itineraryExistence.wednesday.validDates.contains(WED_2026_04_22));
-            assertEquals(verifiedItinerary.startTime, persistedTrip.itinerary.startTime);
-            // The previous itinerary check should have been removed.
-            assertEquals(checksSize, MonitoredTripController.getChecksSize());
         }
+    }
+
+    private static Stream<Arguments> createMonitoredTripUsingPriorExistenceCheckCases() {
+        return Stream.of(
+            Arguments.of(
+                new TripModifier(null),
+                false,
+                false,
+                "Recurring trip monitored all days"
+                ),
+            Arguments.of(
+                new TripModifier(trip -> {
+                    trip.updateAllDaysOfWeek(false);
+                    trip.wednesday = true;
+                }),
+                true,
+                true,
+                "Recurring trip monitored one day"
+            ),
+            Arguments.of(
+                new TripModifier(trip -> {
+                    trip.updateAllDaysOfWeek(false);
+                }),
+                true,
+                true,
+                "One-time trip, itinerary exists theoretically or temporarily thanks to favorable real-time conditions."
+            ),
+            // Allow persistence of one-trips where the itinerary existence check fails.
+            // This is to be consistent with the OTP-react-redux UI that converts such trips to one-time.
+            Arguments.of(
+                new TripModifier(trip -> {
+                    trip.updateAllDaysOfWeek(false);
+                }),
+                false,
+                true,
+                "One-time trip"
+            )
+        );
     }
 
     @Test
@@ -476,5 +525,16 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         ids.remove(otherTrip.id);
         Set<String> fetchedIds = fetchedTrips.stream().map(t -> t.id).collect(Collectors.toSet());
         assertTrue(ids.containsAll(fetchedIds));
+    }
+
+    /**
+     * This class is needed to wrap a lambda. Arguments.of(...) does not accept lambdas.
+     */
+    private static class TripModifier {
+        private final Consumer<MonitoredTrip> tripModifier;
+
+        public TripModifier(Consumer<MonitoredTrip> tripModifier) {
+            this.tripModifier = tripModifier;
+        }
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -54,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.opentripplanner.middleware.auth.Auth0Connection.restoreDefaultAuthDisabled;
 import static org.opentripplanner.middleware.auth.Auth0Connection.setAuthDisabled;
+import static org.opentripplanner.middleware.controllers.api.MonitoredTripController.CHECK_ITINERARY_SUBPATH;
 import static org.opentripplanner.middleware.persistence.TypedPersistence.filterByUserId;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.TEMP_AUTH0_USER_PASSWORD;
 import static org.opentripplanner.middleware.testutils.ApiTestUtils.createAndAssignAuth0User;
@@ -81,7 +82,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     private static AdminUser multiAdminUser;
     private static OtpUser soloOtpUser;
     private static OtpUser multiOtpUser;
-    private static final String MONITORED_TRIP_PATH = "api/secure/monitoredtrip";
+    private static final String MONITORED_TRIP_PATH = String.join("/", "api", MonitoredTripController.MONITORED_TRIP_PATH);
 
     private static final String DUMMY_STRING = "ABCDxyz";
 
@@ -190,7 +191,8 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         modifiedTrip.itineraryExistence.id = DUMMY_STRING;
         modifiedTrip.itineraryExistence.thursday = new ItineraryExistence.ItineraryExistenceResult();
 
-        mockAuthenticatedRequest(MONITORED_TRIP_PATH,
+        mockAuthenticatedRequest(
+            MONITORED_TRIP_PATH,
             JsonUtils.toJson(modifiedTrip),
             soloOtpUser,
             HttpMethod.PUT
@@ -205,6 +207,38 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         assertEquals(originalTrip.itineraryExistence.id, updatedTrip.itineraryExistence.id);
         assertNull(updatedTrip.itineraryExistence.thursday);
         assertNotNull(updatedTrip.itineraryExistence.wednesday);
+    }
+
+    @Test
+    void canUpdateMonitoredTripAfterRecheckingExistence() throws Exception {
+        ItineraryExistence.otpResponseProviderOverride = this::fakeOtpResponse;
+
+        // Create a trip for the solo OTP user.
+        persistNewMonitoredTripForUser(soloOtpUser);
+
+        Bson filter = filterByUserId(soloOtpUser.id);
+        MonitoredTrip originalTrip = Persistence.monitoredTrips.getOneFiltered(filter);
+        assertTrue(originalTrip.itineraryExistence.wednesday.validDates.isEmpty());
+
+        int checksSize = MonitoredTripController.getChecksSize();
+
+        // Make call to check itinerary existence.
+        mockAuthenticatedRequest(
+            MONITORED_TRIP_PATH + CHECK_ITINERARY_SUBPATH,
+            JsonUtils.toJson(originalTrip),
+            soloOtpUser,
+            HttpMethod.POST
+        );
+
+        MonitoredTrip updatedTrip = Persistence.monitoredTrips.getOneFiltered(filter);
+        assertNotNull(updatedTrip);
+        // The persisted trip should have its existence overwritten with the one simulated above.
+        assertNotNull(updatedTrip.itineraryExistence.id);
+        assertNotEquals(originalTrip.itineraryExistence.id, updatedTrip.itineraryExistence.id);
+        assertEquals(1, updatedTrip.itineraryExistence.wednesday.validDates.size());
+        // No checks should have been added/cached.
+        assertEquals(checksSize, MonitoredTripController.getChecksSize());
+
     }
 
     @ParameterizedTest

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opentripplanner.middleware.auth.Auth0Users;
 import org.opentripplanner.middleware.controllers.response.ResponseList;
 import org.opentripplanner.middleware.models.AdminUser;
@@ -16,6 +18,7 @@ import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.models.RelatedUser;
 import org.opentripplanner.middleware.otp.response.Itinerary;
+import org.opentripplanner.middleware.otp.response.Leg;
 import org.opentripplanner.middleware.otp.response.Place;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.testutils.ApiTestUtils;
@@ -28,8 +31,10 @@ import org.opentripplanner.middleware.utils.JsonUtils;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.mongodb.client.model.Filters.eq;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -124,8 +129,8 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     @Test
     void canGetOwnMonitoredTrips() throws Exception {
         // Create a trip for the solo and the multi OTP user.
-        createMonitoredTripForUser(soloOtpUser);
-        createMonitoredTripForUser(multiOtpUser);
+        persistNewMonitoredTripForUser(soloOtpUser);
+        persistNewMonitoredTripForUser(multiOtpUser);
 
         // Get trips for solo Otp user.
         ResponseList<MonitoredTrip> soloTrips = getMonitoredTripsForUser(MONITORED_TRIP_PATH, soloOtpUser);
@@ -150,7 +155,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     @Test
     void canPreserveTripFields() throws Exception {
         // Create a trip for the solo OTP user.
-        createMonitoredTripForUser(soloOtpUser);
+        persistNewMonitoredTripForUser(soloOtpUser);
 
         Bson filter = filterByUserId(soloOtpUser.id);
 
@@ -190,6 +195,54 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         assertNotNull(updatedTrip.itineraryExistence.wednesday);
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void canCreateMonitoredTripUsingPriorExistenceCheck(boolean monitorAllDays) throws Exception {
+        // Create a trip for the solo OTP user without persisting.
+        MonitoredTrip trip = createMonitoredTripForUser(soloOtpUser);
+        trip.tripName = UUID.randomUUID().toString();
+        if (!monitorAllDays) {
+            trip.updateAllDaysOfWeek(false);
+            trip.wednesday = true;
+        }
+
+        // Simulate a prior itinerary existence check for that trip.
+        ItineraryExistence existence = new ItineraryExistence();
+        existence.id = UUID.randomUUID().toString();
+        existence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
+        existence.wednesday.validDates.add("2026-04-22");
+
+        int checksSize = MonitoredTripController.getChecksSize();
+        MonitoredTripController.simulateExistenceCheck(existence);
+        assertEquals(checksSize + 1, MonitoredTripController.getChecksSize());
+
+        // Add existence id to the trip above
+        trip.itineraryExistence.id = existence.id;
+        assertTrue(trip.itineraryExistence.wednesday.validDates.isEmpty());
+
+        // Make call to persist the trip.
+        mockAuthenticatedRequest(MONITORED_TRIP_PATH,
+            JsonUtils.toJson(trip),
+            soloOtpUser,
+            HttpMethod.POST
+        );
+
+        MonitoredTrip persistedTrip = Persistence.monitoredTrips.getOneFiltered(eq("tripName", trip.tripName));
+        if (monitorAllDays) {
+            assertNull(persistedTrip);
+            // The previous itinerary check should have been kept.
+            assertEquals(checksSize + 1, MonitoredTripController.getChecksSize());
+        } else {
+            assertNotNull(persistedTrip);
+            // The persisted trip should have its existence overwritten with the one simulated above.
+            assertEquals(existence.id, persistedTrip.itineraryExistence.id);
+            assertEquals(1, persistedTrip.itineraryExistence.wednesday.validDates.size());
+            assertTrue(persistedTrip.itineraryExistence.wednesday.validDates.contains("2026-04-22"));
+            // The previous itinerary check should have been removed.
+            assertEquals(checksSize, MonitoredTripController.getChecksSize());
+        }
+    }
+
     /**
      * Helper method to get trips for user.
      */
@@ -201,12 +254,18 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     /**
      * Creates a {@link MonitoredTrip} for the specified user.
      */
-    private static void createMonitoredTripForUser(OtpUser otpUser) {
+    private static void persistNewMonitoredTripForUser(OtpUser otpUser) {
+        MonitoredTrip monitoredTrip = createMonitoredTripForUser(otpUser);
+        Persistence.monitoredTrips.create(monitoredTrip);
+    }
+
+    private static MonitoredTrip createMonitoredTripForUser(OtpUser otpUser) {
         MonitoredTrip monitoredTrip = new MonitoredTrip();
         monitoredTrip.updateAllDaysOfWeek(true);
         monitoredTrip.userId = otpUser.id;
         monitoredTrip.otp2QueryParams = OtpTestUtils.getSampleQueryParams();
         monitoredTrip.itinerary = new Itinerary();
+        monitoredTrip.itinerary.legs = List.of(new Leg());
         monitoredTrip.itinerary.startTime = new Date();
         monitoredTrip.itineraryExistence = new ItineraryExistence();
         monitoredTrip.itineraryExistence.id = "itinerary-existence-id";
@@ -215,8 +274,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip.from.name = "From Place";
         monitoredTrip.to = new Place();
         monitoredTrip.to.name = "To Place";
-
-        Persistence.monitoredTrips.create(monitoredTrip);
+        return monitoredTrip;
     }
 
     @Test

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -212,7 +212,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
 
     @Test
     void canUpdateMonitoredTripAfterRecheckingExistence() throws Exception {
-        ItineraryExistence.otpResponseProviderOverride = this::fakeOtpResponse;
+        ItineraryExistence.otpResponseProviderOverride = MonitoredTripControllerTest::fakeOtpResponse;
 
         // Create a trip for the solo OTP user.
         persistNewMonitoredTripForUser(soloOtpUser);
@@ -251,7 +251,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
 
     @Test
     void canCreateCheckForNewMonitoredTrip() throws Exception {
-        ItineraryExistence.otpResponseProviderOverride = this::fakeOtpResponse;
+        ItineraryExistence.otpResponseProviderOverride = MonitoredTripControllerTest::fakeOtpResponse;
 
         // Create a trip for the solo OTP user without persisting.
         MonitoredTrip trip = createMonitoredTripForUser(soloOtpUser);
@@ -331,7 +331,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
 
     @Test
     void canCreateMonitoredTripWithoutPriorExistenceCheck() throws Exception {
-        ItineraryExistence.otpResponseProviderOverride = this::fakeOtpResponse;
+        ItineraryExistence.otpResponseProviderOverride = MonitoredTripControllerTest::fakeOtpResponse;
 
         // Create a trip for the solo OTP user without persisting.
         MonitoredTrip trip = createMonitoredTripForUser(soloOtpUser);
@@ -352,11 +352,10 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     /**
      * Fake OTP response provider whose itineraries always match the original itinerary of the test.
      */
-    private OtpResponse fakeOtpResponse(OtpRequest request) {
-        Itinerary itinerary = makeItinerary(Date.from(request.dateTime.toInstant()));
+    private static OtpResponse fakeOtpResponse(OtpRequest request) {
         OtpResponse response = new OtpResponse();
         response.plan = new TripPlan();
-        response.plan.itineraries = List.of(itinerary);
+        response.plan.itineraries = List.of(makeItinerary(Date.from(request.dateTime.toInstant())));
         return response;
     }
 

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -17,9 +17,12 @@ import org.opentripplanner.middleware.models.MobilityProfileLite;
 import org.opentripplanner.middleware.models.MonitoredTrip;
 import org.opentripplanner.middleware.models.OtpUser;
 import org.opentripplanner.middleware.models.RelatedUser;
+import org.opentripplanner.middleware.otp.OtpRequest;
 import org.opentripplanner.middleware.otp.response.Itinerary;
 import org.opentripplanner.middleware.otp.response.Leg;
+import org.opentripplanner.middleware.otp.response.OtpResponse;
 import org.opentripplanner.middleware.otp.response.Place;
+import org.opentripplanner.middleware.otp.response.TripPlan;
 import org.opentripplanner.middleware.persistence.Persistence;
 import org.opentripplanner.middleware.testutils.ApiTestUtils;
 import org.opentripplanner.middleware.testutils.OtpMiddlewareTestEnvironment;
@@ -27,12 +30,14 @@ import org.opentripplanner.middleware.testutils.OtpTestUtils;
 import org.opentripplanner.middleware.testutils.PersistenceTestUtils;
 import org.opentripplanner.middleware.utils.DateTimeUtils;
 import org.opentripplanner.middleware.utils.HttpResponseValues;
+import org.opentripplanner.middleware.utils.ItineraryUtils;
 import org.opentripplanner.middleware.utils.JsonUtils;
 
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
@@ -126,6 +131,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     void tearDownAfterTest() {
         Persistence.monitoredTrips.removeFiltered(filterByUserId(soloOtpUser.id));
         Persistence.monitoredTrips.removeFiltered(filterByUserId(multiOtpUser.id));
+        ItineraryExistence.otpResponseProviderOverride = null;
     }
 
     /**
@@ -220,11 +226,9 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         existence.id = UUID.randomUUID().toString();
         existence.wednesday = new ItineraryExistence.ItineraryExistenceResult();
         existence.wednesday.validDates.add(WED_2026_04_22);
-        Itinerary verifiedItinerary = new Itinerary();
-        verifiedItinerary.startTime = DateTimeUtils.convertToDate(
+        Itinerary verifiedItinerary = makeItinerary(DateTimeUtils.convertToDate(
             LocalDateTime.of(LocalDate.parse(WED_2026_04_22, DateTimeFormatter.ISO_LOCAL_DATE), LocalTime.MIDNIGHT)
-        );
-        verifiedItinerary.legs = List.of(new Leg());
+        ));
         existence.wednesday.itineraries = List.of(verifiedItinerary);
 
         int checksSize = MonitoredTripController.getChecksSize();
@@ -259,6 +263,53 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         }
     }
 
+    @Test
+    void canCreateMonitoredTripWithoutPriorExistenceCheck() throws Exception {
+        ItineraryExistence.otpResponseProviderOverride = this::fakeOtpResponse;
+
+        final String WED_2026_04_22 = "2026-04-22";
+        // Create a trip for the solo OTP user without persisting.
+        MonitoredTrip trip = createMonitoredTripForUser(soloOtpUser);
+        trip.tripName = UUID.randomUUID().toString();
+        trip.otp2QueryParams.date = WED_2026_04_22;
+        trip.itinerary.startTime = Date.from(Instant.ofEpochMilli(0));
+
+        // Make call to persist the trip.
+        mockAuthenticatedRequest(MONITORED_TRIP_PATH,
+            JsonUtils.toJson(trip),
+            soloOtpUser,
+            HttpMethod.POST
+        );
+
+        MonitoredTrip persistedTrip = Persistence.monitoredTrips.getOneFiltered(eq("tripName", trip.tripName));
+        assertNotNull(persistedTrip);
+        ZonedDateTime tripTime = ItineraryUtils.getDatesToCheckItineraryExistence(trip).get(0);
+        assertEquals(Date.from(tripTime.toInstant()), persistedTrip.itinerary.startTime);
+    }
+
+    /**
+     * Fake OTP response provider whose itineraries always match the original itinerary of the test.
+     */
+    private OtpResponse fakeOtpResponse(OtpRequest request) {
+        Itinerary itinerary = makeItinerary(Date.from(request.dateTime.toInstant()));
+        OtpResponse response = new OtpResponse();
+        response.plan = new TripPlan();
+        response.plan.itineraries = List.of(itinerary);
+        return response;
+    }
+
+    /**
+     * Creates a trivial itinerary with one leg, with the start and end date of the itinerary and leg the same.
+     */
+    private static Itinerary makeItinerary(Date date) {
+        Itinerary itinerary = new Itinerary();
+        itinerary.startTime = itinerary.endTime = date;
+        Leg leg = new Leg();
+        leg.startTime = leg.endTime = date;
+        itinerary.legs = List.of(leg);
+        return itinerary;
+    }
+
     /**
      * Helper method to get trips for user.
      */
@@ -280,9 +331,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         monitoredTrip.updateAllDaysOfWeek(true);
         monitoredTrip.userId = otpUser.id;
         monitoredTrip.otp2QueryParams = OtpTestUtils.getSampleQueryParams();
-        monitoredTrip.itinerary = new Itinerary();
-        monitoredTrip.itinerary.legs = List.of(new Leg());
-        monitoredTrip.itinerary.startTime = new Date();
+        monitoredTrip.itinerary = makeItinerary(new Date());
         monitoredTrip.itineraryExistence = new ItineraryExistence();
         monitoredTrip.itineraryExistence.id = "itinerary-existence-id";
         monitoredTrip.itineraryExistence.wednesday = new ItineraryExistence.ItineraryExistenceResult();

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -82,6 +82,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
     private static AdminUser multiAdminUser;
     private static OtpUser soloOtpUser;
     private static OtpUser multiOtpUser;
+    private static Bson soloUserFilter;
     private static final String MONITORED_TRIP_PATH = String.join("/", "api", MonitoredTripController.MONITORED_TRIP_PATH);
 
     private static final String DUMMY_STRING = "ABCDxyz";
@@ -97,6 +98,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
 
         String multiUserEmail = ApiTestUtils.generateEmailAddress("test-multiotpuser");
         soloOtpUser = PersistenceTestUtils.createUser(ApiTestUtils.generateEmailAddress("test-solootpuser"));
+        soloUserFilter = filterByUserId(soloOtpUser.id);
         multiOtpUser = PersistenceTestUtils.createUser(multiUserEmail);
         multiAdminUser = PersistenceTestUtils.createAdminUser(multiUserEmail);
         try {
@@ -130,7 +132,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
 
     @AfterEach
     void tearDownAfterTest() {
-        Persistence.monitoredTrips.removeFiltered(filterByUserId(soloOtpUser.id));
+        Persistence.monitoredTrips.removeFiltered(soloUserFilter);
         Persistence.monitoredTrips.removeFiltered(filterByUserId(multiOtpUser.id));
         ItineraryExistence.otpResponseProviderOverride = null;
     }
@@ -170,12 +172,10 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         // Create a trip for the solo OTP user.
         persistNewMonitoredTripForUser(soloOtpUser);
 
-        Bson filter = filterByUserId(soloOtpUser.id);
-
         // Expect only 1 trip for solo Otp user.
-        assertEquals(1, Persistence.monitoredTrips.getCountFiltered(filter));
+        assertEquals(1, Persistence.monitoredTrips.getCountFiltered(soloUserFilter));
 
-        MonitoredTrip originalTrip = Persistence.monitoredTrips.getOneFiltered(filter);
+        MonitoredTrip originalTrip = Persistence.monitoredTrips.getOneFiltered(soloUserFilter);
         assertNotNull(originalTrip.itinerary);
         assertNotNull(originalTrip.itineraryExistence);
         // Can't really assert journeyState because itinerary checks will not be run for these tests.
@@ -216,8 +216,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         // Create a trip for the solo OTP user.
         persistNewMonitoredTripForUser(soloOtpUser);
 
-        Bson filter = filterByUserId(soloOtpUser.id);
-        MonitoredTrip originalTrip = Persistence.monitoredTrips.getOneFiltered(filter);
+        MonitoredTrip originalTrip = Persistence.monitoredTrips.getOneFiltered(soloUserFilter);
         assertTrue(originalTrip.itineraryExistence.wednesday.validDates.isEmpty());
 
         int checksSize = MonitoredTripController.getChecksSize();
@@ -230,7 +229,7 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
             HttpMethod.POST
         );
 
-        MonitoredTrip updatedTrip = Persistence.monitoredTrips.getOneFiltered(filter);
+        MonitoredTrip updatedTrip = Persistence.monitoredTrips.getOneFiltered(soloUserFilter);
         assertNotNull(updatedTrip);
         // The persisted trip should have its existence overwritten with the one simulated above.
         assertNotNull(updatedTrip.itineraryExistence.id);

--- a/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
+++ b/src/test/java/org/opentripplanner/middleware/controllers/api/MonitoredTripControllerTest.java
@@ -220,6 +220,11 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
         MonitoredTrip originalTrip = Persistence.monitoredTrips.getOneFiltered(soloUserFilter);
         assertTrue(originalTrip.itineraryExistence.wednesday.validDates.isEmpty());
 
+        // Mess up some fields in the trip. The modified field values should not appear in the persisted trip.
+        originalTrip.tripName = DUMMY_STRING;
+        originalTrip.otp2QueryParams.fromPlace = DUMMY_STRING;
+        originalTrip.userId = DUMMY_STRING;
+
         int checksSize = MonitoredTripController.getChecksSize();
 
         // Make call to check itinerary existence.
@@ -232,6 +237,10 @@ class MonitoredTripControllerTest extends OtpMiddlewareTestEnvironment {
 
         MonitoredTrip updatedTrip = Persistence.monitoredTrips.getOneFiltered(soloUserFilter);
         assertNotNull(updatedTrip);
+        // Messed up values should not have been modified. Test additional fields as needed.
+        assertNotEquals(DUMMY_STRING, updatedTrip.tripName);
+        assertNotEquals(DUMMY_STRING, updatedTrip.userId);
+        assertNotEquals(DUMMY_STRING, updatedTrip.otp2QueryParams.fromPlace);
         // The persisted trip should have its existence overwritten with the one simulated above.
         assertNotNull(updatedTrip.itineraryExistence.id);
         assertNotEquals(originalTrip.itineraryExistence.id, updatedTrip.itineraryExistence.id);

--- a/src/test/java/org/opentripplanner/middleware/persistence/TripHistoryPersistenceTest.java
+++ b/src/test/java/org/opentripplanner/middleware/persistence/TripHistoryPersistenceTest.java
@@ -20,19 +20,23 @@ import java.util.List;
 import static com.mongodb.client.model.Filters.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.opentripplanner.middleware.testutils.PersistenceTestUtils.*;
+import static org.opentripplanner.middleware.persistence.TypedPersistence.filterByUserId;
 import static org.opentripplanner.middleware.persistence.TypedPersistence.filterByUserAndDateRange;
+import static org.opentripplanner.middleware.testutils.PersistenceTestUtils.createTripRequest;
+import static org.opentripplanner.middleware.testutils.PersistenceTestUtils.createTripRequests;
+import static org.opentripplanner.middleware.testutils.PersistenceTestUtils.createTripSummary;
+import static org.opentripplanner.middleware.testutils.PersistenceTestUtils.createTripSummaryWithError;
+import static org.opentripplanner.middleware.testutils.PersistenceTestUtils.createUser;
 
 /**
  * Tests to verify that trip request and trip summary persistence in MongoDB collections are functioning properly. A
  * number of {@link TypedPersistence} methods are tested here, but the HTTP endpoints defined in
  * {@link org.opentripplanner.middleware.controllers.api.ApiController} are not themselves tested here.
  */
-public class TripHistoryPersistenceTest extends OtpMiddlewareTestEnvironment {
+class TripHistoryPersistenceTest extends OtpMiddlewareTestEnvironment {
     private static final int LIMIT = 3;
     private static final String TEST_EMAIL = "john.doe@example.com";
     private static final String TRIP_REQUEST_DATE_CREATED_FIELD_NAME = "dateCreated";
-    private static final String TRIP_REQUEST_USER_ID_FIELD_NAME = "userId";
 
     private static OtpUser otpUser = null;
     private static TripRequest tripRequest = null;
@@ -41,7 +45,7 @@ public class TripHistoryPersistenceTest extends OtpMiddlewareTestEnvironment {
     private static List<TripRequest> tripRequests = null;
 
     @BeforeAll
-    public static void setup() throws Exception {
+    static void setup() throws Exception {
         otpUser = createUser(TEST_EMAIL);
         tripRequest = createTripRequest(otpUser.id);
         tripRequests = createTripRequests(LIMIT, otpUser.id);
@@ -50,20 +54,20 @@ public class TripHistoryPersistenceTest extends OtpMiddlewareTestEnvironment {
     }
 
     @AfterAll
-    public static void tearDown() {
+    static void tearDown() {
         if (otpUser != null) otpUser.delete(false);
         if (tripSummaryWithError != null) Persistence.tripSummaries.removeById(tripSummaryWithError.id);
     }
 
     @Test
-    public void canCreateTripRequest() {
+    void canCreateTripRequest() {
         if (tripRequest == null) tripRequest = createTripRequest(otpUser.id);
         TripRequest retrieved = Persistence.tripRequests.getById(tripRequest.id);
         assertEquals(tripRequest.id, retrieved.id, "Found Trip request ID should equal inserted ID.");
     }
 
     @Test
-    public void canDeleteTripRequest() {
+    void canDeleteTripRequest() {
         Persistence.tripRequests.removeById(tripRequest.id);
         TripRequest deletedTripRequest = Persistence.tripRequests.getById(tripRequest.id);
         tripRequest = null;
@@ -71,26 +75,26 @@ public class TripHistoryPersistenceTest extends OtpMiddlewareTestEnvironment {
     }
 
     @Test
-    public void canCreateTripSummaryWithError() {
+    void canCreateTripSummaryWithError() {
         TripSummary retrieved = Persistence.tripSummaries.getById(tripSummaryWithError.id);
         assertEquals(tripSummaryWithError.id, retrieved.id, "Found Trip summary ID should equal inserted ID.");
     }
 
     @Test
-    public void canCreateTripSummary() {
+    void canCreateTripSummary() {
         TripSummary retrieved = Persistence.tripSummaries.getById(tripSummary.id);
         assertEquals(tripSummary.id, retrieved.id, "Found Trip summary ID should equal inserted ID.");
     }
 
     @Test
-    public void canDeleteTripSummary() {
+    void canDeleteTripSummary() {
         Persistence.tripSummaries.removeById(tripSummary.id);
         TripSummary deletedTripSummary = Persistence.tripSummaries.getById(tripSummary.id);
         assertNull(deletedTripSummary, "Deleted trip summary should no longer exist in database (should return as null).");
     }
 
     @Test
-    public void canGetFilteredTripRequestsWithFromAndToDate() {
+    void canGetFilteredTripRequestsWithFromAndToDate() {
         LocalDateTime fromStartOfDay = DateTimeUtils.nowAsLocalDate().atTime(LocalTime.MIN);
         LocalDateTime toEndOfDay = DateTimeUtils.nowAsLocalDate().atTime(LocalTime.MAX);
         Date fromDate = Date.from(fromStartOfDay
@@ -105,47 +109,43 @@ public class TripHistoryPersistenceTest extends OtpMiddlewareTestEnvironment {
     }
 
     @Test
-    public void canGetFilteredTripRequestsFromDate() {
+    void canGetFilteredTripRequestsFromDate() {
         LocalDateTime fromStartOfDay = DateTimeUtils.nowAsLocalDate().atTime(LocalTime.MIN);
         Bson filter = Filters.and(
             gte(
                 TRIP_REQUEST_DATE_CREATED_FIELD_NAME,
                 Date.from(fromStartOfDay.atZone(DateTimeUtils.getSystemZoneId()).toInstant())
             ),
-            eq(TRIP_REQUEST_USER_ID_FIELD_NAME, otpUser.id)
+            filterByUserId(otpUser.id)
         );
         List<TripRequest> result = Persistence.tripRequests.getFilteredWithLimit(filter, LIMIT);
         assertEquals(result.size(), tripRequests.size());
     }
 
     @Test
-    public void canGetFilteredTripRequestsToDate() {
+    void canGetFilteredTripRequestsToDate() {
         LocalDateTime toEndOfDay = DateTimeUtils.nowAsLocalDate().atTime(LocalTime.MAX);
         Bson filter = Filters.and(
             lte(
                 TRIP_REQUEST_DATE_CREATED_FIELD_NAME,
                 Date.from(toEndOfDay.atZone(DateTimeUtils.getSystemZoneId()).toInstant())
             ),
-            eq(TRIP_REQUEST_USER_ID_FIELD_NAME, otpUser.id)
+            filterByUserId(otpUser.id)
         );
         List<TripRequest> result = Persistence.tripRequests.getFilteredWithLimit(filter, LIMIT);
         assertEquals(result.size(), tripRequests.size());
     }
 
     @Test
-    public void canGetFilteredTripRequestsForUser() {
-        String TRIP_REQUEST_USER_ID_FIELD_NAME = "userId";
-        Bson filter = Filters.eq(TRIP_REQUEST_USER_ID_FIELD_NAME, otpUser.id);
-        List<TripRequest> result = Persistence.tripRequests.getFilteredWithLimit(filter, LIMIT);
+    void canGetFilteredTripRequestsForUser() {
+        List<TripRequest> result = Persistence.tripRequests.getFilteredWithLimit(filterByUserId(otpUser.id), LIMIT);
         assertEquals(result.size(), tripRequests.size());
     }
 
     @Test
-    public void canGetFilteredTripRequestsForUserWithMaxLimit() {
+    void canGetFilteredTripRequestsForUserWithMaxLimit() {
         int max = 2;
-        String TRIP_REQUEST_USER_ID_FIELD_NAME = "userId";
-        Bson filter = Filters.eq(TRIP_REQUEST_USER_ID_FIELD_NAME, otpUser.id);
-        List<TripRequest> result = Persistence.tripRequests.getFilteredWithLimit(filter, max);
-        assertEquals(result.size(), max);
+        List<TripRequest> result = Persistence.tripRequests.getFilteredWithLimit(filterByUserId(otpUser.id), max);
+        assertEquals(max, result.size());
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR improves itinerary checks:
- For new monitored trips, where a `/checkitinerary` call is made by a client prior to persisting, the itinerary check result is placed in a cache and consumed when the trip that triggered the check is persisted, with the condition that the client provides the check id in the trip's `itineraryExistence.id` field. This avoids performing the check again upon initial POST. If `itineraryExistence.id` is not provided, the check is performed on POST as before.
- For existing trips, a request to `/checkitinerary` causes the returned `ItineraryExistence` to be also persisted into the existing trip. The PUT operation on an existing trip does not touch existing content in `itineraryExistence`.

Tests are added for the new logic and to solidify the existing logic.
