### PR TITLE
Support new JDK time format

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -8,6 +8,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        javaVersion: [11, 25]
 
     steps:
       - uses: actions/checkout@v2
@@ -15,10 +18,10 @@ jobs:
         uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: 4.2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.javaVersion }}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.javaVersion }}
       - name: Setup Maven Cache
         uses: actions/cache@v4
         id: cache
@@ -98,23 +101,28 @@ jobs:
       # only prepare deploy files on push events to avoid duplicate pushes to s3 when a commit is
       # pushed to a branch with an open pull request
       - name: Prepare files for deployment to s3
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && matrix.javaVersion == '11'
         run: ./scripts/prep-for-deploy-from-github-actions.sh
       - name: Copy deployment files to the otp-middleware-builds bucket
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && matrix.javaVersion == '11'
         run: |
           aws s3 sync ./deploy s3://otp-middleware-builds --acl public-read
       # Build and Publish Docker image
       - name: Set up QEMU
+        if: matrix.javaVersion == '11'
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
+        if: matrix.javaVersion == '11'
         uses: docker/setup-buildx-action@v1
       - name: Login to Amazon ECR
+        if: matrix.javaVersion == '11'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
       - name: Connect ECR Login to Docker
+        if: matrix.javaVersion == '11'
         run: aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/s2a5w2n9
       - name: Build and push
+        if: matrix.javaVersion == '11'
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -122,6 +130,7 @@ jobs:
           push: true
           tags: public.ecr.aws/s2a5w2n9/otp-middleware:${{ github.sha }}
       - name: Build and push with different tag
+        if: matrix.javaVersion == '11'
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -96,7 +96,9 @@ jobs:
           TWILIO_VERIFICATION_SERVICE_SID: ${{ secrets.TWILIO_VERIFICATION_SERVICE_SID }}
           RUN_E2E: true
 
-      # if this point it reached, the CI build has succeeded
+      # If this point it reached, the CI build has succeeded.
+      # The condition on the JDK version is so that artifacts (jar, docker image)
+      # are uploaded only once (for now, we keep the JDK 11 versions).
 
       # only prepare deploy files on push events to avoid duplicate pushes to s3 when a commit is
       # pushed to a branch with an open pull request

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.15</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/org/opentripplanner/middleware/models/TripMonitorNotification.java
+++ b/src/main/java/org/opentripplanner/middleware/models/TripMonitorNotification.java
@@ -76,8 +76,8 @@ public class TripMonitorNotification extends Model {
                     STOPWATCH_ICON,
                     TRIP_DELAY_DEPART.get(locale),
                     delayHumanTime,
-                    DateTimeUtils.formatShortDate(startTime, locale),
-                    DateTimeUtils.formatShortDate(arrivalTime, locale)
+                    DateTimeUtils.formatShortTime(startTime, locale),
+                    DateTimeUtils.formatShortTime(arrivalTime, locale)
                 )
             );
         }
@@ -90,7 +90,7 @@ public class TripMonitorNotification extends Model {
                 STOPWATCH_ICON,
                 (isArrivalDelay ? TRIP_DELAY_ARRIVE : TRIP_DELAY_DEPART).get(locale),
                 delayHumanTime,
-                DateTimeUtils.formatShortDate(isArrivalDelay ? arrivalTime : startTime, locale)
+                DateTimeUtils.formatShortTime(isArrivalDelay ? arrivalTime : startTime, locale)
             )
         );
     }
@@ -150,7 +150,7 @@ public class TripMonitorNotification extends Model {
             NotificationType.INITIAL_REMINDER,
             String.format(Message.TRIP_REMINDER_NOTIFICATION.get(locale),
                 trip.tripName,
-                DateTimeUtils.formatShortDate(trip.itinerary.startTime, locale)
+                DateTimeUtils.formatShortTime(trip.itinerary.startTime, locale)
             )
         );
     }

--- a/src/main/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstruction.java
+++ b/src/main/java/org/opentripplanner/middleware/triptracker/instruction/WaitForTransitInstruction.java
@@ -36,7 +36,7 @@ public class WaitForTransitInstruction extends TransitLegInstruction {
             "Wait%s for your bus, route %s, scheduled at %s (%s)",
             getReadableMinutes(waitInMinutes),
             routeShortName,
-            DateTimeUtils.formatShortDate(Date.from(transitLeg.getScheduledStartTime().toInstant()), locale),
+            DateTimeUtils.formatShortTime(Date.from(transitLeg.getScheduledStartTime().toInstant()), locale),
             status
         );
     }

