### PR TITLE
Log using logback with time+size caps

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -59,6 +59,17 @@
             <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
     </appender>
+    <appender name="DEFAULT_LOG_FILE" class="RollingFileAppender">
+        <file>logs/otp-middleware.log</file>
+        <rollingPolicy class="TimeBasedRollingPolicy">
+            <fileNamePattern>${ARCHIVED_LOG_FOLDER}/otp-middleware.log</fileNamePattern>
+            <maxHistory>${LOG_RETENTION_DAYS}</maxHistory>
+            <totalSizeCap>4GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
     <logger name="org.opentripplanner.middleware.utils.NotificationUtils">
         <appender-ref ref="NOTIFICATION-FILE"/>
     </logger>
@@ -75,6 +86,7 @@
         <appender-ref ref="GMAP-TRACKING-DEBUG-FILE"/>
     </logger>
     <root level="info">
+        <appender-ref ref="DEFAULT_LOG_FILE" />
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR sets the logging to a fixed-file otp-middleware.log managed by logback. The file will be split by day so it is easier to find stuff, and there is a total cap for all the otp-middleware.log files so that they don't overrun the storage. Otherwise, log retention is set to the same as the other log files (62 days).