--- a/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
@@ -46,6 +46,10 @@ public class DateTimeUtils {
         DEFAULT_DATE_FORMAT_PATTERN
     );
 
+    public static final DateTimeFormatter US_TIME_FORMATTER = DateTimeFormatter
+        .ofLocalizedTime(FormatStyle.SHORT)
+        .withLocale(Locale.US);
+
     /**
      * These are internal variables that can be used to mock dates and times in tests
      */
@@ -392,11 +396,9 @@ public class DateTimeUtils {
     }
 
     /**
-     * Mostly used in tests.
+     * Mostly used in tests. Shorthand to produce strings such as "5:40 PM" with the correct spacing character.
      */
-    public static DateTimeFormatter usTimeFormatter() {
-        return DateTimeFormatter
-            .ofLocalizedTime(FormatStyle.SHORT)
-            .withLocale(Locale.US);
+    public String usTime(int hour, int minute) {
+        return LocalTime.of(hour, minute).format(US_TIME_FORMATTER);
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
@@ -390,4 +390,13 @@ public class DateTimeUtils {
     public static Date dateAsSeconds() {
         return new Date(Instant.now().getEpochSecond());
     }
+
+    /**
+     * Mostly used in tests.
+     */
+    public static DateTimeFormatter usTimeFormatter() {
+        return DateTimeFormatter
+            .ofLocalizedTime(FormatStyle.SHORT)
+            .withLocale(Locale.US);
+    }
 }

--- a/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
@@ -101,7 +101,7 @@ public class DateTimeUtils {
     /**
      * Helper to format a date in short format (e.g. "5:40 PM" - no seconds) in the specified locale.
      */
-    public static String formatShortDate(Date date, Locale locale) {
+    public static String formatShortTime(Date date, Locale locale) {
         return DateTimeFormatter
             .ofLocalizedTime(FormatStyle.SHORT)
             .withLocale(locale)

--- a/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/DateTimeUtils.java
@@ -396,9 +396,9 @@ public class DateTimeUtils {
     }
 
     /**
-     * Mostly used in tests. Shorthand to produce strings such as "5:40 PM" with the correct spacing character.
+     * Used in tests. Inserts strings such as "5:40 PM" within other text with the correct spacing character.
      */
-    public String usTime(int hour, int minute) {
-        return LocalTime.of(hour, minute).format(US_TIME_FORMATTER);
+    public static String usTime(int hour, int minute, String message) {
+        return String.format(message, LocalTime.of(hour, minute).format(US_TIME_FORMATTER));
     }
 }

--- a/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
+++ b/src/main/java/org/opentripplanner/middleware/utils/NotificationUtils.java
@@ -126,7 +126,7 @@ public class NotificationUtils {
         }
 
         Locale locale = I18nUtils.getOtpUserLocale(otpUser);
-        String tripTime = DateTimeUtils.formatShortDate(trip.itinerary.startTime, locale);
+        String tripTime = DateTimeUtils.formatShortTime(trip.itinerary.startTime, locale);
         String body = String.format(TRIP_SURVEY_NOTIFICATION.get(locale), tripTime);
         return sendPush(otpUser, body, trip.tripName, trip.id, TRIP_SURVEY_ID, TRIP_SURVEY_SUBDOMAIN, notificationId);
     }

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -75,6 +75,7 @@ import static org.opentripplanner.middleware.tripmonitor.TripStatus.TRIP_ACTIVE;
 import static org.opentripplanner.middleware.tripmonitor.TripStatus.TRIP_UPCOMING;
 import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTripBasicTest.makeMonitoredTripFromNow;
 import static org.opentripplanner.middleware.tripmonitor.jobs.CheckMonitoredTripBasicTest.setRecurringTodayAndTomorrow;
+import static org.opentripplanner.middleware.utils.DateTimeUtils.usTime;
 
 /**
  * This class contains tests for the {@link CheckMonitoredTrip} job.
@@ -801,16 +802,15 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         ZonedDateTime afterTripEnds = DateTimeUtils.makeOtpZonedDateTime(monitoredTrip.itinerary.endTime).plusMinutes(3);
 
         List<DelayCase> cases = List.of(
-            // TODO: fix time separator char
             // Add some delays for the trip.
-            new DelayCase(300, 420, true, beforeTripStart, 1, "⏱ Your trip is now predicted to depart 5 minutes late (at 8:34 AM)."),
+            new DelayCase(300, 420, true, beforeTripStart, 1, usTime(8, 34, "⏱ Your trip is now predicted to depart 5 minutes late (at %s).")),
             // Decrease real-time delays (subtract delays) from the OTP response.
-            new DelayCase(-100, -60, true, beforeTripStart, 1, "⏱ Your trip is now predicted to arrive 6 minutes late (at 9:04 AM)."),
+            new DelayCase(-100, -60, true, beforeTripStart, 1, usTime(9, 4, "⏱ Your trip is now predicted to arrive 6 minutes late (at %s).")),
             // Drop real-time updates (subtract delays) from the OTP response.
             new DelayCase(-200, -360, false, beforeTripStart, 1, "⏱ Real-time updates for your trip were lost. Monitoring will be based on your originally saved trip."),
 
             // Add back delays for the trip.
-            new DelayCase(300, 420, true, beforeTripStart, 1, "⏱ Your trip is now predicted to depart 5 minutes late (at 8:34 AM)."),
+            new DelayCase(300, 420, true, beforeTripStart, 1, usTime(8, 34, "⏱ Your trip is now predicted to depart 5 minutes late (at %s).")),
             // OTP drops real-time updates at/after the end of the transit leg.
             // No notifications should be sent when the transit leg is over.
             new DelayCase(

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -56,8 +56,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -319,7 +317,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
         } else {
             assertNotNull(notification);
             assertEquals(notificationType, notification.type);
-            assertThat(message, notification.body, matchesPattern(expectedNotificationPattern));
+            assertEquals(expectedNotificationPattern, notification.body, message);
         }
     }
 
@@ -371,7 +369,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 0,
                 NotificationType.DEPARTURE_AND_ARRIVAL_DELAY,
                 STOPWATCH_ICON +
-                " Your trip is now predicted to depart 20 minutes late at 8:49[\\u202f ]AM \\(Now arriving at 9:18[\\u202f ]AM\\)\\.",
+                usTime(8, 49, " Your trip is now predicted to depart 20 minutes late at %s ") +
+                usTime(9, 18, "(Now arriving at %s)."),
                 "20m-late trip previously on-time => show dep/arr delay notifications"
             ),
             Arguments.of(
@@ -379,7 +378,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 0,
                 NotificationType.DEPARTURE_DELAY,
                 STOPWATCH_ICON +
-                " Your trip is now predicted to depart 20 minutes late \\(at 8:49[\\u202f ]AM\\)\\.",
+                usTime(8, 49, " Your trip is now predicted to depart 20 minutes late (at %s)."),
                 "20m-late departure previously on-time, but still arriving on-time => show departure-only delay notifications"
             ),
             Arguments.of(
@@ -387,7 +386,7 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 0,
                 NotificationType.ARRIVAL_DELAY,
                 STOPWATCH_ICON +
-                " Your trip is now predicted to arrive 20 minutes late \\(at 9:18[\\u202f ]AM\\)\\.",
+                usTime(9, 18, " Your trip is now predicted to arrive 20 minutes late (at %s)."),
                 "20m-late arrival previously on-time, but still departing on-time => show arrival-only delay notifications"
             ),
             Arguments.of(
@@ -395,7 +394,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 0,
                 NotificationType.DEPARTURE_AND_ARRIVAL_DELAY,
                 STOPWATCH_ICON +
-                " Your trip is now predicted to depart 18 minutes early at 8:11[\\u202f ]AM \\(Now arriving at 8:40[\\u202f ]AM\\)\\.",
+                usTime(8, 11, " Your trip is now predicted to depart 18 minutes early at %s ") +
+                usTime(8, 40, "(Now arriving at %s)."),
                 "18m-early trip previously on-time => show delay (early) notifications"
             ),
             Arguments.of(
@@ -410,7 +410,8 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
                 15,
                 NotificationType.DEPARTURE_AND_ARRIVAL_DELAY,
                 STOPWATCH_ICON +
-                " Your trip is now predicted to depart about on time at 8:29[\\u202f ]AM \\(Now arriving at 8:58[\\u202f ]AM\\)\\.",
+                usTime(8, 29, " Your trip is now predicted to depart about on time at %s ") +
+                usTime(8, 58, "(Now arriving at %s)."),
                 "On-time trip previously late => show on-time notifications"
             )
         );

--- a/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
+++ b/src/test/java/org/opentripplanner/middleware/tripmonitor/jobs/CheckMonitoredTripTest.java
@@ -804,14 +804,14 @@ public class CheckMonitoredTripTest extends OtpMiddlewareTestEnvironment {
 
         List<DelayCase> cases = List.of(
             // Add some delays for the trip.
-            new DelayCase(300, 420, true, beforeTripStart, 1, usTime(8, 34, "⏱ Your trip is now predicted to depart 5 minutes late (at %s).")),
+            new DelayCase(300, 420, true, beforeTripStart, 1, usTime(8, 34, STOPWATCH_ICON + " Your trip is now predicted to depart 5 minutes late (at %s).")),
             // Decrease real-time delays (subtract delays) from the OTP response.
-            new DelayCase(-100, -60, true, beforeTripStart, 1, usTime(9, 4, "⏱ Your trip is now predicted to arrive 6 minutes late (at %s).")),
+            new DelayCase(-100, -60, true, beforeTripStart, 1, usTime(9, 4, STOPWATCH_ICON + " Your trip is now predicted to arrive 6 minutes late (at %s).")),
             // Drop real-time updates (subtract delays) from the OTP response.
-            new DelayCase(-200, -360, false, beforeTripStart, 1, "⏱ Real-time updates for your trip were lost. Monitoring will be based on your originally saved trip."),
+            new DelayCase(-200, -360, false, beforeTripStart, 1, STOPWATCH_ICON + " Real-time updates for your trip were lost. Monitoring will be based on your originally saved trip."),
 
             // Add back delays for the trip.
-            new DelayCase(300, 420, true, beforeTripStart, 1, usTime(8, 34, "⏱ Your trip is now predicted to depart 5 minutes late (at %s).")),
+            new DelayCase(300, 420, true, beforeTripStart, 1, usTime(8, 34, STOPWATCH_ICON + " Your trip is now predicted to depart 5 minutes late (at %s).")),
             // OTP drops real-time updates at/after the end of the transit leg.
             // No notifications should be sent when the transit leg is over.
             new DelayCase(

--- a/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
+++ b/src/test/java/org/opentripplanner/middleware/triptracker/ManageLegTraversalTest.java
@@ -48,6 +48,7 @@ import static org.opentripplanner.middleware.triptracker.TravelerLocator.isWithi
 import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.NO_INSTRUCTION;
 import static org.opentripplanner.middleware.triptracker.instruction.TripInstruction.TRIP_INSTRUCTION_UPCOMING_RADIUS;
 import static org.opentripplanner.middleware.utils.ConfigUtils.DEFAULT_ENV;
+import static org.opentripplanner.middleware.utils.DateTimeUtils.usTime;
 import static org.opentripplanner.middleware.utils.GeometryUtils.calculateBearing;
 import static org.opentripplanner.middleware.utils.GeometryUtils.createPoint;
 
@@ -531,7 +532,9 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                     .withPosition(busStopCoords)
                     .withTripStatus(TripStatus.BEHIND_SCHEDULE)
                     .withInstant(Instant.now())
-                    .withExpectedInstruction("Wait for your bus, route 20, scheduled at 7:58 AM (That time has passed)")
+                    .withExpectedInstruction(
+                        usTime(7, 58, "Wait for your bus, route 20, scheduled at %s (That time has passed)")
+                    )
             ),
             Arguments.of(
                 "Arrive at bus stop well after the bus departure (indicates past departure).",
@@ -541,7 +544,9 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                     .withPosition(walkToBusTransition.legs.get(0).to.toCoordinates())
                     .withTripStatus(TripStatus.BEHIND_SCHEDULE)
                     .withInstant(Instant.now())
-                    .withExpectedInstruction("Wait for your bus, route 40, scheduled at 6:41 AM (That time has passed)")
+                    .withExpectedInstruction(
+                        usTime(6, 41, "Wait for your bus, route 40, scheduled at %s (That time has passed)")
+                    )
             ),
             Arguments.of(
                 "Arrive at bus stop well in advance.",
@@ -551,7 +556,9 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                     .withPosition(walkToBusTransition.legs.get(0).to.toCoordinates())
                     .withTripStatus(TripStatus.AHEAD_OF_SCHEDULE)
                     .withInstant(walkToBusTransition.legs.get(1).startTime.toInstant().minus(40, ChronoUnit.MINUTES))
-                    .withExpectedInstruction("Wait 40 minutes for your bus, route 40, scheduled at 6:41 AM (On time)")
+                    .withExpectedInstruction(
+                        usTime(6, 41,"Wait 40 minutes for your bus, route 40, scheduled at %s (On time)")
+                    )
             ),
             Arguments.of(
                 "Arrive at bus stop where the walk geometry is so the stop is farther than the last walk shape. Should produce a bus-stop-in-vicinity instruction, not 'destination in vicinity'.",
@@ -614,7 +621,9 @@ public class ManageLegTraversalTest extends OtpMiddlewareTestEnvironment {
                 "If present at the transit stop after the trip departure, instruct to wait (indicate past departure).",
                 new TraceData()
                     .withPosition(originCoords)
-                    .withExpectedInstruction("Wait for your bus, route 27, scheduled at 9:18 AM (That time has passed)")
+                    .withExpectedInstruction(
+                        usTime(9, 18, "Wait for your bus, route 27, scheduled at %s (That time has passed)")
+                    )
                     .withTripStatus(TripStatus.BEHIND_SCHEDULE)
                     .withInstant(Instant.now())
             ),

--- a/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
@@ -112,6 +112,6 @@ class DateTimeUtilsTest {
         assertEquals(LocalTime.of(9, 6).format(US_TIME_FORMATTER.withZone(getOtpZoneId())), formattedDate);
         // Before JDK 20: a regular space precedes AM/PM.
         // JDK 20+: A narrow non-breaking space (NNBSP) is used instead.
-        assertThat(formattedDate, matchesPattern("9:06[\\u202f ]AM"));
+        assertThat(formattedDate, matchesPattern("\\d:06[\\u202f ]AM"));
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
@@ -5,9 +5,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -28,7 +31,7 @@ class DateTimeUtilsTest {
     void supportsDateFormatsInSeveralLocales(String localeTag, String pattern) {
         ZonedDateTime zonedTime = ZonedDateTime.of(2023, 2, 12, 17, 44, 0, 0, DateTimeUtils.getOtpZoneId());
         assertThat(
-            DateTimeUtils.formatShortDate(Date.from(zonedTime.toInstant()), Locale.forLanguageTag(localeTag)),
+            DateTimeUtils.formatShortTime(Date.from(zonedTime.toInstant()), Locale.forLanguageTag(localeTag)),
             matchesPattern(pattern)
         );
     }
@@ -99,5 +102,20 @@ class DateTimeUtilsTest {
             LocalDateTime.of(2024, 8, 11, 2, 0, 0)
         );
         assertEquals(expectedHours, getHoursBetween(date1, date2));
+    }
+
+    @Test
+    void canFormatShortTime() {
+        var date = Date.from(Instant.ofEpochMilli(1785416763965L)); // 9:06 AM 30-JUL-2026 EDT
+        var formattedDate = DateTimeUtils.formatShortTime(date, Locale.US);
+
+        var formatter = DateTimeFormatter
+            .ofLocalizedTime(FormatStyle.SHORT)
+            .withLocale(Locale.US);
+
+        assertEquals(LocalTime.of(9, 6).format(formatter), formattedDate);
+        // Before JDK 20: a regular space precedes AM/PM.
+        // JDK 20+: A narrow non-breaking space (NNBSP) is used instead.
+        assertThat(formattedDate, matchesPattern("9:06[\\u202f ]AM"));
     }
 }

--- a/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
@@ -22,7 +22,7 @@ import static org.opentripplanner.middleware.utils.DateTimeUtils.getDaysBetween;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.getHoursBetween;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.getPreviousDayFrom;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.getPreviousWholeHourFrom;
-import static org.opentripplanner.middleware.utils.DateTimeUtils.usTimeFormatter;
+import static org.opentripplanner.middleware.utils.DateTimeUtils.US_TIME_FORMATTER;
 
 class DateTimeUtilsTest {
     @ParameterizedTest
@@ -108,7 +108,7 @@ class DateTimeUtilsTest {
         var date = Date.from(Instant.ofEpochMilli(1785416763965L)); // 9:06 AM 30-JUL-2026 EDT
         var formattedDate = DateTimeUtils.formatShortTime(date, Locale.US);
 
-        assertEquals(LocalTime.of(9, 6).format(usTimeFormatter()), formattedDate);
+        assertEquals(LocalTime.of(9, 6).format(US_TIME_FORMATTER), formattedDate);
         // Before JDK 20: a regular space precedes AM/PM.
         // JDK 20+: A narrow non-breaking space (NNBSP) is used instead.
         assertThat(formattedDate, matchesPattern("9:06[\\u202f ]AM"));

--- a/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
@@ -9,8 +9,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.FormatStyle;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -24,6 +22,7 @@ import static org.opentripplanner.middleware.utils.DateTimeUtils.getDaysBetween;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.getHoursBetween;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.getPreviousDayFrom;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.getPreviousWholeHourFrom;
+import static org.opentripplanner.middleware.utils.DateTimeUtils.usTimeFormatter;
 
 class DateTimeUtilsTest {
     @ParameterizedTest
@@ -109,11 +108,7 @@ class DateTimeUtilsTest {
         var date = Date.from(Instant.ofEpochMilli(1785416763965L)); // 9:06 AM 30-JUL-2026 EDT
         var formattedDate = DateTimeUtils.formatShortTime(date, Locale.US);
 
-        var formatter = DateTimeFormatter
-            .ofLocalizedTime(FormatStyle.SHORT)
-            .withLocale(Locale.US);
-
-        assertEquals(LocalTime.of(9, 6).format(formatter), formattedDate);
+        assertEquals(LocalTime.of(9, 6).format(usTimeFormatter()), formattedDate);
         // Before JDK 20: a regular space precedes AM/PM.
         // JDK 20+: A narrow non-breaking space (NNBSP) is used instead.
         assertThat(formattedDate, matchesPattern("9:06[\\u202f ]AM"));

--- a/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.getDaysBetween;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.getHoursBetween;
+import static org.opentripplanner.middleware.utils.DateTimeUtils.getOtpZoneId;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.getPreviousDayFrom;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.getPreviousWholeHourFrom;
 import static org.opentripplanner.middleware.utils.DateTimeUtils.US_TIME_FORMATTER;
@@ -108,7 +109,7 @@ class DateTimeUtilsTest {
         var date = Date.from(Instant.ofEpochMilli(1785416763965L)); // 9:06 AM 30-JUL-2026 EDT
         var formattedDate = DateTimeUtils.formatShortTime(date, Locale.US);
 
-        assertEquals(LocalTime.of(9, 6).format(US_TIME_FORMATTER), formattedDate);
+        assertEquals(LocalTime.of(9, 6).format(US_TIME_FORMATTER.withZone(getOtpZoneId())), formattedDate);
         // Before JDK 20: a regular space precedes AM/PM.
         // JDK 20+: A narrow non-breaking space (NNBSP) is used instead.
         assertThat(formattedDate, matchesPattern("9:06[\\u202f ]AM"));

--- a/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
@@ -109,7 +109,10 @@ class DateTimeUtilsTest {
         var date = Date.from(Instant.ofEpochMilli(1785416763965L)); // 9:06 AM 30-JUL-2026 EDT
         var formattedDate = DateTimeUtils.formatShortTime(date, Locale.US);
 
-        assertEquals(LocalTime.of(9, 6).format(US_TIME_FORMATTER.withZone(getOtpZoneId())), formattedDate);
+        assertEquals(
+            DateTimeUtils.makeOtpZonedDateTime(date).toLocalTime().format(US_TIME_FORMATTER.withZone(getOtpZoneId())),
+            formattedDate
+        );
         // Before JDK 20: a regular space precedes AM/PM.
         // JDK 20+: A narrow non-breaking space (NNBSP) is used instead.
         assertThat(formattedDate, matchesPattern("\\d:06[\\u202f ]AM"));

--- a/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
+++ b/src/test/java/org/opentripplanner/middleware/utils/DateTimeUtilsTest.java
@@ -115,6 +115,6 @@ class DateTimeUtilsTest {
         );
         // Before JDK 20: a regular space precedes AM/PM.
         // JDK 20+: A narrow non-breaking space (NNBSP) is used instead.
-        assertThat(formattedDate, matchesPattern("\\d:06[\\u202f ]AM"));
+        assertThat(formattedDate, matchesPattern("\\d:06[\\u202f ][AP]M"));
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Supersedes #348.

This PR makes unit tests that involve local US time formatting run in both older and newer JRE versions by applying the correct format to expected time values according to the ambient JRE. In older JREs, with times such as "10:48 AM", a regular space precedes "AM". In newer JREs, that space is actually a narrow non-breaking space (NNBSP - u202f). CI now runs tests with Java 11 and 25.
